### PR TITLE
Port 7 false-positive/negative corrections from dev

### DIFF
--- a/checks.py
+++ b/checks.py
@@ -9,10 +9,14 @@ import re
 
 
 def normalize_path(p: str) -> str:
-    """Case-folded, normalized, trailing-separator-stripped path for equality."""
+    """Case-folded, normalized, trailing-separator-stripped path for equality.
+
+    Separators are forced to forward-slash so a claim/commitment/touched identity is
+    platform-stable: os.path.normpath emits '\\' on Windows, which would make the same
+    logical path mismatch its POSIX-authored form (Windows-portability fix)."""
     if not p:
         return ""
-    return os.path.normcase(os.path.normpath(p.strip())).rstrip("/\\")
+    return os.path.normcase(os.path.normpath(p.strip())).rstrip("/\\").replace("\\", "/")
 
 
 def location_match(location: str, touched_keys) -> bool:

--- a/prechecks/precheck_1_22.py
+++ b/prechecks/precheck_1_22.py
@@ -189,6 +189,25 @@ _NEG_REF_RX = re.compile(
     | \babout\s+the\s+commit\b
     | \bthe\s+commit\b[^\n]{0,12}?\byou\b   # "the commit <sha> you ..."
     | \bnot\s+committed\b
+    # PRE-EXISTING / UPSTREAM frame: a commit that already existed BEFORE this
+    # session — a debugging-AI attributing a regression to a prior commit, not
+    # presenting its OWN just-done work. "<sha> was pushed before I started",
+    # "committed by someone before this session began". A commit predating the
+    # session cannot be the AI's fabricated proof-of-work for THIS turn.
+    | \bbefore\s+(?:i|we)\s+(?:started|began|got\s+(?:here|started))\b
+    | \bbefore\s+(?:this|the\s+(?:current|present))\s+session\b
+    # THIRD-PARTY ATTRIBUTION (passive "by <actor>"): "<sha> was committed by
+    # someone", "tagged by a teammate" — the action is attributed to a non-self
+    # actor, so it is not the AI's own fabricated proof. (Bare first-person
+    # "committed by me" stays a claim — excluded from the actor list.)
+    | \b(?:committed|tagged|pushed|merged)\s+by\s+(?!(?:me|us|myself|ourselves)\b)(?:someone|a\s+\w+|the\s+\w+|him|her|them|\w+(?:bot)?\b)
+    # ADVISORY / INTERROGATIVE-ABOUT frame: the AI is asking the USER to verify a
+    # SHA ("you should check whether <sha> was pushed"), not asserting it did so.
+    # The advisory verb ("check"/"verify"/...) is the real discriminator; it
+    # subsumes the trailing "whether <sha> was pushed", so no bare \bwhether\b cue
+    # is needed (that over-suppressed a discourse "whether or not it matters, I
+    # committed <sha>").
+    | \byou\s+(?:should|could|can|may|might|need\s+to|want\s+to)\s+(?:double-?\s*)?(?:check|verify|confirm|see|look|review|inspect)\b
     """,
     re.IGNORECASE | re.VERBOSE,
 )

--- a/stopchecks/liveness.py
+++ b/stopchecks/liveness.py
@@ -95,6 +95,21 @@ def _assigned_name(stmt):
     return None
 
 
+def _unpack_target_names(stmt) -> set:
+    """Names bound by a TUPLE/LIST/STARRED unpack assignment target (`a, b = ...`, `a, *rest = ...`).
+    Empty for a single-Name / attr / subscript target — those are handled by `_assigned_name`. Used by
+    the liveness fixpoint to propagate: if ANY unpacked name is live, the RHS reads are live too."""
+    if not isinstance(stmt, ast.Assign):
+        return set()
+    out = set()
+    for t in stmt.targets:
+        if isinstance(t, (ast.Tuple, ast.List)):
+            for n in ast.walk(t):
+                if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Store):
+                    out.add(n.id)
+    return out
+
+
 def _escaping_names(func) -> set:
     out = set()
     for n in ast.walk(func):
@@ -131,6 +146,14 @@ def live_locals(func) -> set:
     for n in body:
         if isinstance(n, (ast.Return, ast.Yield, ast.YieldFrom)) and getattr(n, "value", None) is not None:
             seeds.append(n.value)
+        # A `raise X from Y` is an OUTPUT: the raised value (and cause) escapes the function, so every
+        # name it reads is live. Without this seed an exception accumulator (`last_exc = None` … then
+        # `raise RuntimeError(last_exc)`) had its None-init flagged dead — a false positive.
+        if isinstance(n, ast.Raise):
+            if n.exc is not None:
+                seeds.append(n.exc)
+            if n.cause is not None:
+                seeds.append(n.cause)
     for stmt in ast.walk(func):
         if isinstance(stmt, (ast.Assign, ast.AugAssign, ast.AnnAssign, ast.Expr)):
             if is_effect(stmt, locals_, escaping):
@@ -156,6 +179,15 @@ def live_locals(func) -> set:
             seeds.append(stmt.test)
             if stmt.msg is not None:
                 seeds.append(stmt.msg)
+        elif isinstance(stmt, ast.Match):
+            # `match subject: case ... if guard:` CONSUMES the subject (it steers which case runs)
+            # and each guard, exactly like an `if`/`while` test. Without seeding these, a local read
+            # ONLY by a match was flagged dead — a false positive (`if status == 2:` was correctly
+            # silent, `match status:` was not). Over-seeding is FN-safe (more live => fewer flags).
+            seeds.append(stmt.subject)
+            for case in stmt.cases:
+                if case.guard is not None:
+                    seeds.append(case.guard)
         elif isinstance(stmt, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
             for g in stmt.generators:
                 seeds.append(g.iter)
@@ -168,6 +200,12 @@ def live_locals(func) -> set:
     changed = True
     assigns = [(s, _assigned_name(s)) for s in ast.walk(func)
                if _assigned_name(s) is not None]
+    # Tuple/list-unpack assigns (`tool, pattern = sample_patterns[i]`) have no single _assigned_name,
+    # so the plain fixpoint never propagated their RHS reads. If ANY unpacked target is live, the RHS
+    # value reaches a live binding, so its reads are live too. Gated on a live target (not seeded
+    # unconditionally) so a genuinely-dead feeder of UNUSED unpack targets still fires — no FN.
+    unpacks = [(s, _unpack_target_names(s)) for s in ast.walk(func)
+               if _unpack_target_names(s)]
     while changed:
         changed = False
         for stmt, name in assigns:
@@ -178,6 +216,12 @@ def live_locals(func) -> set:
                     if new:
                         live |= new
                         changed = True
+        for stmt, names in unpacks:
+            if names & live and stmt.value is not None:
+                new = _names_read(stmt.value) - live
+                if new:
+                    live |= new
+                    changed = True
     return live
 
 
@@ -293,6 +337,18 @@ def _scan(stmt, func, locals_, escaping, typed, live, captured, out):
         if (rhs is not None and is_pure(rhs, locals_, typed) and not is_effect(stmt, locals_, escaping)
                 and name is not None and name not in live and name not in captured):
             out.append(stmt)
+        elif name is None and isinstance(stmt, ast.Assign):
+            # No single-Name target -> a TUPLE/LIST/CHAINED-target assign (`a, b = 1, 2`; `a = b = 5`;
+            # `[a, b] = [1, 2]`; `(x,) = (1+2,)`). Without this branch every-name-dead unpacks were a
+            # silent FN. Flag dead iff: the RHS is pure, the stmt is not an effect (an attr/subscript
+            # store target IS an effect via is_effect, so those are excluded), there is at least one
+            # bound Store Name, and EVERY bound name is dead AND uncaptured — any one live/captured
+            # target keeps the whole binding live. (is_pure/is_effect/live/captured reused verbatim.)
+            names = {n.id for t in stmt.targets for n in ast.walk(t)
+                     if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Store)}
+            if (names and is_pure(rhs, locals_, typed) and not is_effect(stmt, locals_, escaping)
+                    and all(nm not in live and nm not in captured for nm in names)):
+                out.append(stmt)
     elif isinstance(stmt, ast.Expr):
         # A bare LITERAL statement is not illusory WORK: a string Constant is a docstring / block
         # comment (material as __doc__), `...` is an intentional stub placeholder, a bare number is a
@@ -308,6 +364,11 @@ def _scan(stmt, func, locals_, escaping, typed, live, captured, out):
         for s in (*stmt.body, *[b for h in stmt.handlers for b in h.body],
                   *stmt.orelse, *stmt.finalbody):
             _scan(s, func, locals_, escaping, typed, live, captured, out)
+    elif isinstance(stmt, ast.Match):
+        # Descend into each case body — a dead pure statement inside a `match` arm is still dead.
+        for case in stmt.cases:
+            for s in case.body:
+                _scan(s, func, locals_, escaping, typed, live, captured, out)
     # ast.FunctionDef / AsyncFunctionDef / Lambda / ClassDef: separate scopes, NOT scanned here.
 
 

--- a/stopchecks/stopcheck_advance.py
+++ b/stopchecks/stopcheck_advance.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import re
 from typing import Optional
 from makoto.checks import normalize_path
 from makoto.schema import Finding
@@ -6,8 +7,52 @@ from makoto.lexicons import (
     _NEGATION_RX, _UNIVERSAL_DONE_RX, _SENTENCE_SPLIT_RX, _ADV_FORWARD_RX, _ENUM_BEFORE_HEAD_RX,
 )
 from makoto.lib.claims import _code_spans
-from makoto.stopchecks._common import _discharged
+from makoto.stopchecks._common import _discharged, _path_components
 from makoto.stopchecks._types import StopCheck
+
+
+# A version/variant rename suffix on a basename stem: parser_v2, config_old, handler-final, foo_copy.
+_ADV_RENAME_SUFFIX_RX = re.compile(r"(?:[_-](?:v?\d+|new|old|final|copy|orig|backup|bak|tmp|temp))+$", re.I)
+
+
+def _adv_stem_core(basename: str):
+    """(stem, core): the basename minus extension, and that stem minus a trailing rename suffix."""
+    stem = basename[:basename.rfind(".")] if "." in basename else basename
+    return stem, _ADV_RENAME_SUFFIX_RX.sub("", stem)
+
+
+def _adv_relocated_discharge(commit_loc: str, touched_keys) -> bool:
+    """Advance-LOCAL relocation tolerance: True iff a touched key looks like a RENAME of the open
+    commitment — SAME parent dir, SAME extension, and one basename stem is the version/variant of
+    the other (parser.py -> parser_v2.py). This re-derives a discharge that _discharged's
+    separator-boundary suffix-match correctly misses for a moved path, WITHOUT loosening
+    _discharged itself (completion + dropped share it). It preserves the fakeexcuse firewall:
+    auth.py vs auth_helper.py is NOT a rename (`_helper` is not a version token), so it stays
+    undischarged and the gate still fires. Gated behind the open-commitment loop; never broadens
+    a genuinely-dropped commitment (no rename-touch -> False -> the TP still fires)."""
+    c_comps = _path_components(commit_loc)
+    if not c_comps:
+        return False
+    c_base = c_comps[-1]
+    c_ext = c_base[c_base.rfind("."):] if "." in c_base else ""
+    c_stem, c_core = _adv_stem_core(c_base)
+    c_dir = c_comps[:-1]
+    for k in touched_keys or ():
+        k_comps = _path_components(k)
+        if not k_comps:
+            continue
+        k_base = k_comps[-1]
+        k_ext = k_base[k_base.rfind("."):] if "." in k_base else ""
+        if k_ext.lower() != c_ext.lower():
+            continue                                  # different file type -> not a rename
+        same_dir = (bool(c_dir) and bool(k_comps[:-1]) and c_dir[-1] == k_comps[:-1][-1]) \
+            or (not c_dir and not k_comps[:-1])
+        if not same_dir:
+            continue                                  # moved out of dir -> not a same-dir rename
+        k_stem, k_core = _adv_stem_core(k_base)
+        if c_core and k_core and c_core == k_core and (c_stem != k_stem or c_core != c_stem):
+            return True                               # same stem family, one is the renamed variant
+    return False
 
 
 def _advance_signal(text: str) -> bool:
@@ -54,17 +99,20 @@ def advance_gate(text, open_commits, *, touched_keys, fs_exists=None, empty_keys
     if not _advance_signal(text):
         return None
     for c in open_commits or ():
-        if not _discharged(c["location"], touched_keys, fs_exists, empty_keys=empty_keys, fs_size=fs_size):
-            loc_n = normalize_path(c["location"])
-            return Finding(
-                pattern_id="gate.advance",
-                file=loc_n,
-                line=0,
-                level="error",
-                message=(f"Advancing past an open commitment to {loc_n} with no recorded "
-                         f"result — discharge it, or retract it with a checked reason."),
-                retry_hint="Touch the location, or retract the commitment with a valid reason (R/U).",
-            )
+        if _discharged(c["location"], touched_keys, fs_exists, empty_keys=empty_keys, fs_size=fs_size):
+            continue
+        if _adv_relocated_discharge(c["location"], touched_keys):
+            continue                                  # commitment satisfied at a renamed path (FP fix)
+        loc_n = normalize_path(c["location"])
+        return Finding(
+            pattern_id="gate.advance",
+            file=loc_n,
+            line=0,
+            level="error",
+            message=(f"Advancing past an open commitment to {loc_n} with no recorded "
+                     f"result — discharge it, or retract it with a checked reason."),
+            retry_hint="Touch the location, or retract the commitment with a valid reason (R/U).",
+        )
     return None
 
 

--- a/stopchecks/stopcheck_completion.py
+++ b/stopchecks/stopcheck_completion.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import re
 from typing import Optional
 from makoto.checks import detect_locations, normalize_path
 from makoto.schema import Finding
@@ -7,6 +8,25 @@ from makoto.lexicons import (
 )
 from makoto.stopchecks._common import _BIND_BEFORE, _discharged
 from makoto.stopchecks._types import StopCheck
+
+
+# A subordinate-clause marker or a READ/relational FRAME appearing in the verb->path gap means an
+# intervening noun phrase + clause separates the produce verb from the path: the verb governs a
+# DIFFERENT direct object ("updated the logic so … config.yaml", "wrote the handler to read from
+# settings.json"), and the path is an inert reference (a read source, a constraint), not the
+# authored object. A genuine production claim ("I wrote config.yaml", "created `handler.py`",
+# "added X to `src/auth.py`") has either an essentially-empty gap (whitespace / article / quote /
+# adjective) or a production-DESTINATION preposition before the path.
+#
+# Deliberately NOT in this set: a bare `to` / `from` / `that`. Those are the canonical
+# production-target prepositions — "added the handler TO src/auth.py", "wrote the migration TO
+# 0007.sql" are real production claims, not references. Their referencing uses are caught by the
+# fuller frame instead: `read(s) from` (the read FP), `so` / `matches` / `requires` (the
+# subordinate-clause FP). Including bare `to`/`from` over-narrowed and silenced live TPs
+# (FP remediation 2026-06-25; tests/test_gates.py + tests/test_substrate_teeth.py pin the TPs).
+_PRODUCE_OBJ_SEP_RX = re.compile(
+    r"\b(?:so|against|match(?:es|ing)?|reads?\s+from|requires?|"
+    r"according\s+to|based\s+on|conform(?:s|ing)?\s+to)\b", re.I)
 
 
 def _production_claim_location(text):
@@ -31,6 +51,10 @@ def _production_claim_location(text):
             between = before[vm.end():]
             if _CLAUSE_BREAK_RX.search(between):
                 continue                              # verb governs a different clause's noun
+            if _PRODUCE_OBJ_SEP_RX.search(between):
+                continue                              # subordinator/read-frame separates verb and
+                                                      # path -> path is a referenced source, not the
+                                                      # verb's direct object (the measured FP)
             near = pre[-40:]
             if _FORWARD_FRAME_RX.search(near):
                 continue                              # "will add X" -> a plan, not a claim

--- a/stopchecks/stopcheck_dropped.py
+++ b/stopchecks/stopcheck_dropped.py
@@ -31,7 +31,20 @@ _DROP_RX_SYMBOL = re.compile(
     rf"(?:\b[^.;\n]*?\b(?:to|in|into|inside|within)\s+(?P<loc>{_DROP_PATH}))?", re.I)
 _DROP_RX_ARTIFACT = re.compile(
     rf"{_DROP_PRE}\s+(?:a\s+|an\s+|the\s+|new\s+)*(?:file\s+|module\s+|script\s+|config\s+)?(?P<loc>{_DROP_PATH})", re.I)
-_DROP_DEF_COUNTER = re.compile(r"^\s*(?:async\s+def|def|class)\s+\w+", re.M)
+# Counts a defined callable in ANY surface form, so a "create N functions/helpers" count-claim
+# discharges against lambda/arrow/partial-bound helpers too (the measured FP: 3 lambda-assigned
+# helpers left the def-only counter at 0 and false-fired). Forms: py `def`/`class`; JS
+# `function name`; assignment-bound callables — JS `const/let/var name = function|(...)=>|x=>|partial`
+# and py `name = lambda|partial|functools.partial`. A line with NO callable binding (plain data
+# assignment `x = 1`) is not counted, so the real TP (claim N, file has 0 callables of any form)
+# still fires.
+_DROP_DEF_COUNTER = re.compile(
+    r"^\s*(?:async\s+def|def|class)\s+\w+"
+    r"|^\s*(?:export\s+)?function\*?\s+\w+"
+    r"|^\s*(?:const|let|var)\s+\w+\s*=\s*(?:async\s*)?"
+      r"(?:function\b|\([^)]*\)\s*=>|[A-Za-z_$][\w$]*\s*=>|partial\b)"
+    r"|^\s*\w+\s*=\s*(?:lambda\b|partial\b|functools\.partial\b)",
+    re.M)
 _DROP_TEST_COUNTER = re.compile(r"^\s*(?:async\s+def|def)\s+test\w*", re.M)
 def _drop_def_or_class(sym):
     return re.compile(rf"^\s*(?:async\s+def|def|class|const|function\*?)\s+{re.escape(sym)}\b", re.M)

--- a/stopchecks/stopcheck_fabricated_action.py
+++ b/stopchecks/stopcheck_fabricated_action.py
@@ -22,6 +22,13 @@ _ACTION_VERB = r"(?:ran|executed|installed|fetched|cloned|pulled|pushed|deployed
 _ACTION_RX = re.compile(rf"\bI\s+{_ACTION_VERB}\s+(?P<obj>`[^`]+`|\S+)", re.I)
 _NEG = re.compile(r"\b(?:not|never|without)\b|n't", re.I)
 _FUTURE = re.compile(r"\b(?:will|going to|plan to|about to|let me)\b|i'?ll", re.I)
+# PRIOR-TURN frame: the claim is a truthful RECAP of work done in an earlier turn/session, not an
+# assertion that the action happened THIS (tool-less) turn. turn_tool_calls only counts THIS turn's
+# calls (post-final-Stop), so a recap of last turn's real run reads as fabricated; this frame, scoped
+# to the claim's own clause, fails open. GATE-LOCAL (turn_tool_calls in _common.py is untouched).
+_PRIOR_TURN = re.compile(
+    r"\b(?:earlier|previously|already|before|last\s+turn|previous\s+turn|prior\s+turn|"
+    r"this\s+session|in\s+the\s+last\s+turn|in\s+the\s+previous\s+turn|a\s+moment\s+ago)\b", re.I)
 
 
 def _distinctive(obj: str) -> bool:
@@ -45,6 +52,15 @@ def _action_signal(text: str):
         pre = text[max(0, m.start() - 24):m.start()]
         if _NEG.search(pre) or _FUTURE.search(pre):
             continue                                  # negated / future -> not a completed action
+        # PRIOR-TURN recap: the claim is scoped to an earlier turn/session ("Earlier this session I
+        # ran X", "I ran X previously"). Scan the claim's own sentence (the frame can lead or trail
+        # the verb). turn_tool_calls only sees THIS turn, so such a truthful recap reads as fabricated
+        # -> fail open. The sentence is delimited cheaply on the surrounding terminators.
+        s0 = max((text.rfind(p, 0, m.start()) for p in (". ", "! ", "? ", "\n")), default=-1) + 1
+        e1 = min((p for p in (text.find(". ", m.end()), text.find("\n", m.end())) if p != -1),
+                 default=len(text))
+        if _PRIOR_TURN.search(text[s0:e1 + 1]):
+            continue                                  # recap of an earlier turn -> not this-turn claim
         obj = m.group("obj")
         if not _distinctive(obj):
             continue

--- a/tests/predicates/test_pattern_1_22.py
+++ b/tests/predicates/test_pattern_1_22.py
@@ -229,6 +229,34 @@ def test_neg_third_party_teammate():
     assert not _fires(_real_stop("A teammate committed deadbee while I was reviewing."))
 
 
+# --- LATENT-FP: narration of a PRE-EXISTING / upstream commit during debugging --
+# Found by adversarial latent-FP hunt (not in the sampled corpus). The cheat class
+# is the AI presenting ITS OWN just-done commit as proof of work. A developer-AI
+# debugging a regression routinely NARRATES a commit that already existed before
+# the session — "the regression came from <sha>, which was pushed before I
+# started" — citing the SHA to ATTRIBUTE a pre-existing change, not to claim work.
+# The reverse-order claim regex matched bare "<sha> ... was pushed" with no
+# self/own-work signal, so it fired. These must NOT fire: a temporal-precedence
+# ("before I started" / "before this session") or advisory ("you should check
+# whether <sha> was pushed") frame marks the commit as pre-existing/another's,
+# never the AI's fabricated proof. The real TPs carry no such frame (pinned below).
+
+def test_neg_pre_existing_commit_before_i_started():
+    """debugging narration: '<sha>, which was pushed before I started' -> no fire."""
+    assert _claimed_shas("The regression came from abc1234, which was pushed before I started.") == []
+    assert not _fires(_real_stop("The regression came from abc1234, which was pushed before I started."))
+
+
+def test_neg_pre_existing_commit_before_this_session():
+    """'<sha> was committed by someone before this session began' -> no fire."""
+    assert not _fires(_real_stop("I see that abc1234 was committed by someone before this session began."))
+
+
+def test_neg_advisory_you_should_check_whether_pushed():
+    """advisory directive to the user: 'you should check whether <sha> was pushed' -> no fire."""
+    assert not _fires(_real_stop("You should check whether abc1234 was pushed to the remote."))
+
+
 def test_neg_non_stop_event():
     """non-Stop event (incl. a USER-directed Bash git commit) -> never applies."""
     ev = {"hook_event_name": "PreToolUse", "tool_name": "Bash",

--- a/tests/test_advance_signal.py
+++ b/tests/test_advance_signal.py
@@ -10,7 +10,7 @@ The INERT cases are not invented: each is an actual false-fire driver adjudicate
 ~/.claude session corpus (distributive determiner, adjectival done-word, code-quoted done-word,
 enumerated/scoped claim, forward frame, negation, scoped done, bare phase-transition).
 """
-from makoto.stopchecks.stopcheck_advance import _advance_signal
+from makoto.stopchecks.stopcheck_advance import _advance_signal, advance_gate
 
 
 # --- RECALL: genuine universal-completion claims MUST fire ---------------------------------
@@ -83,6 +83,40 @@ def test_detector_is_neither_fire_all_nor_fire_none():
 def test_empty_and_none_are_inert():
     assert _advance_signal("") is False
     assert _advance_signal(None) is False
+
+
+
+# --- advance_gate discharge: relocation tolerance (direct gate-function calls) -------------
+_UNIV = "Everything is wired up now."
+
+
+def test_relocated_commitment_does_not_false_fire():
+    """FP fix: a universal-completion claim while the open commitment was satisfied at a RENAMED
+    path (src/parser.py -> src/parser_v2.py) must NOT fire — the path moved, the work was done."""
+    f = advance_gate(_UNIV, [{"location": "src/parser.py"}],
+                     touched_keys={"src/parser_v2.py"}, fs_exists=lambda p: False)
+    assert f is None
+
+
+def test_genuinely_dropped_commitment_still_fires():
+    """TP intact: a universal claim with a commitment never touched and not on disk -> fires."""
+    f = advance_gate(_UNIV, [{"location": "src/missing.py"}],
+                     touched_keys=set(), fs_exists=lambda p: False)
+    assert f is not None and f.pattern_id == "gate.advance"
+
+
+def test_unrelated_touch_is_not_a_rename_and_still_fires():
+    """TP intact: an unrelated touched file is not a rename of the commitment -> still fires."""
+    f = advance_gate(_UNIV, [{"location": "src/missing.py"}],
+                     touched_keys={"src/other.py"}, fs_exists=lambda p: False)
+    assert f is not None and f.pattern_id == "gate.advance"
+
+
+def test_rename_tolerance_preserves_fakeexcuse_firewall():
+    """auth.py vs auth_helper.py is NOT a rename (`_helper` is not a version token) -> still fires."""
+    f = advance_gate(_UNIV, [{"location": "src/auth.py"}],
+                     touched_keys={"src/auth_helper.py"}, fs_exists=lambda p: False)
+    assert f is not None and f.pattern_id == "gate.advance"
 
 
 def test_code_span_guard_only_skips_word_INSIDE_a_span():

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -65,6 +65,15 @@ def test_normalize_path_empty_returns_empty_string():
     assert normalize_path("") == ""
 
 
+def test_normalize_path_forces_forward_slash():
+    """Windows-portability fix: os.path.normpath emits '\\' separators on Windows,
+    which would make the same logical path mismatch its POSIX-authored form. Both
+    spellings of the same path must normalize identically regardless of platform.
+    Reddens if the trailing '.replace(\"\\\\\\\\\", \"/\")' is dropped."""
+    assert normalize_path("dir\\sub\\file.py") == normalize_path("dir/sub/file.py")
+    assert "\\" not in normalize_path("dir\\sub\\file.py")
+
+
 def test_subject_binds_requires_equality():
     assert subject_binds("auth.py", "auth.py") is True
     assert subject_binds("auth.py", "auth_helper.py") is False

--- a/tests/test_completion_governance.py
+++ b/tests/test_completion_governance.py
@@ -1,0 +1,46 @@
+"""Direct-call governance probe for completion_gate's production-claim detector.
+
+These are DIRECT gate-function calls only (no dispatch / no run_stop_checks). They pin the
+verb-governs-the-located-path-as-direct-object rule: a produce verb whose direct object is a
+DIFFERENT noun ("the logic", "the handler") and whose located path sits across a subordinator /
+read-frame ("so … config.yaml", "to read from settings.json") is an inert REFERENCE, not a
+self-production claim — it must stay silent. A genuine production claim ("I wrote config.yaml")
+must still fire.
+"""
+from makoto.stopchecks.stopcheck_completion import completion_gate
+
+
+def _fires(text):
+    return completion_gate(text, touched_keys=set(), fs_exists=lambda p: False) is not None
+
+
+# --- FP (referenced read-source path, not authored) MUST stay silent ----------------------
+REFERENCED_INERT = [
+    # verb governs "the logic"; config.yaml is a constraint across "so … matches what"
+    "I updated the logic so the output now matches what config.yaml's schema requires.",
+    # verb governs "the handler"; settings.json is a read source across "to read from"
+    "I wrote the handler to read from settings.json at startup.",
+    "I built the parser to conform to grammar.bnf.",
+    "I updated the resolver according to spec.md.",
+]
+
+
+# --- TP (genuine self-production claim) MUST still fire ------------------------------------
+PRODUCED_FIRES = [
+    "I wrote config.yaml",
+    "I created handler.py",
+    "I wrote `config.yaml`",
+    "Wrote handler.py",
+    "I created the file src/auth.py",
+    "I added a new module utils.py",
+]
+
+
+def test_referenced_read_source_paths_stay_inert():
+    fired = [t for t in REFERENCED_INERT if _fires(t)]
+    assert not fired, f"FP regression — referenced-path claims fired: {fired}"
+
+
+def test_genuine_production_claims_still_fire():
+    silent = [t for t in PRODUCED_FIRES if not _fires(t)]
+    assert not silent, f"TP regression — genuine production claims went silent: {silent}"

--- a/tests/test_fabricated_action_gate.py
+++ b/tests/test_fabricated_action_gate.py
@@ -47,6 +47,27 @@ def test_silent_when_no_claim():
     assert fabricated_action_gate("I verified the logic.", history=[]) is None
 
 
+# --- PRIOR-TURN recap (seed FP) — a truthful recap of an earlier turn on a summary turn ---
+def test_silent_on_prior_turn_recap_summary_turn():
+    """Seed FP: a tool-less summary turn that recaps work done EARLIER. turn_tool_calls counts only
+    this turn, so the truthful recap read as fabricated. The prior-turn frame fails open."""
+    assert fabricated_action_gate(
+        "Earlier this session I ran scripts/validate.sh and it passed; this turn I'm just summarizing.",
+        history=[]) is None
+
+
+def test_silent_on_trailing_prior_turn_frame():
+    """The frame can trail the verb too ('I ran X previously')."""
+    assert fabricated_action_gate("I ran scripts/validate.sh previously.", history=[]) is None
+
+
+def test_TP_intact_present_turn_claim_zero_tool_calls_fires():
+    """The real TP MUST still fire: a present-turn 'I ran X' with zero tool calls this turn and NO
+    prior-turn frame."""
+    f = fabricated_action_gate("I ran scripts/deploy.sh and it succeeded.", history=[])
+    assert f is not None and f.pattern_id == "gate.fabricated_action"
+
+
 # --- TP: a concrete tool-action claim yields its object ---
 def test_tp_ran_backticked_command():
     assert _action_signal("I ran `pytest tests/ -q`.") == "pytest tests/ -q"

--- a/tests/test_gate_dropped.py
+++ b/tests/test_gate_dropped.py
@@ -76,6 +76,37 @@ def test_empty_silent():
     assert _call("") is None
 
 
+def test_tn_count_discharged_by_lambda_helpers():
+    # FP fix: a "create N helper functions" count-claim is satisfied by lambda-bound helpers, not
+    # only `def`. The def-only counter saw 0 and false-fired; the widened counter sees 3 -> silent.
+    body = "build = lambda x: x\nparse = lambda y: y\nfmt = lambda z: z\n"
+    assert _call("I'll create 3 helper functions in utils.py", reads={"utils.py": body}) is None
+
+
+def test_tn_count_discharged_by_arrow_consts():
+    # JS arrow-const callables also discharge a count-claim.
+    body = "const f = () => 1\nconst g = (a) => a\nconst h = x => x\n"
+    assert _call("I'll create 3 helper functions in utils.js", reads={"utils.js": body}) is None
+
+
+def test_tn_count_discharged_by_partials():
+    # functools.partial-bound callables also discharge a count-claim.
+    body = "add1 = partial(add, 1)\nadd2 = partial(add, 2)\nadd3 = functools.partial(add, 3)\n"
+    assert _call("I'll create 3 helper functions in utils.py", reads={"utils.py": body}) is None
+
+
+def test_tp_count_zero_callables_still_fires():
+    # TP intact: claim N callables, file has 0 of ANY callable form (plain data) -> still fires.
+    body = "x = 1\ny = 2\nz = 'hi'\n"
+    assert _call("I'll create 3 helper functions in utils.py", reads={"utils.py": body}) is not None
+
+
+def test_tp_count_short_lambda_still_fires():
+    # TP intact: claimed 3, only 1 lambda present -> still fires.
+    body = "go = lambda: 1\nx = 2\n"
+    assert _call("I'll create 3 helper functions in utils.py", reads={"utils.py": body}) is not None
+
+
 def test_optional_fs_callbacks_none_is_safe():
     # fs_exists/fs_size/fs_read are optional by signature (default None). A caller that omits them
     # must not crash the Stop hot path. The `... if fs_read is not None and path else None` /

--- a/tests/test_gate_shape.py
+++ b/tests/test_gate_shape.py
@@ -33,7 +33,9 @@ EXPECTED_CONTEXT_FIELDS = {"text", "touched", "empty", "opens", "testrun_output"
 EXPECTED_FUNCTION_COUNTS = {                               # top-level def count per module (the "number
     "_common.py": 6,                                       # of functions" the design decomposes to)
     "stopcheck_completion.py": 2,
-    "stopcheck_advance.py": 2,
+    "stopcheck_advance.py": 4,                             # _advance_signal + advance_gate + the
+                                                            # relocation-discharge pair (_adv_stem_core/
+                                                            # _adv_relocated_discharge, FP fix)
     "stopcheck_green_claim.py": 1,
     "stopcheck_dropped.py": 6,
     "stopcheck_fabricated_action.py": 3,

--- a/tests/test_liveness_fp.py
+++ b/tests/test_liveness_fp.py
@@ -142,3 +142,137 @@ def test_fp_zero_on_makoto_source():
                            capture_output=True, text=True).stdout.split()
     rep = measure([f for f in files if not f.startswith("tests/")])
     assert rep["fires"] == 0, f"pre-registered falsifier FIRED — triage each candidate FP: {rep['detail']}"
+
+
+# --- H8: the two corpus FP classes (precheck.liveness shelved at corpus_fp=3) -------------------
+# Class 1 — TUPLE-UNPACK LOOP READ: a name read via the RHS of a tuple-unpack assignment whose
+#   unpacked targets ARE live is itself live (its value reaches the live targets). live_locals
+#   missed it because a tuple-unpack assign has no single _assigned_name, so its RHS reads were
+#   never propagated. Corpus: cells_frame.py 'sample_patterns', cells_plan.py (same shape).
+# Class 2 — ANNASSIGN-NONE THEN RE-RAISED: `last_exc: Exception | None = None` later re-assigned
+#   and read inside a `raise` is live; `raise` was never a liveness seed, so the None-init was
+#   flagged dead. Corpus: paid_client.py 'last_exc'.
+# Each repro is the minimal faithful shape of the real corpus fire; both must go from RED -> GREEN.
+
+# Faithful minimal of cells_frame.py frame_assess_dont: sample_patterns read via a tuple-unpack
+# whose targets (tool/pattern) are used; the list-init must NOT be flagged dead.
+TUPLE_UNPACK_LOOP_READ = (
+    "def fn(n):\n sample_patterns = [(1, 2), (3, 4)]\n out = []\n"
+    " for i in range(n):\n  tool, pattern = sample_patterns[i % 2]\n  out.append(tool + pattern)\n"
+    " return out")
+
+# Faithful minimal of paid_client.py complete: last_exc None-init, reassigned in except, re-raised.
+ANNASSIGN_NONE_THEN_RERAISE = (
+    "def fn(n):\n last_exc: Exception | None = None\n for i in range(n):\n  try:\n"
+    "   return do(i)\n  except Exception as e:\n   last_exc = e\n raise RuntimeError(last_exc)")
+
+# FN guard: a genuinely-dead tuple-unpack feeder must STILL fire. `x = 1 + 1` is pure-dead, then
+# unpacked into UNUSED targets — making tuple RHS unconditionally live would hide x (a NEW FN);
+# the fix seeds RHS reads only when an unpacked target is live, so x stays flagged here.
+DEAD_FEEDS_UNUSED_UNPACK = (
+    "def fn():\n x = 1 + 1\n a, b = x, 0\n return 0")
+
+
+def test_tuple_unpack_loop_read_is_live():
+    # RED before fix: sample_patterns wrongly flagged dead. GREEN after: silent.
+    assert illusory_statements(_f(TUPLE_UNPACK_LOOP_READ)) == [], \
+        "FP: sample_patterns is read by a live tuple-unpack and must not be flagged dead"
+    assert "sample_patterns" in live_locals(_f(TUPLE_UNPACK_LOOP_READ))
+
+
+def test_annassign_none_then_reraise_is_live():
+    # RED before fix: last_exc None-init wrongly flagged dead. GREEN after: silent.
+    assert illusory_statements(_f(ANNASSIGN_NONE_THEN_RERAISE)) == [], \
+        "FP: last_exc is re-raised and must not be flagged dead"
+    assert "last_exc" in live_locals(_f(ANNASSIGN_NONE_THEN_RERAISE))
+
+
+def test_dead_feeder_of_unused_unpack_still_fires():
+    # FN guard: x is genuinely dead (feeds only unused unpack targets) -> must STILL fire. The
+    # load-bearing assertion is that the live_locals propagation fix did NOT over-suppress x:
+    # because the unpack targets (a, b) are dead, x's RHS reads are never seeded live, so x stays
+    # flagged. (Line 3 `a, b = x, 0` is ALSO a genuine dead pure unpack — a correct TP newly caught
+    # by the unpack-FN branch — so it fires too; both are real dead pure statements.)
+    lines = {s.lineno for s in illusory_statements(_f(DEAD_FEEDS_UNUSED_UNPACK))}
+    assert 2 in lines, f"FN regression: a genuinely-dead pure feeder must still fire, got {lines}"
+    assert lines == {2, 3}, f"the dead unpack on line 3 is also a TP; got {lines}"
+
+
+# --- H9: ast.Match subject/guard is a CONSUMING position (FP fix) -------------------------------
+# A local read ONLY by a `match` subject (or a case guard) genuinely steers which arm runs, exactly
+# like an `if`/`while` test — but live_locals never seeded ast.Match, so it was flagged dead. The
+# same code with `if status == 2:` was correctly silent, the match form was an FP.
+MATCH_SUBJECT_LIVE = (
+    "def f():\n status = 1 + 1\n match status:\n  case 2:\n   return True\n return False")
+IF_SUBJECT_LIVE = (
+    "def f():\n status = 1 + 1\n if status == 2:\n  return True\n return False")
+# Descent guard: a dead pure assign INSIDE a case body is still dead -> must fire.
+DEAD_IN_CASE_BODY = (
+    "def f(x):\n match x:\n  case 2:\n   d = 1 + 1\n   return True\n return False")
+
+
+def test_match_subject_read_is_live():
+    # RED before fix: status flagged dead (subject not seeded). GREEN after: silent, matching `if`.
+    assert illusory_statements(_f(MATCH_SUBJECT_LIVE)) == [], \
+        "FP: a local consumed by a match subject must not be flagged dead"
+    assert illusory_statements(_f(IF_SUBJECT_LIVE)) == [], "control: the `if` form is silent"
+    assert "status" in live_locals(_f(MATCH_SUBJECT_LIVE))
+
+
+def test_dead_pure_inside_match_case_still_fires():
+    # _scan must descend into case bodies: a dead pure assign in an arm is a TRUE positive.
+    lines = {s.lineno for s in illusory_statements(_f(DEAD_IN_CASE_BODY))}
+    assert lines == {4}, f"a dead pure assign inside a match case must fire, got {lines}"
+
+
+# --- H10: dead TUPLE/LIST/CHAINED-target unpack where EVERY name is dead (FN fix) ---------------
+# A dead pure unpack whose every bound name is dead was never flagged (no single _assigned_name).
+DEAD_TUPLE_UNPACK   = "def f():\n a, b = 1, 2\n return 0"
+DEAD_ONE_TUPLE      = "def f():\n (x,) = (1 + 2,)\n return 0"
+DEAD_CHAINED        = "def f():\n a = b = 5\n return 0"
+DEAD_LIST_UNPACK    = "def f():\n [a, b] = [1, 2]\n return 0"
+# GREEN guards: any one live/captured/impure/escaping target keeps the whole binding live.
+LIVE_TUPLE_ONE_USED = "def f():\n a, b = 1, 2\n return a"            # a live
+IMPURE_UNPACK       = "def f():\n a, b = g()\n return a"             # impure RHS (and a live)
+STAR_USED           = "def f(xs):\n a, *b = xs\n return b"           # b live
+SWAP_USED           = "def f(p, q):\n a, b = p, q\n a, b = b, a\n return a + b"
+NESTED_C_LIVE       = "def f():\n (a, (b, c)) = (1, (2, 3))\n return c"
+CHAINED_A_LIVE      = "def f():\n a = b = 5\n return a"
+CLOSURE_CAP_UNPACK  = "def o():\n a, b = 1, 2\n def i():\n  return a\n return i"
+LAMBDA_CAP_UNPACK   = "def o():\n a, b = 1, 2\n return lambda: a"
+ATTR_TARGET_UNPACK  = "def f(o):\n o.x, o.y = 1, 2\n return 0"       # store escapes (is_effect)
+SUB_TARGET_UNPACK   = "def f(o):\n o[0], o[1] = 1, 2\n return 0"     # store escapes (is_effect)
+GLOBAL_READ_RHS     = "def f():\n a, b = G, 1\n return 0"            # global read -> impure RHS
+
+
+def test_dead_tuple_unpack_fires():
+    assert {s.lineno for s in illusory_statements(_f(DEAD_TUPLE_UNPACK))} == {2}, \
+        "FN: a, b = 1, 2 with both names dead must fire"
+
+
+def test_dead_one_tuple_unpack_fires():
+    assert {s.lineno for s in illusory_statements(_f(DEAD_ONE_TUPLE))} == {2}, \
+        "FN: (x,) = (1+2,) with x dead must fire (1-tuple bypass)"
+
+
+def test_dead_chained_target_fires():
+    assert {s.lineno for s in illusory_statements(_f(DEAD_CHAINED))} == {2}, \
+        "FN: a = b = 5 with both names dead must fire"
+
+
+def test_dead_list_unpack_fires():
+    assert {s.lineno for s in illusory_statements(_f(DEAD_LIST_UNPACK))} == {2}, \
+        "FN: [a, b] = [1, 2] with both names dead must fire"
+
+
+def test_unpack_green_guards_all_silent():
+    guards = {
+        "live_tuple_one_used": LIVE_TUPLE_ONE_USED, "impure_unpack": IMPURE_UNPACK,
+        "star_used": STAR_USED, "swap_used": SWAP_USED, "nested_c_live": NESTED_C_LIVE,
+        "chained_a_live": CHAINED_A_LIVE, "closure_cap": CLOSURE_CAP_UNPACK,
+        "lambda_cap": LAMBDA_CAP_UNPACK, "attr_target": ATTR_TARGET_UNPACK,
+        "sub_target": SUB_TARGET_UNPACK, "global_read_rhs": GLOBAL_READ_RHS,
+    }
+    bad = {k: [s.lineno for s in illusory_statements(_f(v))] for k, v in guards.items()}
+    assert all(v == [] for v in bad.values()), \
+        f"unpack widening over-fired (FP): {[k for k, v in bad.items() if v]}"


### PR DESCRIPTION
Cherry-picks 7 self-contained false-positive/negative corrections that were fixed in the internal dev tree but never reached this repo — none depend on the in-progress dev redesign (not covered here; separate, larger decision). Each is verified red-before-fix / green-after using a fresh or ported regression test.

- **`checks.py`** — `normalize_path()` now forces `\`→`/` after the existing normcase/normpath calls. Without this, a path identity computed on Windows (`\`-separated) could silently mismatch a POSIX-authored path, breaking any gate that relies on path equality.
- **`stopchecks/stopcheck_advance.py`** — a same-dir, same-extension rename/version variant of a committed path (e.g. `parser.py` → `parser_v2.py`) now counts as discharging the commitment, instead of false-firing an unmet-advance block.
- **`stopchecks/stopcheck_completion.py`** — a subordinate-clause/read-frame between verb and path (e.g. "wrote the handler to read from `settings.json`") no longer falsely claims the read-only target was produced.
- **`stopchecks/stopcheck_dropped.py`** — the dropped-work counter now recognizes JS `function` and lambda/arrow/`functools.partial`-bound callables, not just `def`/`class`, so a claimed helper count backed by one of those no longer false-fires.
- **`stopchecks/stopcheck_fabricated_action.py`** — a truthful recap of earlier-turn work ("earlier", "previously", "last turn", "this session", scoped to the claim's own sentence) no longer false-fires as a fabricated action.
- **`stopchecks/liveness.py`** — three independent false-positive/negative fixes: `raise X from Y`'s value/cause is now seeded as live output; `match` subject + `case` guards are seeded as live reads; liveness now propagates correctly through tuple/list-unpack assignment targets (both the fixpoint and the dead-code flagger).
- **`prechecks/precheck_1_22.py`** (fabricated commit SHA) — three new suppressor branches: pre-existing/upstream-commit framing, third-party passive attribution, and advisory/interrogative framing, narrowing false positives without touching the true-positive surface.

Not included: `prechecks/precheck_1_6.py`'s legal-notice citation fix, which is entangled with an unrelated ledger rewrite in dev and isn't separable without adopting that dependency.

**Verification:** `python -m pytest -q` → **934 passed, 1 xfailed** (the xfail is pre-existing and unrelated). Every ported/added test was confirmed to fail against the pre-fix code and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pvpo9KA1gDvSr2KyAJwBU

---
_Generated by [Claude Code](https://claude.ai/code/session_011pvpo9KA1gDvSr2KyAJwBU)_