### PR TITLE
Fix _DESTRUCTIVE_RX false-positive/negative on dd, and the same shape elsewhere in the denylist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to makoto. Versions follow the live check inventory
 ## [Unreleased]
 
 ### Fixed
+- **`canon.destructive_command` no longer false-blocks a read-only `dd`, and now catches a
+  force-push/hard-reset/interactive-clean wherever its trigger flag actually sits.** `dd if=`
+  fired on any `dd` invocation regardless of whether it also wrote anywhere (`of=`) — using
+  `dd` as a byte-range reader (piped to `fold`/`xxd`, no `of=`) tripped `destructive_command`
+  for the rest of the session. Also generalized the same fix to the rest of the denylist:
+  `git clean`/`git push`/`git reset --hard` required their trigger flag immediately after the
+  base command, missing e.g. `git push origin main --force`; `git clean`/`git push` now also
+  veto on a real `-n`/`--dry-run` found anywhere in the command; and `git checkout -- .` had a
+  regex bug that made it dead code (it could never actually match). `mkfs.*`'s own `-n` was
+  deliberately left alone — it means dry-run for `mkfs.ext4` but volume-label for `mkfs.vfat`,
+  so a blanket exclusion would have silently created a false negative on a real format. (#10)
 - **`canon.recur` no longer stays permanently stuck once a retry loop genuinely resolves.**
   Verdict is now judged per (tool, input) key, and the last judgment for each key wins: a later
   success for that key silences it even when different calls happened in between, while a

--- a/makoto/substrate/_canonAtoms.py
+++ b/makoto/substrate/_canonAtoms.py
@@ -118,16 +118,30 @@ def _is_test_path(fp) -> bool:
 # ponytail: heuristic denylist of canonically-destructive shell operations; expand as real corpus
 # misses surface -- an FN-safe recall bound (it only ever ADDS an alternative), never a false-block
 # source.
+#
+# Five entries below scan `[^|;&\n]*` past the base command rather than requiring the trigger
+# token immediately adjacent to it (git-issue #10's own dd fix, generalized: `\bdd\s+if=` missed
+# `dd of=X if=Y` for the same reason `git\s+push\s+(?:-f|--force)` misses `git push origin main
+# --force`, and `git\s+reset\s+--hard` misses `git reset --quiet --hard` -- all three required the
+# trigger to be the very next token). The stop-set excludes a pipe/semicolon/`&`/newline so the
+# scan can't wander into an unrelated chained command on either side. `git clean` and `git push`
+# additionally veto on a real `-n`/`--dry-run` flag found anywhere in that same span, since neither
+# command does anything on a dry run regardless of what else is present. `mkfs.*` deliberately does
+# NOT get a dry-run veto: `-n` means "dry run" for mkfs.ext4 but "volume label" for mkfs.vfat, so a
+# blanket exclusion would silently create a false negative on a real mkfs.vfat format. `rm`'s own
+# long-form gap (`rm --recursive --force`) is left unfixed for the same kind of reason -- closing
+# it needs a real flag parser, not a wider letter-class scan (a loose scan for a bare "r" collides
+# with unrelated flags like --preserve-root).
 _DESTRUCTIVE_RX = re.compile(
     r"\brm\s+-\w*(?:rf|fr)\w*\b"
-    r"|\bgit\s+reset\s+--hard\b"
-    r"|\bgit\s+clean\s+-\w*[dfx]\w*\b"
-    r"|\bgit\s+push\s+(?:-f\b|--force\b)"
-    r"|\bgit\s+checkout\s+--\s+\.\b"
+    r"|\bgit\s+reset\b(?=[^|;&\n]*--hard\b)"
+    r"|\bgit\s+clean\b(?=[^|;&\n]*(?:\s-\w*[dfx]\w*\b|--force\b))(?![^|;&\n]*(?:\s-\w*n\w*\b|--dry-run\b))"
+    r"|\bgit\s+push\b(?=[^|;&\n]*(?:\s-f\b|--force\b))(?![^|;&\n]*(?:\s-n\b|--dry-run\b))"
+    r"|\bgit\s+checkout\s+--\s+\.(?!\w)"
     r"|\bdrop\s+(?:table|database)\b"
     r"|\btruncate\s+table\b"
     r"|\bmkfs\.\w+"
-    r"|\bdd\s+if=",
+    r"|\bdd\b[^|;&\n]*\bof=",
     re.IGNORECASE)
 
 # ponytail: a bash bypass-flag denylist for "a check was disabled" -- not a general flag parser.


### PR DESCRIPTION
`dd if=` fired on any `dd` invocation with `if=` present regardless of whether it also wrote anywhere (`of=`), turning a read-only byte-range read into a degenerate hard block for the rest of the session in a no-test/no-source-edit turn. Require `of=` in the same command, in either argument order (#10).

Auditing the rest of the denylist for the same two shapes — a condition that gates real destructiveness but isn't checked, and a match that only looks at the token immediately following the base command — surfaced:

- `git clean` / `git push` / `git reset --hard` required their trigger token immediately adjacent to the base command, missing e.g. `git push origin main --force` and `git reset --quiet --hard`.
- `git clean` / `git push` now also veto on a real `-n`/`--dry-run` found anywhere in the command, since neither does anything on a dry run.
- `git checkout -- .` had a stray trailing `\b` after the literal "." that made it dead code.

`mkfs.*`'s own `-n` was investigated and deliberately left alone: it means dry-run for `mkfs.ext4` but volume-label for `mkfs.vfat`, so a blanket exclusion would silently create a false negative on a real format. `rm`'s long-form gap (`--recursive --force`) is left open too, for the same class of reason.

Synced verbatim from makoto-dev's `substrate/_canonAtoms.py` (full test battery lives in dev's `tests/test_canon_atoms_destructive.py`); public's own smoke suite passes.

Addresses #10 (already closed there with the fix summary — this is the merge into `main`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVvmJMgErcvVJBprS9wyYE)_