### PR TITLE
Sync from dev: two false-positive fixes; add gate.claimed_shipped

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     {
       "name": "makoto",
       "source": "./",
-      "description": "Holds Claude Code to its word — every claim checked against the agent's own logged record; faked checks blocked, not warned (four narrow advisory self-checks excepted). Two-tier catalog (15 pre-checks, 18 Stop gates), each shipped at measured zero false positives.",
+      "description": "Holds Claude Code to its word — every claim checked against the agent's own logged record; faked checks blocked, not warned (four narrow advisory self-checks excepted). Two-tier catalog (15 pre-checks, 19 Stop gates), each shipped at measured zero false positives.",
       "category": "workflow",
       "tags": ["integrity", "guardrails", "hooks", "claims"],
       "license": "Apache-2.0",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "makoto",
-  "description": "Holds Claude Code to its word — every claim checked against the agent's own logged record; faked checks blocked, not warned (two narrow advisory self-checks excepted). Two-tier catalog (15 pre-checks, 14 Stop gates), each shipped at measured zero false positives.",
+  "description": "Holds Claude Code to its word — every claim checked against the agent's own logged record; faked checks blocked, not warned (two narrow advisory self-checks excepted). Two-tier catalog (15 pre-checks, 17 Stop gates), each shipped at measured zero false positives.",
   "version": "2.1.1",
   "author": {"name": "Clear-Sights"},
   "homepage": "https://github.com/Clear-Sights/Makoto",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,39 @@ All notable changes to makoto. Versions follow the live check inventory
   liveness-check command ran at all this session, or the most recently recorded one ended in a
   direct error state (interrupted, or a non-zero exit code). The claim signal requires a
   co-occurring first-person process-start verb ("I started / launched / ran ...") in the same
-  message, so generic explanatory prose about a tool's default behavior doesn't trip it. 17th
+  message, so generic explanatory prose about a tool's default behavior doesn't trip it. 15th
   end-of-turn gate; see `makoto/checks/claimedRunningAbsent.py`.
 - **`gate.run_promised`** — a new blocking end-of-turn gate, the forward-looking sibling of
   `gate.claimed_running`: the immediately prior turn made a first-person run-intent promise
   ("I'll run the tests", "let me deploy this") with no Bash call anywhere in the session's
   recorded history since. One-turn grace period: a promise made this turn can only be checked
-  starting at the next one. 18th end-of-turn gate; see `makoto/checks/runIntentUnfulfilled.py`.
+  starting at the next one. 16th end-of-turn gate; see `makoto/checks/runIntentUnfulfilled.py`.
+- **`gate.claimed_shipped`** — a new blocking end-of-turn gate, sibling to `gate.claimed_running`/
+  `gate.run_promised`: the assistant claims a REMOTE mutation is already done ("I merged the PR",
+  "pushed it to main", "it's live now") but no successful remote-mutating tool call appears
+  anywhere in the session's recorded history. Evidence is a non-dry-run `git push` over Bash, or
+  a successful call from a closed GitHub MCP tool set (`merge_pull_request` — requiring `merged:
+  true`, not just an error-free response — and `push_files`); `create_pull_request` is
+  deliberately excluded, since opening a PR establishes intent but does not substantiate "merged"
+  or "live". Reads pooled cross-agent history so a subagent's real push/merge grounds a
+  main-thread claim, same reasoning as `gate.claimed_running`. Immediate check, no grace period.
+  `gate.completion` keeps sole ownership of local file-production claims. 17th end-of-turn gate;
+  see `makoto/checks/claimedShippedAbsent.py`.
 
 ### Fixed
+- **`_DESTRUCTIVE_RX`/`_DISABLE_RX` no longer false-block a safe `git push --force-with-lease` or
+  `--force-if-includes`.** Both regexes' bare-force checks matched `--force\b` — a word boundary
+  fires right after "force" regardless of what follows, so a hyphen (a non-word character) let
+  these safe flags match identically to a bare `--force`, even though both are git's own SAFE
+  alternative (each refuses to push if the remote ref moved since the last fetch). Every
+  bare-force alternative is now `--force\b(?!-)`, excluding both safe flags while leaving bare
+  `--force`, `-f`, and every other destructive/disable clause unaffected.
+- **`gate.completion` no longer false-blocks a true claim that refers to a well-known file by its
+  bare, extensionless name** (e.g. "I updated the CHANGELOG" against a real `CHANGELOG.md` touch).
+  `_suffix_match` required the final path component to match exactly, so a claim binding to bare
+  "CHANGELOG" never matched a real touch at `.../CHANGELOG.md`. It now also accepts an
+  extensionless short side against a long side whose final component is `<short>.<recognized
+  extension>`; the existing firewall (`auth.py` never matches `auth_helper.py`) is unaffected.
 - **`canon.destructive_command` no longer false-blocks a read-only `dd`, and now catches a
   force-push/hard-reset/interactive-clean wherever its trigger flag actually sits.** `dd if=`
   fired on any `dd` invocation regardless of whether it also wrote anywhere (`of=`) — using

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ accept without re-deriving it.
 makoto fires on mechanical hook events: every `PreToolUse`, `PostToolUse`, `Stop`, and (advisory-only;
 see [ConfigChange watch](#configchange-watch-advisory--evidence-gated-blocking) below) `ConfigChange`.
 It **blocks** (exit 2, which Claude Code treats as block-and-retry) on **15 pre-checks** across five
-families and **14 end-of-turn gates** (plus `gate.stale_establisher` and `gate.undeclared_falsifiable`,
-two permanently-advisory catalog-completeness checks outside this 14-gate contract entirely: 16 live
-Stop-tier checks in total). Every pre-check and every one of the 14 end-of-turn gates but two blocks;
+families and **17 end-of-turn gates** (plus `gate.stale_establisher` and `gate.undeclared_falsifiable`,
+two permanently-advisory catalog-completeness checks outside this 17-gate contract entirely: 19 live
+Stop-tier checks in total). Every pre-check and every one of the 17 end-of-turn gates but two blocks;
 there is no silent "warning" tier for those (see [Fire level](#fire-level)). The two documented
 exceptions are `gate.self_wired` and `gate.canon_fingerprints_advisory` (below), advisory-only checks
 that by design never block.
@@ -56,6 +56,9 @@ that by design never block.
 - `gate.fabricated_action`: "I ran `X` / executed `Y`" in a turn with no tool call at all (presence-of-work, not command-text match)
 - `gate.named_test`: "`test_foo` passes" against a recorded `FAILED` of that exact named test (coreference-pinned; the green_claim delta)
 - `gate.stale_pass`: "all tests pass" against pytest's own `lastfailed` record still naming a live failing test (the runner's ledger, existence-filtered for staleness)
+- `gate.claimed_running`: "the server is running" / "it's up and listening on port 5173" but this session's own recorded Bash evidence contradicts it — no process-start or liveness-check command ran at all this session, or the most recently recorded one ended in a direct error state (`interrupted`, or a non-zero exit code). Agnostic in the `gate.canon` sense: the failure verdict reads only those two protocol terminals, never a test-runner regex or a language/framework token; the command classifier is a broad, open-world, multi-ecosystem net (like `is_test_runner`'s), so an unlisted launcher/healthcheck shape is a documented recall bound, never a false-block source.
+- `gate.run_promised`: the forward-looking sibling of `gate.claimed_running` — the immediately prior turn's own message promised a first-person run-intent action ("I'll run the tests", "I'm going to restart the server", "let me deploy this") but no Bash call appears anywhere in this session's recorded history since. Closed first-person-auxiliary + closed process-lifecycle-verb lexicon (mirroring `gate.claimed_running`'s own verb set), checked one turn later: the one-turn grace period falls out of `history` structurally never containing the row for the Stop currently being evaluated, so a promise made this turn can only be checked starting at the next one.
+- `gate.claimed_shipped`: a completed-action sibling to `gate.claimed_running`/`gate.run_promised`, scoped to REMOTE mutations instead of local process liveness — "I merged the PR", "pushed it to main", "it's live now" with no successful remote-mutating tool call anywhere in this session's recorded history. Evidence is a non-dry-run `git push` over Bash, or a successful call from a closed non-Bash tool set (`merge_pull_request` — requiring `merged: true`, not just an error-free response — and `push_files`); `create_pull_request` is deliberately excluded, since opening a PR establishes intent but does not substantiate "merged" or "live". Reads pooled cross-agent history so a subagent's own real push/merge grounds a main-thread claim. Immediate check, no grace period. `gate.completion` keeps sole ownership of local file-production claims.
 - `gate.liveness`: fires on the code itself, not a claim: a statement with no live effect inside a closed function (dead/illusory work the present-closure model can prove inert). It walks the turn's touched `.py` ASTs, so it yields a finding per illusory statement rather than one per turn.
 - `gate.self_wired`: **advisory only, never blocks** (see [Fire level](#fire-level)). Partial-strip detection of makoto's own `.claude/settings.json` hook wiring: fires if `PreToolUse`/`PostToolUse`/`Stop` is missing a makoto-dispatching entry while at least one other still has one. It has a documented blind spot: a single edit that strips all three simultaneously disables this check in the same instant it would have fired (Claude Code reloads hook config live, not once at session start), so it provides zero coverage against that full-strip case. See the [ConfigChange watch](#configchange-watch-advisory--evidence-gated-blocking) section below, which closes exactly this gap when wired.
 - `gate.hollow_test`: fires on the code itself, not a claim: a HOLLOWED test (SPIRIT.md §4), one that survives in name while its content is gutted, so it can never actually fail. Four sub-patterns: no assertion of any kind in the test body; an asserted tautology (`assert True`, or comparing an expression to itself); a broad, no-op `try`/`except` that silently swallows the only call-under-test's failure; and a test-shaped function that can never fire independently, either nested inside another function (pytest's collector never discovers it) or gated behind a `skipif`/`skipIf` condition that is provably always true.
@@ -205,7 +208,7 @@ non-blocking tier**: a `warning`/`disabled` resting state (witnessing a violatio
 tool through) is itself an illusory word, the exact weakening shape makoto exists to catch. The
 earlier three-tier system was removed in the 2026-06-02 *warning-tier-elimination* (a pattern either
 blocks at proven zero corpus-FP, or it is cut). This still governs all 15 pre-checks (`_ALLOWED_FIRE_LEVELS
-= {"error"}`, enforced at load) and 12 of the 14 end-of-turn gates.
+= {"error"}`, enforced at load) and 15 of the 17 end-of-turn gates.
 
 **Two narrow, explicitly-recorded exceptions:** `gate.self_wired` (2026-07-05) and
 `gate.canon_fingerprints_advisory` (SPEC-5 Task 9, DESIGN DECISION 26) fire at `level="advisory"`,
@@ -255,7 +258,7 @@ mis-block or mis-allow a tool call: a fundamental separation-of-concerns invaria
 
 ## ConfigChange watch (advisory + evidence-gated blocking)
 
-Separate from the 15 pre-checks and 16 end-of-turn checks above: an optional `ConfigChange` hook
+Separate from the 15 pre-checks and 19 end-of-turn checks above: an optional `ConfigChange` hook
 entry (`_dispatch_configchange.py`) watches `.claude/settings.json` edits for makoto's own hooks
 being stripped. Two tiers, both fail-open on any unexpected fault:
 

--- a/makoto/checks/claimedShippedAbsent.py
+++ b/makoto/checks/claimedShippedAbsent.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+from typing import Optional
+
+from makoto.core.schema import Finding
+from makoto.core.lexicons import (
+    _SHIPPED_ACTION_CLAIM_RX, _SHIPPED_STATE_CLAIM_RX, _REMOTE_GIT_PUSH_CMD_RX,
+    _NEGATION_RX, _ADV_FORWARD_RX, _SENTENCE_SPLIT_RX,
+)
+from makoto.substrate.claims import _code_spans
+from makoto.substrate.io import decode_history_row
+
+# gate.claimed_shipped -- an immediate claim-vs-record integrity gate for completed REMOTE
+# mutations. It owns "I pushed/merged/published/deployed/shipped/released X" and present-result
+# claims such as "it's live now"; gate.completion continues to own local file-production claims.
+#
+# EVIDENCE is existential across the session's recorded PostToolUse history: (1) a successful,
+# non-dry-run Bash `git push`, or (2) a successful call from the closed remote-mutation tool set
+# below. Like gate.run_promised, this deliberately does not attempt semantic coreference between
+# "it"/"#42" and a command's owner/repo/ref fields: guessing that mapping would create false
+# blocks. Any successful remote mutation is enough grounding to fail open.
+#
+# CLOSED NON-BASH SET: GitHub's merge_pull_request and push_files are actual shipping actions.
+# create_pull_request is intentionally excluded: opening a PR establishes review intent but does
+# not substantiate "merged", "pushed", or "live". create_or_update_file is excluded for the same
+# reason and remains closer to gate.completion. Both the bare MCP action names recorded by tests
+# and Claude Code's fully-qualified `mcp__github__...` names are enumerated explicitly; no suffix
+# or substring heuristic can silently admit a read-only tool.
+_REMOTE_MUTATING_TOOL_NAMES = frozenset({
+    "merge_pull_request",
+    "push_files",
+    "mcp__github__merge_pull_request",
+    "mcp__github__push_files",
+})
+
+
+def _shipped_claim(text: str):
+    """Return the first active completed-action or present-result shipping claim, else None.
+    Quoted/fenced mentions and negated/forward-framed clauses are inert. Past passive forms do
+    not enter either closed regex: the action regex requires first-person agency (or a boundary-
+    anchored status-report verb), while the state regex permits present copulas only."""
+    if not text:
+        return None
+    spans = _code_spans(text)
+    matches = sorted(
+        list(_SHIPPED_ACTION_CLAIM_RX.finditer(text))
+        + list(_SHIPPED_STATE_CLAIM_RX.finditer(text)),
+        key=lambda m: m.start(),
+    )
+    for m in matches:
+        a = m.start()
+        if any(s <= a < e for s, e in spans):
+            continue
+        clause = _SENTENCE_SPLIT_RX.split(text[max(0, a - 90):a])[-1] + m.group(0)
+        if _NEGATION_RX.search(clause) or _ADV_FORWARD_RX.search(clause):
+            continue
+        return m
+    return None
+
+
+def _response_succeeded(response) -> bool:
+    """Protocol-level success for a settled tool response. Missing/empty/errored responses fail
+    closed as evidence (which can make the gate fire), because they do not record a genuinely
+    successful mutation."""
+    if not isinstance(response, dict) or not response:
+        return False
+    if response.get("interrupted") is True:
+        return False
+    exit_code = response.get("exitCode", response.get("exit"))
+    if exit_code is not None and exit_code != 0:
+        return False
+    if any(response.get(k) not in (None, "", False) for k in ("error", "error_code", "is_error")):
+        return False
+    return True
+
+
+def _successful_remote_mutation(history) -> bool:
+    """True iff pooled history contains a completed, successful remote mutation."""
+    for row in history or ():
+        ev = decode_history_row(row)
+        if not isinstance(ev, dict) or ev.get("hook_event_name") != "PostToolUse":
+            continue
+        name = ev.get("tool_name", "")
+        tool_input = ev.get("tool_input") or {}
+        response = ev.get("tool_response")
+        if name == "Bash":
+            command = str(tool_input.get("command", "") or "") if isinstance(tool_input, dict) else ""
+            if (_REMOTE_GIT_PUSH_CMD_RX.search(command)
+                    and isinstance(response, dict)
+                    and response.get("exitCode", response.get("exit")) == 0
+                    and _response_succeeded(response)):
+                return True
+        elif name in _REMOTE_MUTATING_TOOL_NAMES and _response_succeeded(response):
+            if name.endswith("merge_pull_request") and response.get("merged") is not True:
+                continue
+            return True
+    return False
+
+
+def claimed_shipped_gate(text, *, history=()) -> Optional[Finding]:
+    """Fire immediately when a completed remote-shipping claim has no successful mutation
+    evidence anywhere in the session's pooled history."""
+    claim = _shipped_claim(text)
+    if claim is None or _successful_remote_mutation(history):
+        return None
+    return Finding(
+        pattern_id="gate.claimed_shipped", file="", line=0, level="error",
+        message=(f"Claim states a remote change was shipped "
+                 f"(\"{claim.group(0).strip()}\") but no successful remote-mutating tool call "
+                 "appears anywhere in this session's recorded history — the word must match "
+                 "the world."),
+        retry_hint=("Actually push/merge it with a successful recorded tool call, or "
+                    "retract/rescope the shipping claim."),
+    )
+
+
+from makoto.substrate._loader import Check as _Check
+CHECK = _Check(id="gate.claimed_shipped", applies_at="Stop", posture="BLOCK", may_block=True,
+               run=lambda c: claimed_shipped_gate(c.text, history=c.history_all_agents))

--- a/makoto/core/lexicons.py
+++ b/makoto/core/lexicons.py
@@ -10,6 +10,14 @@ import re
 
 _DONE_WORDS_RX = re.compile(r"\b(done|complete|completed|finished)\b", re.IGNORECASE)
 
+# File extensions recognized by the location detector. Kept at L0 because both the detector
+# and shared path-suffix discharge logic must recognize precisely the same extension set.
+_PATH_EXT = (
+    r"py|pyi|md|rst|txt|toml|json|jsonl|ndjson|ya?ml|ini|cfg|conf|env|lock|"
+    r"sh|bash|zsh|fish|js|jsx|mjs|cjs|ts|tsx|rs|go|rb|java|kt|swift|c|h|hpp|cc|cpp|"
+    r"sql|html?|css|scss|sass|xml|csv|tsv|sock|proto|graphql|tf|svg|ipynb|dockerfile"
+)
+
 _NEGATION_RX = re.compile(r"\b(not|never|no)\b|n['’]t\b", re.IGNORECASE)
 
 # Universal exemption marker (2026-05-29). Makoto's bundled CLAUDE.md (written by the
@@ -403,6 +411,43 @@ _RUN_INTENT_IDIOM_VETO_RX = re.compile(
     r"^\s*(?:\w+\s+){0,3}by\s+(?:you|him|her|them|us|the\s+team|everyone|someone)\b"
     r"|^\s*through\b"
     r"|^\s*(?:the\s+|some\s+)?numbers\b",
+    re.IGNORECASE)
+
+
+# --- gate.claimed_shipped vocabulary (a completed remote/external mutation claim) ---
+# Two deliberately CLOSED claim families. The action family binds a first-person subject to a
+# past/perfective shipping verb; the second alternative permits the conventional subject-less
+# status-report form only at a sentence/list-item boundary ("Pushed it to main.", "Merged #42.").
+# That boundary is the precision firewall: ordinary explanatory prose such as "the hook pushes
+# artifacts" and third-party narration cannot acquire an implied first-person subject merely by
+# containing a ship-shaped word. Present/base forms are absent, so "this deploys to a CDN" is
+# inert by construction.
+_SHIPPED_ACTION_CLAIM_RX = re.compile(
+    r"\bI(?:['’]ve|\s+have)?\s+(?:just\s+|now\s+|successfully\s+|already\s+)?"
+    r"(?:pushed|merged|published|deployed|shipped|released)\b"
+    r"|(?:^|(?<=[.!?\n]))[ \t]*(?:[-*]\s+)?"
+    r"(?:pushed|merged|published|deployed|shipped|released)\b",
+    re.IGNORECASE | re.MULTILINE)
+# State claims use present tense plus a CLOSED remote-result predicate. "Live" is anchored by
+# `now`/`already` because bare "it is live" is routinely descriptive (a fixture, connection, or
+# UI state), while "it's live now" is the high-confidence completion report this gate owns.
+# Past copulas are deliberately absent: "it was merged" is passive/third-party history. The
+# subject set likewise excludes arbitrary nouns, accepting the recall bound rather than turning
+# every technical use of "published"/"deployed" into a claim about the assistant's own action.
+_SHIPPED_STATE_CLAIM_RX = re.compile(
+    r"\b(?:it|this|that|the\s+(?:pr|pull\s+request|change|commit|package|release|"
+    r"deployment|site|app(?:lication)?|service))\s*"
+    r"(?:is|are|['’]s|['’]re)\s*"
+    r"(?:(?:now|already|successfully)\s+"
+    r"(?:merged|published|deployed|shipped|released|live)"
+    r"|live\s+now)\b",
+    re.IGNORECASE)
+# Bash evidence for this gate is intentionally narrower than canon's destructive classifier:
+# any real `git push` mutates a remote, not only a forced push. The bounded command span and the
+# `-n`/`--dry-run` veto exactly mirror _canonAtoms._DESTRUCTIVE_RX's hardened push alternative,
+# including the `(?!-)` boundary that keeps unrelated long options from masquerading as flags.
+_REMOTE_GIT_PUSH_CMD_RX = re.compile(
+    r"\bgit\s+push\b(?![^|;&\n]*(?:\s-n\b|--dry-run\b))",
     re.IGNORECASE)
 
 

--- a/makoto/substrate/_canonAtoms.py
+++ b/makoto/substrate/_canonAtoms.py
@@ -135,8 +135,8 @@ def _is_test_path(fp) -> bool:
 _DESTRUCTIVE_RX = re.compile(
     r"\brm\s+-\w*(?:rf|fr)\w*\b"
     r"|\bgit\s+reset\b(?=[^|;&\n]*--hard\b)"
-    r"|\bgit\s+clean\b(?=[^|;&\n]*(?:\s-\w*[dfx]\w*\b|--force\b))(?![^|;&\n]*(?:\s-\w*n\w*\b|--dry-run\b))"
-    r"|\bgit\s+push\b(?=[^|;&\n]*(?:\s-f\b|--force\b))(?![^|;&\n]*(?:\s-n\b|--dry-run\b))"
+    r"|\bgit\s+clean\b(?=[^|;&\n]*(?:\s-\w*[dfx]\w*\b|--force\b(?!-)))(?![^|;&\n]*(?:\s-\w*n\w*\b|--dry-run\b))"
+    r"|\bgit\s+push\b(?=[^|;&\n]*(?:\s-f\b|--force\b(?!-)))(?![^|;&\n]*(?:\s-n\b|--dry-run\b))"
     r"|\bgit\s+checkout\s+--\s+\.(?!\w)"
     r"|\bdrop\s+(?:table|database)\b"
     r"|\btruncate\s+table\b"
@@ -146,7 +146,7 @@ _DESTRUCTIVE_RX = re.compile(
 
 # ponytail: a bash bypass-flag denylist for "a check was disabled" -- not a general flag parser.
 _DISABLE_RX = re.compile(
-    r"--no-verify\b|--no-gpg-sign\b|--no-hooks?\b|--force\b|SKIP=\S|--skip-tests?\b",
+    r"--no-verify\b|--no-gpg-sign\b|--no-hooks?\b|--force\b(?!-)|SKIP=\S|--skip-tests?\b",
     re.IGNORECASE)
 
 # a test command combined with a failure-swallowing suffix.

--- a/makoto/substrate/_declared.py
+++ b/makoto/substrate/_declared.py
@@ -62,4 +62,7 @@ DECLARED_IDS: dict = {
     # The forward-looking sibling of gate.claimed_running: a first-person run-intent promise
     # ("I'll run the tests") left with no Bash evidence anywhere in history by the next turn.
     "gate.run_promised": "runIntentUnfulfilled",
+    # Immediate completed-remote-action sibling: a pushed/merged/live claim must be backed by a
+    # successful Bash git-push or an explicitly recognized remote-mutating tool call.
+    "gate.claimed_shipped": "claimedShippedAbsent",
 }

--- a/makoto/substrate/_primitives.py
+++ b/makoto/substrate/_primitives.py
@@ -15,6 +15,8 @@ byte-for-byte unchanged from the old `checks.py`.
 import os
 import re
 
+from makoto.core.lexicons import _PATH_EXT
+
 
 def normalize_path(p: str) -> str:
     """Case-folded, normalized, trailing-separator-stripped path for equality.
@@ -65,11 +67,6 @@ def subject_binds(commitment_location: str, result_key: str) -> bool:
 # arbitrary backtick content — those name no file and were the completion gate's measured
 # false-positive source (5.83% irreducible on the 1200-msg honest corpus). A backticked
 # path still matches: the path token is found wherever it sits, backticks or not.
-_PATH_EXT = (
-    r"py|pyi|md|rst|txt|toml|json|jsonl|ndjson|ya?ml|ini|cfg|conf|env|lock|"
-    r"sh|bash|zsh|fish|js|jsx|mjs|cjs|ts|tsx|rs|go|rb|java|kt|swift|c|h|hpp|cc|cpp|"
-    r"sql|html?|css|scss|sass|xml|csv|tsv|sock|proto|graphql|tf|svg|ipynb|dockerfile"
-)
 # Well-known extensionless files that ARE locations (so "created the Dockerfile" binds).
 _DOTLESS_FILES = r"Makefile|Dockerfile|README|LICENSE|CHANGELOG|Gemfile|Procfile|CODEOWNERS"
 _LOC_RX = re.compile(

--- a/makoto/substrate/_shared.py
+++ b/makoto/substrate/_shared.py
@@ -13,12 +13,13 @@ line (`from makoto.substrate._shared import ...`) serves every migrated gate mod
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass
 from typing import Callable, Optional, Sequence
 
 from makoto.checks import normalize_path
 from makoto.substrate._planNode import Plan
-from makoto.core.lexicons import _EMPTY_OK
+from makoto.core.lexicons import _EMPTY_OK, _PATH_EXT
 
 
 # ---- schemas (formerly stopchecks/_types.py) --------------------------------------------------
@@ -59,13 +60,14 @@ class GateContext:
     #   uses (never guessed via env-var fallback) -- same explicit-root discipline as audit.py.
     history_all_agents: Sequence = ()       # the SAME _select_recent time-windowed slice as
     #   `history`, but NOT narrowed by _history_for_agent's thread-boundary firewall -- every
-    #   agent's PostToolUse rows pooled. Exists ONLY for gate.claimed_running's Bash-launch
-    #   evidence (2026-07-23): a subagent dispatched to start/verify a process is real session
-    #   evidence the main thread's own running-claim must see. `history` narrows to the calling
+    #   agent's PostToolUse rows pooled. Exists for completed cross-agent evidence used by
+    #   gate.claimed_running and gate.claimed_shipped: a subagent dispatched to start/verify a
+    #   process or perform a remote mutation is real session evidence the main thread's own claim
+    #   must see. `history` narrows to the calling
     #   thread specifically to stop a DANGLING (in-flight) PreToolUse from synthesizing a FAILURE
     #   across threads -- a risk that does not apply to a completed PostToolUse Bash call. Every
     #   other gate should keep reading `history`; widen a gate onto this field only with the same
-    #   reasoning claimedRunningAbsent.py's module docstring documents.
+    #   completed-evidence reasoning these claim gates document.
 
     @property
     def roots(self):
@@ -80,6 +82,8 @@ class GateContext:
 
 # ---- shared discharge/suffix-match helpers (formerly stopchecks/_common.py) --------------------
 _BIND_BEFORE = 70
+_KNOWN_PATH_EXT_RX = re.compile(r"(?:" + _PATH_EXT + r")\Z", re.IGNORECASE)
+
 def _path_components(p: str):
     """Normalized path split into components, dropping empties and a leading '~' (a home
     reference that never appears in a touched key)."""
@@ -89,11 +93,26 @@ def _suffix_match(a_comps, b_comps) -> bool:
     relative commitment ('settings.json', '~/.claude/CLAUDE.md') discharges against an absolute
     write ('/repo/.claude/CLAUDE.md'). The match is at a path-SEPARATOR boundary, which preserves
     the fakeexcuse firewall: 'auth.py' is NOT a suffix of 'auth_helper.py' (components
-    ['auth_helper.py'] != ['auth.py']), only of '.../auth.py'."""
+    ['auth_helper.py'] != ['auth.py']), only of '.../auth.py'. A dotless final component may
+    also match that exact basename with one recognized extension (for informal references such
+    as 'CHANGELOG' to the real file 'CHANGELOG.md')."""
     if not a_comps or not b_comps:
         return False
     short, long = (a_comps, b_comps) if len(a_comps) <= len(b_comps) else (b_comps, a_comps)
-    return long[-len(short):] == short
+    if long[-len(short):] == short:
+        return True
+
+    # Component prefixes must still be an exact suffix; only the final component gets the
+    # deliberate dotless-file leniency. On equal-length one-component inputs, prefer the
+    # dotless side as the informal reference.
+    if len(a_comps) == len(b_comps) and "." not in b_comps[-1] and "." in a_comps[-1]:
+        short, long = b_comps, a_comps
+    if long[-len(short):-1] != short[:-1]:
+        return False
+    short_final, long_final = short[-1], long[-1]
+    if "." in short_final or not long_final.startswith(short_final + "."):
+        return False
+    return bool(_KNOWN_PATH_EXT_RX.fullmatch(long_final[len(short_final) + 1:]))
 def _safe_size(fs_size, location):
     """fs_size(location) -> int|None, swallowing errors. None means 'size unknown' (fail-open)."""
     if fs_size is None:


### PR DESCRIPTION
## Summary

Public sync of three dev fixes (`Clear-Sights/makoto-dev#71`):

- **`--force-with-lease`/`--force-if-includes` false positive** in `_DESTRUCTIVE_RX`/`_DISABLE_RX`: a bare `--force\b` word-boundary check matched inside git's own *safe* force-push alternatives (a hyphen is a non-word character, so the boundary fires right after "force" regardless of what follows). Fixed with `--force\b(?!-)`.

- **`_suffix_match` false positive**: `gate.completion` false-blocked a true claim that referred to a well-known file by its bare, extensionless name (e.g. "I updated the CHANGELOG" against a real `CHANGELOG.md` touch), since `_suffix_match` required exact final-path-component equality. Now also accepts an extensionless short side against a long side whose final component is `<short>.<recognized-extension>`; the `auth.py` vs `auth_helper.py` firewall is unaffected.

- **New gate: `gate.claimed_shipped`** — sibling to `gate.claimed_running`/`gate.run_promised`, for completed REMOTE mutations instead of local process liveness. Fires on "I merged the PR"/"pushed it to main"/"it's live now" with no successful remote-mutating tool call anywhere in the session's recorded history. Evidence is a non-dry-run `git push` over Bash or a successful closed-set GitHub MCP mutation (`merge_pull_request` requiring `merged: true`, `push_files`).

Also corrects a gap from the previous sync (#12): its CHANGELOG entry carried dev's gate ordinals (17th/18th) verbatim instead of this repo's own numbering (which runs 2 behind dev's, since two dev-only advisory checks never ship here), and its README gate-count summary was never bumped at all. Both are fixed here alongside this round's additions: **17 end-of-turn gates** (was 14), **19 live Stop-tier checks total** (was 16).

## Test plan

- [x] Full diff reviewed against the dev-side change (`makoto-dev#71`, already merged and CI-verified there)
- [x] Public's own smoke suite run: 6 passed, 0 failed
- [x] Swept README/CHANGELOG/plugin.json for every stale gate-count reference (including the pre-existing gap from the last sync), left dated historical CHANGELOG entries untouched by design

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hj6bZxfByUgqn75L2btuLT)_