### PR TITLE
Fix stale repo-URL strings; add release manifest-version guard

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,9 +2,9 @@
   "name": "makoto",
   "description": "Holds Claude Code to its word — every claim checked against the agent's own logged record; faked checks blocked, not warned (four narrow advisory self-checks excepted). Two-tier catalog (15 pre-checks, 19 Stop gates), each shipped at measured zero false positives.",
   "version": "2.2.0",
-  "author": {"name": "skill-labV2"},
-  "homepage": "https://github.com/skill-labV2/Makoto",
-  "repository": "https://github.com/skill-labV2/Makoto",
+  "author": {"name": "Clear-Sights"},
+  "homepage": "https://github.com/Clear-Sights/Makoto",
+  "repository": "https://github.com/Clear-Sights/Makoto",
   "license": "Apache-2.0",
   "keywords": ["claude-code", "guardrails", "integrity", "hooks", "makoto"]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (e.g. 2.0.0), must match a CHANGELOG.md ## [X.Y.Z] heading'
+        description: 'Version to release (e.g. 2.2.0); must match both manifests and CHANGELOG.md'
         required: true
-        default: '2.0.0'
 
 permissions:
   contents: write
@@ -14,14 +13,25 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ inputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Validate version against package manifests
+        run: |
+          PACKAGE_VERSION="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          PLUGIN_VERSION="$(python -c 'import json; print(json.load(open(".claude-plugin/plugin.json"))["version"])')"
+          if [ "$RELEASE_VERSION" != "$PACKAGE_VERSION" ] || [ "$RELEASE_VERSION" != "$PLUGIN_VERSION" ]; then
+            echo "Requested $RELEASE_VERSION, pyproject.toml has $PACKAGE_VERSION, plugin.json has $PLUGIN_VERSION" >&2
+            exit 1
+          fi
+
       - name: Extract release notes from CHANGELOG.md
         run: |
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION="$RELEASE_VERSION"
           awk -v ver="$VERSION" '
             $0 ~ ("^## \\[" ver "\\]") {flag=1; next}
             flag && /^## \[/ {flag=0}
@@ -38,7 +48,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION="$RELEASE_VERSION"
           TAG="v$VERSION"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "2.2.0"
 description = "Integrity hook for Claude Code — holds the agent's claims against its own logged deeds and blocks faked checks; every check ships at measured zero false positives"
 readme = "README.md"
 requires-python = ">=3.11"
-authors = [{name = "skill-labV2"}]
+authors = [{name = "Clear-Sights"}]
 license = {text = "Apache-2.0"}
 keywords = ["claude-code", "guardrails", "integrity", "hooks"]
 classifiers = [
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = []
 
 [project.urls]
-Homepage = "https://github.com/skill-labV2/makoto"
+Homepage = "https://github.com/Clear-Sights/Makoto"
 
 [tool.setuptools]
 package-dir = {"makoto" = "makoto"}


### PR DESCRIPTION
## Summary

`.claude-plugin/plugin.json` and `pyproject.toml` still referenced the old `skill-labV2` org, even though README already said `Clear-Sights`. Recovered from stale branch `claude/w11-rescue-makoto` — self-labeled "unreviewed, suite not verified" as a whole, but this specific fix is self-contained and verified here.

Also ports that branch's `.github/workflows/release.yml` addition: the manual-release workflow now validates the requested version against both `pyproject.toml`'s and `plugin.json`'s own declared version before tagging, failing loudly on mismatch.

## Verification

Both manifests currently agree (`2.2.0`), so the new guard would pass unmodified at today's state — confirmed by direct read.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtJRGMHKr3C27EwYZdRXTd)_