### PR TITLE
Ship the whole runtime in the built wheel, not just makoto/*.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to makoto. Versions follow the live check inventory
 
 ## [Unreleased]
 
+### Fixed
+- **A built wheel/sdist now ships the whole runtime, not just `makoto/*.py`.** `pyproject.toml`
+  declared `packages = ["makoto"]`, so every subpackage the dispatcher imports at fire time
+  (`makoto.core`, `.checks`, `.record`, `.session`, `.substrate`, `.verdict`) was dropped from the
+  distribution: a `pip install` of the built artifact produced a runtime that died on
+  `ModuleNotFoundError: No module named 'makoto.core'` at first invocation. Packages are now
+  discovered (`[tool.setuptools.packages.find] include = ["makoto*"]`), and the non-`.py` files the
+  runtime reads at fire time ship with them — `_dispatch_shim.sh` (executable bit preserved) plus
+  the packaged `docs/CITATIONS.md` and `docs/MAKOTO-CONVENTIONS.md`. The stale `config/*.toml`
+  package-data entry is dropped (`config/patterns.toml` was deleted 2026-07-08); `docs/*` is no
+  longer excluded, since `makoto/docs/` is runtime data rather than repo documentation. The
+  editable non-plugin install (`pip install -e`) and the plugin install path were never affected.
+
 ## [2.2.0] — 2026-07-26
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,19 @@ dependencies = []
 Homepage = "https://github.com/skill-labV2/makoto"
 
 [tool.setuptools]
-package-dir = {"makoto" = "makoto"}
-packages = ["makoto"]
 include-package-data = true
 
+# every subpackage ships, not just the top-level one: `makoto._dispatch` imports
+# makoto.core / .checks / .record / .session / .substrate / .verdict at hook fire
+# time, so a wheel carrying only makoto/*.py installs a runtime that cannot start.
+[tool.setuptools.packages.find]
+include = ["makoto*"]
+namespaces = false
+
+# non-.py files the runtime reads at fire time: the hook shim settings.json/hooks.json
+# point at, the packaged canonical citation list, and the just-in-time conventions doc.
 [tool.setuptools.package-data]
-makoto = ["config/*.toml"]
+makoto = ["_dispatch_shim.sh", "docs/*.md"]
 
 [tool.setuptools.exclude-package-data]
-makoto = ["tests/*", "docs/*", "*.bak"]
+makoto = ["*.bak"]


### PR DESCRIPTION
## What

`pyproject.toml` declared `packages = ["makoto"]`, so a built wheel/sdist carried only the six top-level modules (`__init__`, `__main__`, `_dispatch`, `_dispatch_configchange`, `events`, `install`). Every subpackage `_dispatch` imports at hook fire time — `makoto.core`, `.checks`, `.record`, `.session`, `.substrate`, `.verdict` — was dropped from the distribution.

Found while building a distributable runtime bundle: `pip install` of the built wheel produces a runtime that dies before loading a single pattern.

```
$ python -m makoto status
  File ".../site-packages/makoto/__main__.py", line 25, in <module>
    from makoto.core.schema import load_prechecks
ModuleNotFoundError: No module named 'makoto.core'
```

## Changes

- Packages are discovered instead of hand-listed: `[tool.setuptools.packages.find] include = ["makoto*"]`, `namespaces = false`. The wheel goes from 11 entries to 88, covering all seven subpackages.
- Package data now covers the non-`.py` files the runtime reads at fire time: `_dispatch_shim.sh` (the path `hooks/hooks.json` and manual `settings.json` wiring both point at) and `docs/*.md` (`docs/CITATIONS.md` for `content.phantom_citation`'s canonical list, `docs/MAKOTO-CONVENTIONS.md` for the just-in-time conventions delivery in `_dispatch.py:571`).
- Drops the stale `config/*.toml` package-data row — `config/patterns.toml` was deleted 2026-07-08 (`makoto/core/schema.py:88`) and no `makoto/config/` directory exists.
- Stops excluding `docs/*`: `makoto/docs/` is runtime data, not repo documentation. The `tests/*` exclusion also goes, since `include = ["makoto*"]` already keeps `tests` out of the wheel.
- Removes `package-dir = {"makoto" = "makoto"}`, redundant under a flat layout with `find`.

Only the built-artifact install path was affected. `pip install -e` and the plugin install (which loads from the plugin root, not site-packages) both worked before and are unchanged.

## Verification

Fresh venv, install the built wheel, no repo on the path:

- `python -m makoto status` → `"patterns_count": 15`, `"patterns_disabled": []`
- `python -m makoto pattern list` renders the live catalog
- a live `PreToolUse` `Write` dispatch on clean content exits 0
- `makoto/_dispatch_shim.sh` keeps mode `0o100755` in the wheel and installs as `-rwxr-xr-x`
- same three checks pass against an install of the built sdist

Through the plugin bundle (`CLAUDE_PLUGIN_ROOT` set to an unpacked plugin root), a `Bash` call of `python -m pytest -q || true` returns the expected `permissionDecision: "deny"` for `content.verifier_exit_masking`, with the diagnostic resolving the packaged `makoto/docs/MAKOTO-CONVENTIONS.md` path — confirming the package-data files land where the runtime looks for them.

Full suite: **1668 passed, 6 skipped, 1 xfailed**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2yFCeekgE8ghoxyu2YFkn)_