### PR TITLE
Port 6 stranded github-issue fixes onto the restructured layout

### DIFF
--- a/makoto/checks/canonTimeoutRecur.py
+++ b/makoto/checks/canonTimeoutRecur.py
@@ -82,6 +82,7 @@ import json
 from typing import Iterable, List
 
 from makoto.vocab import Finding
+from makoto.kit import decode_history_event
 
 # A Call is one paired tool event in protocol form: {"name": tool_name, "input": tool_input,
 # "result": tool_response} — tool_input/tool_response are kept as full DICTS (not the flattened
@@ -225,32 +226,40 @@ def _canon_input(inp) -> str:
         return repr(inp)
 
 
+def _pairing_input(inp) -> str:
+    """`_canon_input` with leading-dunder keys dropped — the identity used ONLY to pair a
+    PostToolUse back to its own PreToolUse, never to judge a verdict.
+
+    A harness may add bookkeeping keys to `tool_input` BETWEEN a call's Pre and its Post
+    (observed live on the `Artifact` tool: a 3-key Pre, then a 6-key Post carrying
+    `__artifactPlanConsentAsk`, `__artifactPlanConsentDecisionCaps`, `__artifactPublishTarget`).
+    Pairing on the FULL canonical input therefore never matched those two rows, so every such
+    call left a dangling Pre and synthesized a phantom mid-turn-abandonment failure — for a call
+    that in fact succeeded. Two of those back-to-back read as an all-error run of length 2 and
+    false-fired `canon.recur` STUCK on a retry that had actually succeeded (#17).
+
+    A leading `__` is a transport/bookkeeping convention, never call semantics, so dropping it
+    cannot collapse two genuinely distinct calls. This RELAXES PAIRING ONLY: `recur_stuck`,
+    `identical_retry` and every other primitive keep keying on the full `_canon_input`, so the
+    verdict's identity test is untouched and no true positive is widened away."""
+    if isinstance(inp, dict):
+        return _canon_input({k: v for k, v in inp.items() if not str(k).startswith("__")})
+    return _canon_input(inp)
+
+
 # ---- the history -> Call adapter (protocol-field decode; fail-open per row) -------------------
 def _decode_row(row):
     """Decode ONE history row into (etype, name, input_dict, result_dict), or None to skip.
-    Accepts BOTH live events-table tuples (id, ts, event_type, cwd, raw_payload_json) and dict
-    rows with a 'payload' key (corpus/replay-style callers) — the same row union
-    makoto.kit.iter_tool_events decodes. A malformed row is skipped (fail-open). Keeps both
-    PreToolUse and PostToolUse rows (unlike the pre-FD14-A cut which dropped Pre at decode time)
-    so `calls_from_history` can pair them and detect a dangling Pre."""
-    wrapper_etype = None
-    if isinstance(row, (tuple, list)) and len(row) > 4:
-        raw = row[4]
-        wrapper_etype = row[2] if len(row) > 2 else None
-    elif hasattr(row, "get"):
-        raw = row.get("payload")
-        wrapper_etype = row.get("event_type")
-    else:
-        raw = None
-    if not raw:
+
+    Raw decode + wrapper-event-type fallback is `kit.decode_history_event` -- the canonical
+    step, shared with `identicalRetryInterdiction._most_recent_completed_bash_call`. This
+    function keeps only what's specific to canon's OWN adapter shape: the tuple conversion, and
+    keeping both PreToolUse and PostToolUse rows (unlike the pre-FD14-A cut which dropped Pre at
+    decode time) so `calls_from_history` can pair them and detect a dangling Pre."""
+    ev = decode_history_event(row)
+    if ev is None:
         return None
-    try:
-        ev = raw if isinstance(raw, dict) else json.loads(raw)
-    except Exception:
-        return None
-    if not isinstance(ev, dict):
-        return None
-    etype = ev.get("hook_event_name") or wrapper_etype
+    etype = ev.get("hook_event_name")
     name = ev.get("tool_name", "") or ""
     if etype not in ("PreToolUse", "PostToolUse") or not name:
         return None
@@ -265,9 +274,12 @@ def _decode_row(row):
 def calls_from_history(history) -> list:
     """Decode GateContext.history rows into agnostic Call dicts carrying the protocol fields the
     terminals read. A completed call contributes a PreToolUse AND a PostToolUse row; each Post is
-    PAIRED to the nearest preceding still-unpaired identical (tool name + canonicalized input)
-    Pre, and only the Post becomes a Call (the Pre is dropped) — so `recur_stuck`'s consecutive-run
+    PAIRED to the nearest preceding still-unpaired identical (tool name + `_pairing_input`) Pre,
+    and only the Post becomes a Call (the Pre is dropped) — so `recur_stuck`'s consecutive-run
     judgment is not corrupted by spurious result-less Calls (module docstring ADAPTATION NOTE).
+    Pairing uses `_pairing_input` (dunder-insensitive), NOT the full `_canon_input` the verdicts
+    key on: a harness may inject bookkeeping keys between a call's Pre and its Post, and pairing
+    on those synthesized a phantom failure for a call that succeeded. See `_pairing_input`.
 
     FD14-A, narrowed to MID-TURN ABANDONMENT ONLY (see module docstring): a leftover unpaired
     PreToolUse (a dangling Pre) synthesizes a FAILURE Call — result `{"interrupted": True, ...}` —
@@ -283,12 +295,12 @@ def calls_from_history(history) -> list:
     for j, (etype, name, ti, _tr) in enumerate(decoded):
         if etype != "PostToolUse":
             continue
-        key = (name, _canon_input(ti))
+        key = (name, _pairing_input(ti))
         for i in range(j - 1, -1, -1):
             if i in paired_pre:
                 continue
             et2, n2, ti2, _ = decoded[i]
-            if et2 == "PreToolUse" and (n2, _canon_input(ti2)) == key:
+            if et2 == "PreToolUse" and (n2, _pairing_input(ti2)) == key:
                 paired_pre.add(i)
                 break
 
@@ -329,10 +341,8 @@ CANON_SEQ_PRIMITIVES: dict = {
         # gate.canon_fingerprints uses (makoto.state.ledger), not a third prose-only path.
         "A call errored (timeout / interrupted / error code) and the turn closed without "
         "resolving it. Re-run it (or the equivalent action) to a real successful result before "
-        "closing, OR if the error is a genuinely unresolvable, already-reviewed block, say "
-        "exactly `makoto release.operator timeout: <reason>` in a real (non-tool, non-quoted) reply -- "
-        "text alone cannot discharge this any other way; the detector reads only whether the "
-        "LAST call in the turn succeeded.",
+        "closing. Text alone cannot discharge this any other way; the detector reads only "
+        "whether the LAST call in the turn succeeded.",
     ),
     "recur": (
         recur_stuck,
@@ -345,14 +355,35 @@ CANON_SEQ_PRIMITIVES: dict = {
 }
 
 
+def _release_clause(cid: str) -> str:
+    """The `release.operator` affordance sentence for ONE primitive, generated from its id.
+
+    `canon_gate` offers the ackblock discharge to EVERY fired primitive — the loop calls
+    `find_ack_block(cid, ...)` for whatever fired, not just `timeout`. But the affordance was
+    spelled out only in `timeout`'s hand-written hint, so a fired `canon.recur` told the agent
+    to "change the input" and nothing else. When the finding was a false positive the agent had
+    no reachable discharge named anywhere, and every subsequent Stop re-fired the same block
+    until the rows aged out of the recency window — a mechanism that existed but was invisible
+    reads exactly like a mechanism that is missing.
+
+    Generated per-id rather than written per-entry so a primitive cannot be added to
+    CANON_SEQ_PRIMITIVES without carrying the discharge it is already wired to honor —
+    the affordance is structural, not prose that the next author must remember to copy."""
+    return (f" If this finding is a genuinely unresolvable, already-reviewed block — or a "
+            f"misfire you have verified — say exactly `makoto release.operator {cid}: <reason>` "
+            f"in a real (non-tool, non-quoted) reply; that is the only discharge other than "
+            f"changing what the detector actually reads.")
+
+
 def fired_primitives(history) -> Iterable:
     """Yield (canon_id, stop_text, retry_hint) for every installed primitive that fires on the
     session's call stream. Pure: no makoto import, no I/O beyond decoding the passed-in history
-    rows."""
+    rows. Every yielded hint carries its own `release.operator` clause (`_release_clause`) —
+    `canon_gate` offers that discharge to every primitive, so every hint must name it."""
     calls = calls_from_history(history)
     for cid, (seq_pred, stop_text, retry_hint) in CANON_SEQ_PRIMITIVES.items():
         if seq_pred(calls):
-            yield (cid, stop_text, retry_hint)
+            yield (cid, stop_text, retry_hint + _release_clause(cid))
 
 
 # =============================================================================================

--- a/makoto/checks/claimedShippedAbsent.py
+++ b/makoto/checks/claimedShippedAbsent.py
@@ -11,7 +11,7 @@ from makoto.vocab import (
 )
 from makoto.substrate.claims import _code_spans
 from makoto.kit import decode_history_row
-from makoto.kit import _PUSH_BRANCH_RX
+from makoto.kit import extract_pushed_branch
 from makoto.core._shell import _command_pushes_git
 
 
@@ -39,10 +39,11 @@ def pushed_tip_matches_remote(text, cwd) -> PushTipResult:
     """
     if not text or not cwd:
         return PushTipResult(PushTipStatus.NOT_EVALUABLE, detail="missing claim text or cwd")
-    match = _PUSH_BRANCH_RX.search(text)
-    if not match:
+    # Pushed-branch extraction: kit.extract_pushed_branch (dedup: was a byte-identical
+    # regex-search + rstrip pair with kit.pushed_ref_matches_world's own call site).
+    branch = extract_pushed_branch(text)
+    if branch is None:
         return PushTipResult(PushTipStatus.NOT_EVALUABLE, detail="push claim names no branch")
-    branch = match.group(1).rstrip("`'\",:;.")
     if not branch:
         return PushTipResult(PushTipStatus.NOT_EVALUABLE, detail="empty branch")
     try:

--- a/makoto/checks/deadPureStatement.py
+++ b/makoto/checks/deadPureStatement.py
@@ -11,6 +11,7 @@ imports beyond stdlib `ast`.
 from __future__ import annotations
 import ast
 
+from makoto.vocab import _MAKOTO_ALLOW_RX
 from makoto.substrate._stdlib_ast_helpers import iter_touched_python_sources
 from makoto.vocab import Finding
 
@@ -391,8 +392,13 @@ def analyze_file(src: str, path: str) -> list:
     except SyntaxError:
         return []                                           # fail-open: skip unparseable files
     lines = src.splitlines()
-    def _allowed(lineno):                                   # on-the-record override (makoto convention)
-        return 1 <= lineno <= len(lines) and "makoto-allow" in lines[lineno - 1].lower()
+    def _allowed(lineno):
+        # On-the-record override via the ONE canonical marker predicate (§7.5b). Was a bare
+        # `"makoto-allow" in line` substring test, which exempted a reasonless `# makoto-allow`
+        # that `makoto_allowed`/`_MAKOTO_ALLOW_RX` rejects — and that this check's own finding
+        # text already tells the author to write with a reason. An exemption marker asserts an
+        # audit trail; accepting one without a rationale accepts the assertion unmeasured.
+        return 1 <= lineno <= len(lines) and _MAKOTO_ALLOW_RX.search(lines[lineno - 1]) is not None
     out = []
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):

--- a/makoto/checks/hollowTest.py
+++ b/makoto/checks/hollowTest.py
@@ -40,6 +40,7 @@ layout, only the file boundary moved.
 from __future__ import annotations
 import ast
 
+from makoto.vocab import _MAKOTO_ALLOW_RX
 from makoto.substrate._stdlib_ast_helpers import _callee_chain, iter_touched_python_sources
 from makoto.vocab import Finding
 
@@ -431,8 +432,20 @@ _KIND_MESSAGE = {
 }
 
 
-def _allowed(lineno, lines) -> bool:                          # on-the-record override (makoto convention)
-    return 1 <= lineno <= len(lines) and "makoto-allow" in lines[lineno - 1].lower()
+def _allowed(lineno, lines) -> bool:
+    """On-the-record override (makoto convention), via the ONE canonical marker predicate.
+
+    This was a bare `"makoto-allow" in line` substring test, which exempted a reasonless
+    `# makoto-allow` — while `makoto_allowed`/`_MAKOTO_ALLOW_RX` (§7.5b, the predicate every
+    factory-built content check uses) requires a colon and a non-empty reason, and while this
+    module's OWN finding text tells the author to write `# makoto-allow: <reason>`. The escape
+    hatch was strictly laxer than the rule makoto installs into the user's CLAUDE.md
+    ("an on-the-record, auditable rationale, never a disguise"), so an exemption marker
+    asserting an audit trail was accepted without one — the flag-decay bug in miniature, on
+    the security-relevant path. One concept, one predicate: the marker means the same thing
+    everywhere it is honored. (`makoto.vocab` is already on this engine's isolation
+    allowlist — see tests/test_detector_engines_are_stdlib_isolated.py.)"""
+    return 1 <= lineno <= len(lines) and _MAKOTO_ALLOW_RX.search(lines[lineno - 1]) is not None
 
 
 def _run(ctx) -> list:

--- a/makoto/checks/identicalRetryInterdiction.py
+++ b/makoto/checks/identicalRetryInterdiction.py
@@ -25,7 +25,7 @@ import json
 from typing import Optional
 
 from makoto.kit import classify_failure
-from makoto.kit import bash_output_text
+from makoto.kit import bash_output_text, decode_history_event
 from makoto.vocab import Finding
 from makoto.registry import Check
 
@@ -37,33 +37,21 @@ def _canon_input(ti: dict) -> str:
         return repr(ti)
 
 
-def _decode_row(row) -> Optional[dict]:
-    """One history row -> its decoded hook payload dict, or None. Accepts both the live
-    events-table tuple shape (id, ts, event_type, cwd, raw_payload_json) and a dict with a
-    'payload' key (corpus/replay callers) -- the same row union makoto.kit.iter_tool_events
-    decodes, kept local (not imported) so this predicate has no cross-module coupling at all."""
-    if isinstance(row, (tuple, list)) and len(row) > 4:
-        raw = row[4]
-    elif hasattr(row, "get"):
-        raw = row.get("payload")
-    else:
-        return None
-    if not raw:
-        return None
-    try:
-        ev = raw if isinstance(raw, dict) else json.loads(raw)
-    except Exception:
-        return None
-    return ev if isinstance(ev, dict) else None
-
-
 def _most_recent_completed_bash_call(history) -> Optional[tuple]:
     """(tool_input, result_text) of the SINGLE MOST RECENT history row, iff that row is a
-    PostToolUse Bash call -- else None (a different tool, a Pre row, or nothing at all)."""
+    PostToolUse Bash call -- else None (a different tool, a Pre row, or nothing at all).
+
+    Decoding is `kit.decode_history_event` -- the canonical row-decode-plus-wrapper-fallback
+    step, shared with `canonTimeoutRecur._decode_row`. A hand-rolled local copy of this logic
+    used to live here, justified as keeping "zero cross-module coupling" with a module that
+    ALREADY imports `bash_output_text` from the same kit two lines above -- that claim was
+    already false when it was written, and the drift it enabled was a real bug: this predicate
+    was blind to rows whose event type lives only on the WRAPPER column, rows its sibling gate
+    (canon.timeout/canon.recur) acts on, from the same table, for the same concept."""
     rows = list(history or ())
     if not rows:
         return None
-    ev = _decode_row(rows[-1])
+    ev = decode_history_event(rows[-1])
     if ev is None or ev.get("hook_event_name") != "PostToolUse" or ev.get("tool_name") != "Bash":
         return None
     ti = ev.get("tool_input", {}) or {}

--- a/makoto/checks/selfMuteGuard.py
+++ b/makoto/checks/selfMuteGuard.py
@@ -24,6 +24,7 @@ from typing import Optional
 from makoto.kit import scan_target_content
 from makoto.vocab import Finding
 from makoto.registry import Check
+from makoto.substrate.wiring import MAKOTO_INVOCATION_RX as _MAKOTO_CMD_RX
 
 # The file makoto wires into: ~/.claude/settings.json (or settings.local.json).
 _SETTINGS_RX = re.compile(r"\.claude/settings(?:\.local)?\.json$")
@@ -47,11 +48,18 @@ _MANAGED_RX = re.compile(r"_makoto_managed")
 # — disables EVERY hook, makoto included, via a key the env/un-wire branches never inspect.
 # Truthy-only (": true") is the FP guard: setting it false RE-ENABLES hooks and must never fire.
 _GLOBAL_DISABLE_RX = re.compile(r'"disableAllHooks"\s*:\s*true\b', re.IGNORECASE)
-# makoto's own hook-command invocation token (the dispatch script / state dir it installs,
-# install.py:76). If the REMOVED text carried it but the introduced text no longer does, the
-# makoto command was gutted to a no-op while the wiring/seal may remain — a self-mute the
-# un-wire branch (which keys on `_makoto_managed`) misses because the marker stays in both.
-_MAKOTO_CMD_RX = re.compile(r"makoto_state|dispatch\.sh")
+# makoto's own hook-command invocation tokens. Imported from `wiring.MAKOTO_INVOCATION_RX`
+# (aliased `_MAKOTO_CMD_RX` above) rather than a local copy: this guard used to hand-roll its
+# own pattern (`makoto_state|dispatch\.sh`, bare unanchored substrings), and it drifted from the
+# one `install`/`entry_dispatches_to_makoto` actually recognize -- missing the plugin-manifest
+# shim form (`${CLAUDE_PLUGIN_ROOT}/makoto/_dispatch_shim.sh`, so gutting a plugin-packaged
+# install was invisible to this guard) while ALSO over-matching an unrelated
+# `/usr/local/bin/dispatch.sh` (false-BLOCKing an edit to a hook makoto does not own -- this
+# check's own module docstring asserts a zero-FP admissibility bar). One invocation-token set,
+# one owner: `substrate.wiring`, the stdlib-only module the pipeline-order firewall already
+# allows this check to import. If the REMOVED text carried it but the introduced text no longer
+# does, the makoto command was gutted to a no-op while the wiring/seal may remain — a self-mute
+# the un-wire branch (which keys on `_makoto_managed`) misses because the marker stays in both.
 
 
 def _removed_text(tool_input: dict) -> str:

--- a/makoto/checks/silentlyDroppedCommitment.py
+++ b/makoto/checks/silentlyDroppedCommitment.py
@@ -118,7 +118,19 @@ def _drop_touched(path, touched_keys, empty_keys) -> bool:
 def _drop_discharged(kind, info, raw, path, *, touched_keys, empty_keys, fs_exists, fs_size, fs_read) -> bool:
     """At turn-end, is the forward claim satisfied on `path`? Content-deep where the kind
     needs it (symbol/count read the file via fs_read); artifact/line discharge on a non-empty
-    touch or a non-empty file. Mirrors completion_gate's content-deep discharge."""
+    touch or a non-empty file.
+
+    Follows completion_gate's content-deep discharge, with a DELIBERATE and bounded difference,
+    stated here because the docstring used to claim it "mirrors" the ledger's `_discharged` and
+    does not: `_discharged` applies the `_EMPTY_OK` conventional-empty carve-out globally, while
+    this applies `conventional` on the `named_artifact` and `line_range` branches only.
+    `named_symbol` and `count` ask a question emptiness cannot answer -- a claim to add 2 exports
+    to `pkg/__init__.py` is not discharged by that file being empty, however conventional its
+    emptiness is in general. So on a zero-byte conventional file with a count/symbol claim,
+    `gate.completion` discharges and `gate.dropped` fires, on identical ledger state. That is the
+    intended reading of two different questions, not an oversight -- but it IS a divergence, and
+    an unstated divergence behind a claim of mirroring is how the next reader "fixes" one of them
+    into agreement and silently deletes a gate."""
     content = fs_read(path) if (fs_read is not None and path) else None
     touched = _drop_touched(path, touched_keys, empty_keys)
     exists = bool(fs_exists and path and fs_exists(path))

--- a/makoto/configchange.py
+++ b/makoto/configchange.py
@@ -192,19 +192,25 @@ def _make_fs_read(payload: dict):
     return fs_read
 
 
-def _record_advisory_fire(payload: dict, verdict) -> None:
-    """Loud stderr note (mirrors `dispatch._dispatch_fact`'s style) + a best-effort AuditRow
-    append. Wrapped so an observability failure can never break the hook — same fail-open
-    philosophy as `dispatch._record_exemption_sink`."""
-    print(f"makoto.configchange: ADVISORY {verdict.reason}", file=sys.stderr)
+def _record_fire(payload: dict, verdict, *, pattern_id: str, level: str, message: str) -> None:
+    """Shared AuditRow-construction shape for both the advisory and blocking tiers -- was two
+    12-line byte-identical bodies differing only in pattern_id/level/message. `exit_code` and
+    `retry_hint_emitted` are DERIVED here from the finding, the same rule
+    `dispatch._record_audit` uses (error-level finding -> exit 2), rather than passed in as
+    literals by each caller. The block tier used to hardcode `exit_code=0` on the very path that
+    PRINTS `{"decision": "block"}`, so every block fire read as a clean exit to anything mining
+    the audit trail: the ledger misreporting the one event it exists to record. Two callers
+    independently supplying a value that is actually a function of `level` is exactly the shape
+    that let it rot; deriving it once, here, makes that drift structurally impossible rather
+    than merely fixed for today."""
     try:
         state_dir = _state_dir()
         finding = {
-            "pattern_id": "gate.configchange_advisory",
+            "pattern_id": pattern_id,
             "file": verdict.config_path,
             "line": 0,
-            "level": "advisory",
-            "message": verdict.reason,
+            "level": level,
+            "message": message,
             "retry_hint": "",
             "snippet": "",
             "source_event_id": 0,
@@ -215,8 +221,8 @@ def _record_advisory_fire(payload: dict, verdict) -> None:
             hook_kind="ConfigChange",
             session_id=payload.get("session_id", ""),
             project_root=payload.get("cwd") or os.getcwd(),
-            pattern_fires=["gate.configchange_advisory"],
-            exit_code=0,
+            pattern_fires=[pattern_id],
+            exit_code=2 if finding["level"] == "error" else 0,
             retry_hint_emitted=bool(finding["retry_hint"]),
             findings=[finding],
             tool_name="",  # ConfigChange is not tool-scoped
@@ -226,36 +232,20 @@ def _record_advisory_fire(payload: dict, verdict) -> None:
         pass  # observability must never break the hook
 
 
+def _record_advisory_fire(payload: dict, verdict) -> None:
+    """Loud stderr note (mirrors `dispatch._dispatch_fact`'s style) + a best-effort AuditRow
+    append. Wrapped so an observability failure can never break the hook — same fail-open
+    philosophy as `dispatch._record_exemption_sink`."""
+    print(f"makoto.configchange: ADVISORY {verdict.reason}", file=sys.stderr)
+    _record_fire(payload, verdict, pattern_id="gate.configchange_advisory",
+                 level="advisory", message=verdict.reason)
+
+
 def _record_block_fire(payload: dict, verdict, reason: str) -> None:
     """Same shape as `_record_advisory_fire`, level="error" -- the blocking tier's own audit
     trail, distinct pattern_id so audit-mining can tell the two tiers apart."""
-    try:
-        state_dir = _state_dir()
-        finding = {
-            "pattern_id": "gate.configchange_transition",
-            "file": verdict.config_path,
-            "line": 0,
-            "level": "error",
-            "message": reason,
-            "retry_hint": "",
-            "snippet": "",
-            "source_event_id": 0,
-        }
-        row = AuditRow(
-            ts=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-            event="live.config_change",
-            hook_kind="ConfigChange",
-            session_id=payload.get("session_id", ""),
-            project_root=payload.get("cwd") or os.getcwd(),
-            pattern_fires=["gate.configchange_transition"],
-            exit_code=0,
-            retry_hint_emitted=False,
-            findings=[finding],
-            tool_name="",
-        )
-        append_row(state_dir, row)
-    except Exception:
-        pass  # observability must never break the hook
+    _record_fire(payload, verdict, pattern_id="gate.configchange_transition",
+                 level="error", message=reason)
 
 
 # ---- D5 blocking tier (owner-authorized, 2026-07-08): manifest + transition detection ----------

--- a/makoto/core/hostdialect.py
+++ b/makoto/core/hostdialect.py
@@ -1,0 +1,178 @@
+"""makoto.core.hostdialect -- the host-dialect boundary: one hop from a host's spelling to the protocol.
+
+ONE domain: a hook envelope arrives from SOME host, and every reader downstream of
+`dispatch.main()` -- routing, gates, history, audit -- must see the SAME protocol regardless of
+which host sent it. Consumed by `dispatch.main()` alone, at the top, immediately after the
+payload parses and before anything routes on it. Stdlib-only, no makoto-internal imports: safe
+for anything to depend on.
+
+WHY THIS MODULE EXISTS (#19)
+`dispatch.main()` routes on an exact-match `HANDLERS` lookup keyed on Claude Code's PascalCase
+event names. Cursor loads Claude-Code-compatible hook wiring (including a third-party plugin's
+`hooks/hooks.json`) but delivers the event name in camelCase: `preToolUse`, not `PreToolUse`.
+Under the wildcard-law routing a `postToolUse` therefore ran the WRONG handler
+(`_evaluate_and_gate` instead of `_accumulate`: no ledger row, no plan advance), the Pre-tier
+predicates that key on `hook_event_name == "PreToolUse"` silently no-opped, and the persisted
+events-table row carried the host's own spelling -- leaving every history decoder that keys on
+the protocol names (`canon.timeout`/`canon.recur`, `gate.identical_retry`, the claim-graph Bash
+evidence path) blind for the rest of the session. A check that reads nothing reports no finding,
+and nothing reports that it read nothing.
+
+WHAT IS DELIBERATELY *NOT* RELAXED
+The genuinely unevaluable envelopes -- non-JSON stdin, non-object payload -- keep failing exactly
+as before (loud-allow / fail-closed respectively; see `dispatch.main()`'s HYBRID contract). A
+genuinely unknown event name (Cursor's native-only `beforeShellExecution`, `sessionEnd`, or
+garbage) is left untouched: `canonical_event` can only ever return a name the caller already
+declared, so this module cannot invent an event, only recognize one that was already installed
+under a different capitalization.
+
+WHY DERIVED, NOT A HAND-WRITTEN ALIAS MAP
+The alias index is built FROM the caller's own set of known event names. A hand-maintained
+`{"preToolUse": "PreToolUse", ...}` table is a second list of the events, and the failure mode of
+a second list is that someone adds a `HANDLERS` row and forgets the alias -- reintroducing exactly
+this outage for the new event only, on one host, silently. Deriving means a new event is aliased
+the moment it is routable, by construction, with nothing to remember. Folding is applied only
+where it is unambiguous: if two known names collide case-insensitively the fold is refused for
+that name and exact-match still decides, so the index can never make routing MORE ambiguous than
+the caller's own table.
+
+PAYLOAD-FIELD PARITY
+Aliasing the event restores routing, but several checks then silently no-op on a foreign host
+because the payload FIELDS differ too. `normalize_payload` fills the protocol field from the
+host's spelling ONLY when the protocol field is absent, so a host that already speaks the
+protocol is passed through untouched.
+
+Deliberately NOT filled: `last_assistant_message`. Cursor's documented stop schema has no
+equivalent, and the Stop gates that read it degrade to empty (fail-open) without it. Fabricating
+a value -- from a transcript, or from anything else -- would manufacture the very evidence those
+gates exist to check. An absent field is an honest gap; a synthesized one is a lie the gate
+cannot see through. Closing it needs a real transcript adapter, not a rename.
+
+WHAT GETS PERSISTED
+`dispatch` ingests the NORMALIZED payload into the events table whenever normalization changed
+anything (a protocol-speaking host still ingests its own bytes, byte-identical). That table is
+the rolling substrate every history decoder reads, and those decoders key on the payload's own
+`hook_event_name` and `tool_name` -- so persisting the host's spelling instead would admit a
+dialect envelope live and then leave it invisible to every history-derived gate for the rest of
+the session: host compatibility bought by silently blinding the Stop tier. The dialect itself is
+not lost -- it is recorded once per session as a dispatch fact naming the host spellings that
+were translated.
+"""
+from __future__ import annotations
+
+import json
+
+# Host tool-name spellings -> the protocol tool name makoto's atoms key on, each admitted ONLY on
+# positive evidence that it is the same tool (see `_TOOL_EVIDENCE`), never on the name alone. A
+# rename on faith would route an unrelated tool into the command-reading atoms.
+_TOOL_ALIASES = {
+    "Shell": "Bash",          # Cursor's shell tool; carries tool_input.command like Bash
+}
+# The input key whose presence proves the aliased tool really is the protocol tool. `Shell` only
+# becomes `Bash` if it actually carries a command to read -- otherwise the atoms would key on a
+# tool whose shape they cannot parse, and read nothing while reporting they ran.
+_TOOL_EVIDENCE = {
+    "Shell": "command",
+}
+
+# Host field spellings -> the protocol field, filled ONLY when the protocol field is absent.
+_FIELD_ALIASES = {
+    "session_id": ("conversation_id",),   # Cursor documents session_id on sessionStart only
+    "tool_response": ("tool_output",),    # Cursor sends a JSON *string*, not an object
+}
+
+
+def alias_index(known) -> dict:
+    """Map every unambiguous case-folded spelling of `known` to its canonical member.
+
+    Derived from the caller's own event set (see the module docstring): a name is folded only if
+    its lowercase form belongs to exactly one known name, so a caller whose table already
+    distinguishes two names by case keeps deciding those by exact match alone."""
+    counts: dict = {}
+    for name in known:
+        if isinstance(name, str):
+            counts[name.lower()] = counts.get(name.lower(), 0) + 1
+    return {name.lower(): name for name in known
+            if isinstance(name, str) and counts.get(name.lower()) == 1}
+
+
+def canonical_event(event, known):
+    """The member of `known` that `event` names in ANY host's capitalization, else None.
+
+    Exact match wins outright, so a host already speaking the protocol is never reinterpreted.
+    None means genuinely unknown -- the caller keeps treating it exactly as before."""
+    if not isinstance(event, str):
+        return None
+    if event in known:
+        return event
+    return alias_index(known).get(event.lower())
+
+
+def _as_response_dict(value):
+    """A host's tool result as the dict every downstream reader expects.
+
+    Cursor sends `tool_output` as a JSON *string*. A string that decodes to an object is that
+    object; anything else is wrapped under `output` rather than dropped -- the readers all use
+    `.get`, so a wrapped scalar is inert to them, while discarding it would silently destroy the
+    only record that the call produced a result at all."""
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except Exception:
+            return {"output": value}
+        return decoded if isinstance(decoded, dict) else {"output": value}
+    return {"output": value}
+
+
+def normalize_payload(payload: dict, known_events) -> tuple:
+    """Return `(normalized_payload, notes)` -- the payload as the protocol, plus what was renamed.
+
+    `notes` is a dict of the host spellings actually encountered, empty when the payload already
+    spoke the protocol. It exists so a dialect translation is an auditable event and not an
+    invisible one: a silent rename is indistinguishable from a bug the next time a field goes
+    missing. The caller owns what to do with a still-unrecognized event -- this function changes
+    nothing else about that decision.
+
+    Never mutates the caller's dict; a host already speaking the protocol gets an equal copy.
+    The copy is deep on `tool_input`/`tool_response` specifically -- `dict(payload)` alone is
+    shallow, and now that the caller persists the normalized dict as the events-table row (see
+    the module docstring's WHAT GETS PERSISTED), any future in-place edit of a nested field by a
+    handler would silently rewrite the persisted record through the alias. Nothing today mutates
+    these in place, but the guarantee should not depend on that staying true."""
+    if not isinstance(payload, dict):
+        return payload, {}
+    out = dict(payload)
+    for nested in ("tool_input", "tool_response"):
+        if isinstance(out.get(nested), dict):
+            out[nested] = dict(out[nested])
+    notes: dict = {}
+
+    raw_event = out.get("hook_event_name")
+    canon = canonical_event(raw_event, known_events)
+    if canon is not None and canon != raw_event:
+        notes["hook_event_name"] = raw_event
+        out["hook_event_name"] = canon
+
+    for field, sources in _FIELD_ALIASES.items():
+        if out.get(field) not in (None, ""):
+            continue                                  # host already speaks the protocol
+        for src in sources:
+            if out.get(src) in (None, ""):
+                continue
+            value = out[src]
+            out[field] = _as_response_dict(value) if field == "tool_response" else value
+            notes[field] = src
+            break
+
+    tool = out.get("tool_name")
+    target = _TOOL_ALIASES.get(tool) if isinstance(tool, str) else None
+    if target is not None:
+        ti = out.get("tool_input")
+        evidence = _TOOL_EVIDENCE.get(tool)
+        if isinstance(ti, dict) and (evidence is None or ti.get(evidence) not in (None, "")):
+            notes["tool_name"] = tool
+            out["tool_name"] = target
+
+    return out, notes

--- a/makoto/dispatch.py
+++ b/makoto/dispatch.py
@@ -27,6 +27,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
+from makoto.core import hostdialect
 from makoto.vocab import Finding
 from makoto.state.store import _state_dir
 from makoto.state import citations
@@ -120,6 +121,36 @@ def _dispatch_fact(state_dir: Path, stage: str, reason: str, *, blocked: bool) -
                            exc=_Unevaluable(f"{disposition}: {reason}"))
     except Exception:
         pass
+
+
+def _note_host_dialect(state_dir: Path, session_id, notes: dict, host_event) -> bool:
+    """Record ONCE PER SESSION that this host's envelopes are being translated. Returns whether
+    this call was the one that recorded it.
+
+    A dialect translation must be visible -- a rename nobody can see is indistinguishable from a
+    bug the next time one of these fields turns up missing. But it must not be visible once per
+    tool call: `_dispatch_fact` writes a guaranteed stderr line, and a foreign host translates
+    EVERY event, so a per-event fact would put a line on the user's terminal for the whole session
+    and grow the error ledger without adding information after the first row. Once per session is
+    the whole signal -- the dialect is a property of the host, not of the call.
+
+    Best-effort by construction: an unwritable marker degrades to re-noting (noisy but correct),
+    never to crashing the hot path or to suppressing the note."""
+    try:
+        marker_dir = state_dir / "host_dialect"
+        marker_dir.mkdir(parents=True, exist_ok=True)
+        key = "".join(c if c.isalnum() or c in "-_" else "_" for c in str(session_id or "nosession"))[:96]
+        marker = marker_dir / f"{key}.json"
+        if marker.exists():
+            return False
+        marker.write_text(json.dumps({"notes": notes, "host_event": host_event}) + "\n",
+                          encoding="utf-8")
+    except Exception:
+        pass
+    _dispatch_fact(state_dir, "host_dialect",
+                   f"normalized host spellings {notes!r} (first seen as event {host_event!r}); "
+                   f"noted once for this session", blocked=False)
+    return True
 
 
 def _self_verify_chain(state_dir: Path) -> None:
@@ -671,6 +702,34 @@ def main() -> int:
         _dispatch_fact(state_dir, "non_object_payload",
                        f"payload was {type(payload).__name__}, not a JSON object", blocked=True)
         return 2
+    # The host-dialect boundary (makoto.core.hostdialect): one hop from whatever spelling the
+    # host sent to the protocol every reader below assumes, applied here -- after the envelope
+    # has been proven evaluable (parseable, an object), before ANYTHING routes on or persists it
+    # -- so routing, gates, history, commitments and audit all see one canonical payload rather
+    # than each learning a second dialect. Cursor loads Claude-Code-compatible hook wiring but
+    # delivers camelCase (`preToolUse`): under the wildcard-law routing that ran the WRONG
+    # handler and persisted a row every history decoder was blind to (#19). The unevaluable-
+    # envelope refusals ABOVE are untouched: this normalizes a known event's capitalization, and
+    # `canonical_event` can only return a name already in HANDLERS, so a genuinely unknown event
+    # still takes exactly the wildcard path it took before.
+    host_event = payload.get("hook_event_name")
+    payload, dialect_notes = hostdialect.normalize_payload(payload, HANDLERS)
+    if dialect_notes:
+        # Persist WHAT WAS EVALUATED, not the host's spelling of it. The events table is the
+        # rolling substrate every history decoder reads, and those decoders key on the PAYLOAD's
+        # `hook_event_name`/`tool_name` -- ingesting the raw dialect envelope would leave
+        # `event.identical_retry`, `canon.recur`/`canon.timeout` and the claim-graph Bash
+        # evidence path reading zero matching rows for a Cursor session: admitted live, then
+        # invisible to every history-derived gate afterwards. Only rewritten when normalization
+        # actually changed something: a host already speaking the protocol still ingests its own
+        # bytes, byte-identical.
+        # ensure_ascii=False: the default escapes non-ASCII to \uXXXX, and this text is also what
+        # `_keyword_hit` prefilters the Pre catalog against as a raw substring scan -- an escaped
+        # row would make a non-ASCII keyword match on a protocol host and silently miss on a
+        # dialect host, the exact "a check that reads nothing" failure mode this boundary exists
+        # to prevent.
+        payload_raw = json.dumps(payload, ensure_ascii=False)
+        _note_host_dialect(state_dir, payload.get("session_id"), dialect_notes, host_event)
     db_path = state_dir / "makoto.record.db"
     if not _ensure_db_initialized(state_dir, db_path):
         _dispatch_fact(state_dir, "db_init_failed", "lazy DB init failed", blocked=False)

--- a/makoto/install.py
+++ b/makoto/install.py
@@ -22,12 +22,15 @@ import os
 import re
 import sys
 from pathlib import Path
-from makoto.registry import load_precheck_catalog
+from makoto.registry import load_checks, load_precheck_catalog
 # Hoisted 2026-07-09 to makoto.substrate.wiring (shared with checks/selfWiredCheck.py, which the
 # gate-side layering firewall bars from importing this lifecycle module directly).
 from makoto.substrate.wiring import (
     MAKOTO_CLAUDE_FLAG as _MAKOTO_CLAUDE_FLAG,
     entry_dispatches_to_makoto as _entry_dispatches_to_makoto,
+    entry_owned_by_makoto as _entry_owned_by_makoto,
+    event_wired,
+    read_plugin_manifest_hooks,
 )
 
 
@@ -64,27 +67,37 @@ def _validate_predicate_modules() -> None:
             sys.exit(1)
 
 
-def _install_bash_scripts(state_dir: Path) -> None:
-    """copy _dispatch_shim.sh into <state_dir>/dispatch.sh for settings.json hook wiring."""
+def _install_bash_scripts(state_dir: Path) -> bool:
+    """copy _dispatch_shim.sh into <state_dir>/dispatch.sh for settings.json hook wiring.
+
+    Returns whether the shim is on disk afterwards. A missing source silently produced an
+    install that reported success with no dispatch.sh — every wired hook then pointing at a
+    file that does not exist, i.e. makoto reporting itself installed while unable to fire."""
     state_dir.mkdir(parents=True, exist_ok=True)
     shim_src = Path(__file__).parent / "_dispatch_shim.sh"
-    if shim_src.exists():
-        shim_dst = state_dir / "dispatch.sh"
-        shim_dst.write_text(shim_src.read_text(encoding="utf-8"), encoding="utf-8")
-        shim_dst.chmod(0o755)
+    if not shim_src.exists():
+        return False
+    shim_dst = state_dir / "dispatch.sh"
+    shim_dst.write_text(shim_src.read_text(encoding="utf-8"), encoding="utf-8")
+    shim_dst.chmod(0o755)
+    return shim_dst.exists()
 
 
 def _wire_claude_hooks(settings_path: Path) -> None:
     """add Makoto-managed PreToolUse + Stop hook entries pointing at dispatch.sh; idempotent.
 
-    Idempotency is FUNCTIONAL: any entry already dispatching to makoto (managed or
-    hand-wired) is absorbed into the single managed entry, never duplicated."""
+    Idempotency is FUNCTIONAL: any entry already dispatching to makoto (managed, hand-wired, or
+    one of makoto's own installed forms — see `wiring.entry_dispatches_to_makoto`) is absorbed
+    into the single managed entry, never duplicated. Absorbing on the SAME predicate uninstall
+    removes with (`entry_owned_by_makoto`, an alias of the same function) keeps install and
+    uninstall inverses of each other — and its anchored invocation regex keeps a user's OWN
+    makoto-CLI hook (`python3 -m makoto.status`) out of both."""
     data = json.loads(settings_path.read_text(encoding="utf-8")) if settings_path.exists() else {}
     hooks = data.setdefault("hooks", {})
     dispatch_path = Path.home() / ".claude" / "makoto_state" / "dispatch.sh"
     for event in ("PreToolUse", "PostToolUse", "Stop"):
         entries = hooks.setdefault(event, [])
-        entries[:] = [h for h in entries if not _entry_dispatches_to_makoto(h)]
+        entries[:] = [h for h in entries if not _entry_owned_by_makoto(h)]
         entries.append({
             _MAKOTO_CLAUDE_FLAG: True,
             "matcher": "*",
@@ -93,19 +106,51 @@ def _wire_claude_hooks(settings_path: Path) -> None:
     settings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
-def _unwire_claude_hooks(settings_path: Path) -> None:
-    """remove all Makoto-managed hook entries; preserve user entries."""
+def _unwire_claude_hooks(settings_path: Path):
+    """Remove every hook entry makoto OWNS; preserve user entries. Returns `(entries_removed,
+    commands_removed)` — an ENTRY count (what was deleted from the file) alongside the inner
+    command strings (what to show the user), kept separate because one entry may carry several
+    commands and conflating the two counts is silently wrong in both directions.
+
+    Keyed on `entry_owned_by_makoto` (an alias of `entry_dispatches_to_makoto` — see
+    `wiring.py`: the same predicate answers both "does this reach makoto" and "may makoto
+    delete this"). It used to key on the `_makoto_managed` flag ALONE, which broke twice over:
+
+    1. The flag decays (#20). Claude Code re-serializes settings.json from a schema-parsed
+       representation that drops unknown keys — including `_makoto_managed` — while KEEPING the
+       hook entries. One `claude plugin marketplace add` is enough. After that the filter matched
+       nothing, so uninstall removed zero hook entries, forever, while still reporting success.
+    2. Install and uninstall were not inverses. `_wire_claude_hooks` absorbs any functionally
+       dispatching entry (flagged or hand-wired), so `install` would swallow a hand-wired
+       `python -m makoto.dispatch` entry, but `uninstall` left that same entry firing.
+
+    Reporting used functional truth while removal trusted the flag — the asymmetry
+    `_hooks_wired`'s own docstring warns about, applied to the other half of the contract.
+    A malformed settings.json fails LOUD (JSONDecodeError propagates) rather than silently:
+    this is the command whose whole job is un-wiring, and a settings file broken enough to
+    reject `json.loads` needs the user's attention, not a report that nothing was removed."""
     if not settings_path.exists():
-        return
+        return 0, []
     data = json.loads(settings_path.read_text(encoding="utf-8"))
     hooks = data.get("hooks", {})
+    entries_removed = 0
+    commands_removed: list = []
     for event in list(hooks.keys()):
-        hooks[event] = [h for h in hooks[event] if not h.get(_MAKOTO_CLAUDE_FLAG)]
+        kept = []
+        for h in hooks[event]:
+            if _entry_owned_by_makoto(h):
+                entries_removed += 1
+                commands_removed.extend(str(i.get("command", "")) for i in (h.get("hooks") or [])
+                                        if isinstance(i, dict))
+            else:
+                kept.append(h)
+        hooks[event] = kept
         if not hooks[event]:
             del hooks[event]
     if not hooks and "hooks" in data:
         del data["hooks"]
     settings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return entries_removed, commands_removed
 
 
 _CONV_START = "<!-- makoto-managed:conventions:start -->"
@@ -144,14 +189,21 @@ def _install_claude_conventions(claude_md_path: Path) -> None:
     claude_md_path.write_text(new, encoding="utf-8")
 
 
-def _uninstall_claude_conventions(claude_md_path: Path) -> None:
-    """remove the makoto-managed conventions block; preserve all user content."""
+def _uninstall_claude_conventions(claude_md_path: Path) -> bool:
+    """Remove the makoto-managed conventions block; preserve all user content.
+
+    Returns whether a managed block was actually PRESENT and stripped — an absent CLAUDE.md and a
+    CLAUDE.md that never carried the block both removed nothing, and reporting those as
+    `conventions_removed: true` describes work that did not happen."""
     if not claude_md_path.exists():
-        return
+        return False
     existing = claude_md_path.read_text(encoding="utf-8")
     stripped = re.sub(re.escape(_CONV_START) + r".*?" + re.escape(_CONV_END), "",
                       existing, flags=re.S).rstrip()
+    if stripped == existing.rstrip():
+        return False                                  # no managed block was there to remove
     claude_md_path.write_text((stripped + "\n") if stripped else "", encoding="utf-8")
+    return True
 
 
 def _record_configchange_manifest(settings_path: Path, *, state_dir: Path) -> None:
@@ -175,11 +227,17 @@ def _record_configchange_manifest(settings_path: Path, *, state_dir: Path) -> No
 
 
 def cmd_install() -> int:
-    """state-dir setup + ~/.claude/settings.json hook wiring. Idempotent."""
+    """state-dir setup + ~/.claude/settings.json hook wiring. Idempotent.
+
+    Every reported field is measured after the fact, for the same reason `cmd_uninstall`'s is:
+    `makoto_db_initialized` and `settings_wired` were printed as literal `True` regardless of
+    outcome, so an install that wired nothing — or wired hooks pointing at a dispatch.sh that
+    was never copied — still reported success. `cmd_status` already derived exactly these values
+    honestly; install asserted them."""
     _validate_predicate_modules()
     state_dir = Path.home() / ".claude" / "makoto_state"
     state_dir.mkdir(parents=True, exist_ok=True)
-    _install_bash_scripts(state_dir)
+    shim_installed = _install_bash_scripts(state_dir)
     from makoto.state import store as db
     citations_path = Path(__file__).parent / "docs" / "CITATIONS.md"
     db.init_db(state_dir, citations_path)
@@ -190,22 +248,91 @@ def cmd_install() -> int:
     _record_configchange_manifest(settings, state_dir=state_dir)
     claude_md = Path.home() / ".claude" / "CLAUDE.md"
     _install_claude_conventions(claude_md)
+    # post-conditions, re-read from disk
+    try:
+        settings_wired = _hooks_wired(json.loads(settings.read_text(encoding="utf-8")))
+    except Exception:
+        settings_wired = False
+    try:
+        conventions_written = _CONV_START in claude_md.read_text(encoding="utf-8")
+    except Exception:
+        conventions_written = False
     print(json.dumps({
         "state_dir": str(state_dir),
-        "makoto_db_initialized": True,
-        "settings_wired": True,
+        "state_dir_present": state_dir.is_dir(),
+        "dispatch_shim_installed": shim_installed,
+        "makoto_db_initialized": (state_dir / "makoto.record.db").exists(),
+        "settings_wired": settings_wired,
         "settings_path": str(settings),
-        "conventions_written": str(claude_md),
+        "conventions_written": conventions_written,
+        "conventions_path": str(claude_md),
     }, indent=2))
     return 0
 
 
+def _plugin_wiring_report() -> dict:
+    """What can be MEASURED about the OTHER wiring source: the marketplace plugin's hooks.json.
+
+    Unwiring settings.json does not disable an enabled `makoto@makoto` plugin — its manifest
+    wires the same dispatch independently, so an uninstall can look clean in settings.json while
+    plugin hooks still fire on every event. Claude Code's plugin-enablement store is not
+    something makoto reads, so this reports what it can observe ($CLAUDE_PLUGIN_ROOT and the
+    manifest there) and says plainly when it cannot observe the rest. An unknown reported as
+    unknown is the point: the previous output implied a completeness it never checked."""
+    root = os.environ.get("CLAUDE_PLUGIN_ROOT") or ""
+    if not root:
+        return {"plugin_hooks_declared": None,
+                "note": "CLAUDE_PLUGIN_ROOT is unset here, so the marketplace plugin's wiring "
+                        "could not be inspected. If `makoto@makoto` is installed as a plugin, "
+                        "its hooks still fire regardless of this settings.json unwire — disable "
+                        "it with Claude Code's plugin CLI."}
+    def _read(path):
+        try:
+            return Path(path).read_text(encoding="utf-8")
+        except Exception:
+            return ""
+    hooks = read_plugin_manifest_hooks(root, _read)
+    declared = sorted(evt for evt in ("PreToolUse", "PostToolUse", "Stop", "SubagentStop",
+                                      "SessionStart") if event_wired(hooks, evt))
+    return {"plugin_hooks_declared": declared,
+            "note": ("A plugin manifest at CLAUDE_PLUGIN_ROOT still declares these events; "
+                     "unwiring settings.json does NOT disable them.") if declared else
+                    "No makoto hooks declared by the plugin manifest at CLAUDE_PLUGIN_ROOT."}
+
+
 def cmd_uninstall() -> int:
-    """remove all Makoto-managed Claude Code hook entries; state dir kept."""
+    """Remove every Claude Code hook entry that makoto owns; state dir kept.
+
+    Every field printed is MEASURED. `unwired` is a post-condition: settings.json is RE-READ from
+    disk after the write and put through `_hooks_wired`, the same predicate `cmd_status` reports
+    with — so the two commands can no longer contradict each other (they did, #20: uninstall
+    printed `unwired: true` while status, run immediately after, printed `hooks_wired: true`).
+
+    This output used to be the literal `{"unwired": True, "conventions_removed": True,
+    "state_dir_kept": True}` — printed unconditionally, measuring nothing, with the removal
+    itself silently no-opping whenever the `_makoto_managed` flags had decayed. An integrity
+    tool whose own success report is a claim rather than a measurement fails the standard it
+    enforces."""
     settings = Path.home() / ".claude" / "settings.json"
-    _unwire_claude_hooks(settings)
-    _uninstall_claude_conventions(Path.home() / ".claude" / "CLAUDE.md")
-    print(json.dumps({"unwired": True, "conventions_removed": True, "state_dir_kept": True}, indent=2))
+    state_dir = Path.home() / ".claude" / "makoto_state"
+    entries_removed, commands_removed = _unwire_claude_hooks(settings)
+    conventions_removed = _uninstall_claude_conventions(Path.home() / ".claude" / "CLAUDE.md")
+    # post-condition, re-read from disk: what the file SAYS now, not what we believe we wrote.
+    still_wired = False
+    if settings.exists():
+        try:
+            still_wired = _hooks_wired(json.loads(settings.read_text(encoding="utf-8")))
+        except Exception:
+            still_wired = True          # unreadable -> cannot claim unwired
+    print(json.dumps({
+        "hook_entries_removed": entries_removed,
+        "hook_commands_removed": commands_removed,
+        "unwired": not still_wired,
+        "conventions_removed": conventions_removed,
+        "state_dir_kept": state_dir.is_dir(),
+        "settings_path": str(settings),
+        **_plugin_wiring_report(),
+    }, indent=2))
     return 0
 
 
@@ -232,10 +359,23 @@ def cmd_status() -> int:
     if settings.exists():
         data = json.loads(settings.read_text(encoding="utf-8"))
         hooks_wired = _hooks_wired(data)
-    disabled = [p.strip() for p in os.environ.get("MAKOTO_DISABLE_PATTERNS", "").split(",") if p.strip()]
+    # MAKOTO_DISABLE_PATTERNS is honored by the Pre-tier predicate loop ONLY
+    # (`dispatch._run_predicates`); the Stop gates are governed by their own `_gates_enabled()`
+    # switch and never consult this list. Echoing the raw request as `patterns_disabled`
+    # therefore told a user who muted a noisy GATE that it was disabled while it went on
+    # blocking them — the report asserting an effect the decision path never applies, the same
+    # defect as an uninstall that reports `unwired` without measuring. Requested vs effective
+    # are separate fields, and an id that cannot fully take effect is named rather than
+    # silently implied. An id present on BOTH edges (gate.contract_order, the one dual-edge
+    # check) keeps its Stop half firing regardless of the env var, so it is ineffective too.
+    requested = [p.strip() for p in os.environ.get("MAKOTO_DISABLE_PATTERNS", "").split(",") if p.strip()]
+    stop_ids = {c.id for c in load_checks(edge="Stop")}
+    muteable = {p.id for p in load_precheck_catalog()} - stop_ids
     print(json.dumps({
         "patterns_count": patterns_count,
-        "patterns_disabled": disabled,
+        "patterns_disabled": [p for p in requested if p in muteable],
+        "patterns_disable_requested": requested,
+        "patterns_disable_ineffective": [p for p in requested if p not in muteable],
         "hooks_wired": hooks_wired,
         "state_dir": str(state_dir),
         "state_dir_present": state_dir.is_dir(),

--- a/makoto/kit.py
+++ b/makoto/kit.py
@@ -209,6 +209,33 @@ def decode_history_row(row):
     return decoded if isinstance(decoded, dict) else None
 
 
+def decode_history_event(row):
+    """Like `decode_history_row`, but also backfills `hook_event_name` from the row's own
+    WRAPPER event-type column (tuple index 2, or dict key `event_type`) when the payload itself
+    doesn't carry one -- the canonical merge of `decode_history_row` + the wrapper-etype
+    fallback.
+
+    Two checks (`canonTimeoutRecur._decode_row`, `identicalRetryInterdiction`) used to re-derive
+    this fallback independently, each a byte-similar copy of the row-union handling above. One
+    drifted: it read only the payload's own field, so a row whose event type lived solely on the
+    wrapper decoded to a payload with no `hook_event_name` -- and `event.identical_retry`
+    requires an exact `== "PostToolUse"` match, so it went silently blind to rows
+    `canon.timeout`/`canon.recur` acted on, from the same table, for the same concept. One
+    primitive now serves both -- see `decode_history_row`'s own docstring on why a shared decode
+    step exists at all."""
+    wrapper_etype = None
+    if isinstance(row, (tuple, list)) and len(row) > 2:
+        wrapper_etype = row[2]
+    elif hasattr(row, "get"):
+        wrapper_etype = row.get("event_type")
+    ev = decode_history_row(row)
+    if ev is None:
+        return None
+    if not ev.get("hook_event_name") and wrapper_etype:
+        ev = {**ev, "hook_event_name": wrapper_etype}
+    return ev
+
+
 def bash_output_text(tool_response) -> str:
     """extract captured stdout+stderr from a Bash tool_response.
 
@@ -896,15 +923,26 @@ def resolve_in_worktree(loc, cwd):
         return None
 
 
+def extract_pushed_branch(text):
+    """The branch name from a "pushed ... to/branch X" claim in `text`, trailing
+    quote/punctuation stripped -- or None if no such claim is present.
+
+    Was two byte-identical regex-plus-rstrip pairs (`pushed_ref_matches_world` here and
+    `checks/claimedShippedAbsent.pushed_tip_matches_remote`), each with its own postprocessing
+    call site. One extraction step; each caller keeps its own downstream use (this module
+    validates against local/remote refs, claimedShippedAbsent compares tips) -- the same
+    shared-decode/caller-owned-interpretation split `decode_history_event` uses."""
+    match = _PUSH_BRANCH_RX.search(text or "")
+    return match.group(1).rstrip("`'\",:;.") if match else None
+
+
 def pushed_ref_matches_world(text, cwd):
     """True iff local and origin remote-tracking refs back a pushed-branch claim."""
     if not text or not cwd:
         return False
     try:
-        match = _PUSH_BRANCH_RX.search(text)
-        if match:
-            branch = match.group(1).rstrip("`'\",:;.")
-        else:
+        branch = extract_pushed_branch(text)
+        if branch is None:
             branch_result = subprocess.run(
                 ["git", "-C", cwd, "symbolic-ref", "--quiet", "--short", "HEAD"],
                 capture_output=True, text=True, timeout=_LOCAL_GIT_TIMEOUT,

--- a/makoto/state/commitments.py
+++ b/makoto/state/commitments.py
@@ -21,7 +21,7 @@ from typing import Optional
 
 from makoto.checks import detect_locations, detect_quantity, normalize_path, subject_binds
 from makoto.vocab import (
-    _BE_AUX_RX,  # L0 shared lexicon (dedup: was a byte-identical local copy)
+    _BE_AUX_RX, _OFFER_COND_RX, _FIRST_PERSON_RX,  # L0 shared lexicon (dedup: were byte-identical local copies)
     _NEG_FRAME_RX, _FENCE_SPAN_RX,
     _RETRACT_VERB_RX, _RETRACT_NEGPROMISE_RX, _RETRACT_POST_RX, _RETRACT_REASON_RX,
     _RETRACT_CLAUSE_BREAK_RX, _WRONG_SUBJECT_RX, _ACCIDENTAL_RX, _RETRACT_KEPT_RX,
@@ -60,15 +60,12 @@ _NEGATED_PROMISE_RX = re.compile(
 # A clause boundary OR a tree/diagram glyph OR a pipe between the verb and the path -> the verb
 # governs a different clause, or a different cell of a file-listing, not this path.
 _GOVERN_BREAK_RX = re.compile(r"[.;:\n—|│]|──|[├└┌┐┘]")
-# A conditional/hypothetical OFFER governing the promise -> not a firm commitment.
-_OFFER_COND_RX = re.compile(r"\b(?:if|once|unless|assuming|provided|whether|in case)\b",
-                            re.IGNORECASE)
-# Makoto watches the AI's OWN promises: a commitment needs a FIRST-PERSON subject ("I'll add X",
-# "we need to write X") OR a clause-initial imperative ("Add X to Y"). A THIRD-PERSON or
-# adverbial subject — "the fold fork writing X" (a subagent's action), "before adding entries to
-# X" (an adverbial gerund), "it leans on a CLAUDE.md convention" — is NOT a promise the AI made.
-_FIRST_PERSON_RX = re.compile(
-    r"\b(?:i|we|i'?ll|we'?ll|i'?m|we'?re|i'?ve|we'?ve|i'?d|we'?d|let'?s|my|our)\b", re.IGNORECASE)
+# _OFFER_COND_RX / _FIRST_PERSON_RX: L0 shared lexicon (makoto.vocab, imported above) --
+# _OFFER_COND_RX carves out a conditional/hypothetical OFFER from being read as a firm
+# commitment; _FIRST_PERSON_RX requires a first-person subject or clause-initial imperative. A
+# THIRD-PERSON or adverbial subject — "the fold fork writing X" (a subagent's action), "before
+# adding entries to X" (an adverbial gerund) — is NOT a promise the AI made. (Dedup: was a
+# byte-identical local copy, mirrored again in state/plan.py.)
 # A box-drawing/tree glyph on the path's line -> a file-listing, not prose. Never a promise.
 _TREE_GLYPH_RX = re.compile(r"[│├└┌┐┘┤┬┴┼─╾╿]")
 # The verb is line-initial (optionally after a bullet/number) -> an imperative plan-item

--- a/makoto/state/plan.py
+++ b/makoto/state/plan.py
@@ -209,11 +209,10 @@ _NEGATED_RX = re.compile(
     r"not planning to|no longer|skip(?:ping)?|never\s?mind|dropping|drop(?:ped)?|"
     r"not\s+(?:doing|finishing|completing|going\s+to))\b",
     re.IGNORECASE)
-_OFFER_COND_RX = re.compile(r"\b(?:if|once|unless|assuming|provided|whether|in case)\b",
-                            re.IGNORECASE)
-_FIRST_PERSON_RX = re.compile(
-    r"\b(?:i|we|i'?ll|we'?ll|i'?m|we'?re|i'?ve|we'?ve|i'?d|we'?d|let'?s|my|our)\b",
-    re.IGNORECASE)
+# _OFFER_COND_RX / _FIRST_PERSON_RX: L0 shared lexicon (makoto.vocab -- dedup: was a
+# byte-identical local copy of the exact regexes commitments.py hoisted; this file's own comment
+# already said it "mirrors commitments.py's hardened guards" without the dedup happening).
+from makoto.vocab import _OFFER_COND_RX, _FIRST_PERSON_RX
 _BIND_BEFORE = 60
 _BIND_AFTER = 40
 

--- a/makoto/substrate/wiring.py
+++ b/makoto/substrate/wiring.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 
 # The managed-entry marker `makoto install` writes into settings.json hook entries.
 MAKOTO_CLAUDE_FLAG = "_makoto_managed"
@@ -24,18 +25,56 @@ MAKOTO_CLAUDE_FLAG = "_makoto_managed"
 PLUGIN_MANIFEST_RELPATH = os.path.join("hooks", "hooks.json")
 
 
+# makoto's own hook-command invocation tokens -- anchored to the forms it actually installs, and
+# ONLY those: `~/.claude/makoto_state/dispatch.sh` (settings.json wiring, two-segment path so a
+# bare `dispatch.sh` living anywhere else does not match), `${CLAUDE_PLUGIN_ROOT}/makoto/
+# _dispatch_shim.sh` and `_dispatch_configchange_shim.sh` (the plugin-manifest shim forms -- see
+# hooks/hooks.json), and the module forms `-m makoto.dispatch` / `-m makoto.configchange` (the
+# two hook entrypoints; `\b` so `makoto.dispatcher_v2` never matches).
+#
+# This ONE regex is the single source for "is this command makoto's" -- exported for
+# `checks/selfMuteGuard` to import rather than maintain its own copy. Two regexes answering one
+# question is exactly the class of bug this module exists to prevent (see the module docstring):
+# a bare `makoto` substring test invented a looser answer that (a) via matching ANY makoto
+# subcommand -- `-m makoto.reference_integrity`, `-m makoto.status` -- let install/uninstall
+# absorb and delete a user's OWN makoto-CLI hooks, the exact "silently disarmed the user's own
+# integrity hook" failure this predicate exists to prevent, and (b) let a decoy hook merely
+# NAMING makoto satisfy `gate.self_wired`'s wired-check, suppressing the self-defense gate.
+# `re.IGNORECASE`: Windows/case-insensitive filesystems can produce either casing for a path
+# makoto itself wrote, and the substring test this replaces was case-insensitive too -- a
+# case-sensitive replacement would silently un-recognize a form makoto had already installed.
+MAKOTO_INVOCATION_RX = re.compile(
+    r"makoto_state[/\\]dispatch\.sh"
+    r"|_dispatch(?:_configchange)?_shim\.sh"
+    r"|-m\s+makoto\.(?:dispatch|configchange)\b",
+    re.IGNORECASE)
+
+
 def entry_dispatches_to_makoto(entry) -> bool:
     """True iff ONE hook entry functionally reaches makoto's dispatch -- the managed-flag entry
-    `makoto install` writes, OR a flag-less hand-wired/shim entry whose command names makoto
-    (`.../makoto_state/dispatch.sh`, `python -m makoto.dispatch`). Keying on the flag alone
-    lies on a shim-wired device (status: hooks_wired=false while firing, fixed v1.2.1;
-    install: a duplicate entry double-dispatching every event, the same bug on the write side)."""
+    `makoto install` writes, or a flag-less hand-wired/shim entry whose command is one of
+    makoto's own invocation forms (`MAKOTO_INVOCATION_RX`).
+
+    This is the SAME predicate used to decide ownership for absorption and removal
+    (`entry_owned_by_makoto` is an alias of this function) -- detecting a wiring and being
+    entitled to delete it are the same question once the invocation check is precise, and a
+    split predicate is exactly what would let the two drift (a decoy hook that merely NAMES
+    makoto satisfying detection while a real makoto CLI invocation fails the narrower one).
+    Keying on the flag alone lies on a shim-wired device (status: hooks_wired=false while
+    firing, fixed v1.2.1; install: a duplicate entry double-dispatching every event, the same
+    bug on the write side)."""
     if not isinstance(entry, dict):
         return False
     if entry.get(MAKOTO_CLAUDE_FLAG):
         return True
-    return any(isinstance(inner, dict) and "makoto" in str(inner.get("command", "")).lower()
+    return any(isinstance(inner, dict)
+               and MAKOTO_INVOCATION_RX.search(str(inner.get("command", "")))
                for inner in entry.get("hooks", []))
+
+
+# Removal and absorption need the SAME question detection answers -- see
+# `entry_dispatches_to_makoto`.
+entry_owned_by_makoto = entry_dispatches_to_makoto
 
 
 def event_wired(hooks, event: str) -> bool:

--- a/makoto/vocab.py
+++ b/makoto/vocab.py
@@ -275,6 +275,17 @@ _PRODUCE_VERB_RX = re.compile(
 # A passive/copular auxiliary right before the verb ⇒ "was written / is wired" — a
 # description of state or of another subject's action, NOT a first-person production claim.
 _BE_AUX_RX = re.compile(r"(?:\b(?:was|were|is|are|been|being|be|am)\s*$)|(?:['’](?:s|re)\s*$)", re.IGNORECASE)
+# A conditional/hypothetical OFFER governing a promise -> not a firm commitment. Byte-identical
+# in `state/commitments.py` and `state/plan.py`; plan.py's own comment already said it "mirrors
+# commitments.py's hardened guards" without the dedup actually happening -- the same class of
+# drift risk `_BE_AUX_RX` above was already hoisted for.
+_OFFER_COND_RX = re.compile(r"\b(?:if|once|unless|assuming|provided|whether|in case)\b",
+                            re.IGNORECASE)
+# Makoto watches the AI's OWN promises: a commitment needs a FIRST-PERSON subject ("I'll add X",
+# "we need to write X") OR a clause-initial imperative ("Add X to Y"). A THIRD-PERSON or
+# adverbial subject is NOT a promise the AI made. Byte-identical in both files, same reason.
+_FIRST_PERSON_RX = re.compile(
+    r"\b(?:i|we|i'?ll|we'?ll|i'?m|we'?re|i'?ve|we'?ve|i'?d|we'?d|let'?s|my|our)\b", re.IGNORECASE)
 # A clause boundary between the verb and the path ⇒ the verb governs a different clause.
 _CLAUSE_BREAK_RX = re.compile(r"[.;:\n—]")
 # A double- or single-quoted string span — used to blank quoted argument bodies before scanning a shell

--- a/tests/test_campaign_dedup.py
+++ b/tests/test_campaign_dedup.py
@@ -1,0 +1,69 @@
+"""Dedup campaign (ported from the stale public-repo branch's 6c633af/dd5c436/df23576):
+drifted duplicate implementations collapsed to canonical definitions, each pinned two ways —
+an IDENTITY assertion (the call sites share the same object, not a copy that happens to agree)
+and a behavioral check on the shared primitive.
+
+NOT ported: 94d4b73 (callee_chain unification into the factories module). The current layout
+already addressed it differently: `kit.py` (rank 1) may not import `substrate._stdlib_ast_helpers`
+(rank 2) under the pipeline-order firewall (tests/test_import_direction.py), and the duplication
+is a REGISTERED exemption with its reason on record in
+tests/test_no_alpha_duplicate_functions.py::_EXEMPT_PAIRS. Forcing the old port would violate
+the firewall that superseded it.
+"""
+from __future__ import annotations
+
+import json
+
+
+# ---- 6c633af: one row-decode-plus-wrapper-fallback step (kit.decode_history_event) ------------
+def test_decode_history_event_falls_back_to_the_wrapper_event_type():
+    from makoto.kit import decode_history_event
+    row = (1, "ts", "PostToolUse", "/repo",
+           json.dumps({"tool_name": "Bash", "tool_input": {"command": "x"},
+                       "tool_response": {"error_code": 1}}))
+    assert decode_history_event(row)["hook_event_name"] == "PostToolUse"
+
+
+def test_a_payloads_own_event_name_still_wins_over_the_wrapper():
+    from makoto.kit import decode_history_event
+    row = (1, "ts", "WrapperType", "/repo",
+           json.dumps({"hook_event_name": "PostToolUse", "tool_name": "Bash",
+                       "tool_input": {"command": "x"}}))
+    assert decode_history_event(row)["hook_event_name"] == "PostToolUse"
+
+
+def test_identical_retry_sees_a_wrapper_only_row_like_its_sibling():
+    """The original drift: identicalRetryInterdiction's hand-rolled decoder read only the
+    payload, so gate.identical_retry was BLIND to rows canon.timeout/canon.recur acted on,
+    from the same table, for the same concept. Both now share kit.decode_history_event."""
+    from makoto.checks.identicalRetryInterdiction import _most_recent_completed_bash_call
+    from makoto.checks.canonTimeoutRecur import _decode_row as canon_decode
+    row = (1, "ts", "PostToolUse", "/repo",
+           json.dumps({"tool_name": "Bash", "tool_input": {"command": "x"},
+                       "tool_response": {"stderr": "SyntaxError: bad", "exitCode": 1}}))
+    assert canon_decode(row)[0] == "PostToolUse"
+    assert _most_recent_completed_bash_call([row]) is not None
+
+
+# ---- dd5c436: shared lexicon + pushed-branch extraction ---------------------------------------
+def test_offer_and_first_person_regexes_are_the_one_vocab_object():
+    from makoto.vocab import _OFFER_COND_RX, _FIRST_PERSON_RX
+    from makoto.state import commitments, plan
+    assert commitments._OFFER_COND_RX is _OFFER_COND_RX
+    assert plan._OFFER_COND_RX is _OFFER_COND_RX
+    assert commitments._FIRST_PERSON_RX is _FIRST_PERSON_RX
+    assert plan._FIRST_PERSON_RX is _FIRST_PERSON_RX
+
+
+def test_extract_pushed_branch_is_shared_and_strips_trailing_punctuation():
+    from makoto.kit import extract_pushed_branch
+    import makoto.checks.claimedShippedAbsent as csa
+    assert csa.extract_pushed_branch is extract_pushed_branch
+    assert extract_pushed_branch("pushed the work to `feat/x`,") == "feat/x"
+    assert extract_pushed_branch("nothing of the sort") is None
+
+
+def test_unsourced_webfetch_uses_the_canonical_row_unwrap():
+    import makoto.checks.unsourcedWebfetch as uw
+    from makoto.kit import raw_payload_str
+    assert uw.raw_payload_str is raw_payload_str

--- a/tests/test_canon_pairing_injected_keys.py
+++ b/tests/test_canon_pairing_injected_keys.py
@@ -1,0 +1,146 @@
+"""Pre<->Post pairing survives harness-injected `tool_input` keys; the verdicts do not widen.
+
+`canon.recur` fired a STUCK verdict on a retry that had actually SUCCEEDED. The primitive was
+behaving as designed -- the bug was upstream, in `calls_from_history`.
+
+A harness may add bookkeeping keys to `tool_input` BETWEEN a call's PreToolUse and its
+PostToolUse. Observed live on the `Artifact` tool: a 3-key Pre, then a 6-key Post carrying
+`__artifactPlanConsentAsk`, `__artifactPlanConsentDecisionCaps`, `__artifactPublishTarget`.
+Pairing keyed on the FULL canonical input, so those two rows never matched: every such call left
+a dangling Pre and synthesized a phantom mid-turn-abandonment failure for a call that succeeded.
+
+One phantom is harmless. Two back-to-back are a run of length 2, all-error, same key -> STUCK.
+The real success lands under a DIFFERENT key, so it cannot flip the phantom run's verdict, and
+the documented [ERR, ERR, OK] guard cannot help.
+
+The fix relaxes PAIRING ONLY (`_pairing_input`), never a verdict: `recur_stuck` and every other
+primitive keep keying on the full `_canon_input`. The true-positive cases below are what hold
+that line -- a pairing relaxed until nothing dangles would discharge the gate while leaving its
+name in place.
+
+Not Artifact-specific: any tool whose PostToolUse carries injected `tool_input` keys degrades
+pairing for that tool everywhere `calls_from_history` is used.
+"""
+from __future__ import annotations
+
+import json
+
+from makoto.checks.canonTimeoutRecur import (
+    _canon_input,
+    _pairing_input,
+    calls_from_history,
+    fired_primitives,
+    recur_stuck,
+)
+
+BASE = {"file_path": "/x", "content": "c", "mode": "w"}
+INJECTED = {**BASE, "__artifactPlanConsentAsk": True,
+            "__artifactPlanConsentDecisionCaps": 2, "__artifactPublishTarget": "gallery"}
+
+
+def _row(event, tool, tool_input, *, error=False):
+    payload = {"hook_event_name": event, "tool_name": tool, "tool_input": tool_input}
+    if event == "PostToolUse":
+        payload["tool_response"] = {"error_code": 1} if error else {"ok": True}
+    return (1, "ts", event, "/repo", json.dumps(payload))
+
+
+def _stream(calls):
+    return "".join("E" if c["result"].get("interrupted") else "o" for c in calls)
+
+
+# ---- the pairing identity ---------------------------------------------------------------------
+def test_pairing_input_ignores_leading_dunder_keys():
+    assert _pairing_input(BASE) == _pairing_input(INJECTED)
+
+
+def test_the_verdict_identity_still_sees_them():
+    """PAIRED. Only pairing is dunder-insensitive; `_canon_input` -- what every verdict keys on --
+    is unchanged, so the relaxation cannot leak into a judgment."""
+    assert _canon_input(BASE) != _canon_input(INJECTED)
+
+
+def test_pairing_input_never_collapses_genuinely_distinct_calls():
+    """PAIRED REFUSAL. A leading `__` is a transport convention, never call semantics -- so
+    dropping it must not make two different calls look like one."""
+    assert _pairing_input({"command": "a"}) != _pairing_input({"command": "b"})
+    assert _pairing_input("scalar") == _canon_input("scalar")
+
+
+# ---- the four shapes from the report ----------------------------------------------------------
+def test_the_reported_false_positive_no_longer_fires():
+    """Shape 1: first call drops its Post (dead socket), second SUCCEEDS but its Post carries the
+    injected keys. Decoded `EEoo` before the fix -> STUCK on a turn that worked."""
+    history = [_row("PreToolUse", "Artifact", BASE),
+               _row("PreToolUse", "Artifact", BASE),
+               _row("PostToolUse", "Artifact", INJECTED),
+               _row("PreToolUse", "Read", {"file_path": "/y"}),
+               _row("PostToolUse", "Read", {"file_path": "/y"})]
+    calls = calls_from_history(history)
+    assert _stream(calls) == "Eoo", _stream(calls)
+    assert recur_stuck(calls) is False
+
+
+def test_the_same_shape_without_injection_was_already_correct():
+    history = [_row("PreToolUse", "Artifact", BASE),
+               _row("PreToolUse", "Artifact", BASE),
+               _row("PostToolUse", "Artifact", BASE),
+               _row("PreToolUse", "Read", {"file_path": "/y"}),
+               _row("PostToolUse", "Read", {"file_path": "/y"})]
+    assert recur_stuck(calls_from_history(history)) is False
+
+
+def test_two_successful_injected_calls_are_silent():
+    history = [_row("PreToolUse", "Artifact", BASE), _row("PostToolUse", "Artifact", INJECTED),
+               _row("PreToolUse", "Artifact", BASE), _row("PostToolUse", "Artifact", INJECTED)]
+    calls = calls_from_history(history)
+    assert _stream(calls) == "oo"
+    assert recur_stuck(calls) is False
+
+
+def test_a_lone_dangling_pre_is_still_silent():
+    assert recur_stuck(calls_from_history([_row("PreToolUse", "Bash", {"command": "x"})])) is False
+
+
+# ---- the true positives that must keep firing -------------------------------------------------
+def test_a_byte_identical_command_failing_twice_still_fires():
+    history = [_row("PreToolUse", "Bash", {"command": "x"}),
+               _row("PostToolUse", "Bash", {"command": "x"}, error=True),
+               _row("PreToolUse", "Bash", {"command": "x"}),
+               _row("PostToolUse", "Bash", {"command": "x"}, error=True)]
+    assert recur_stuck(calls_from_history(history)) is True
+
+
+def test_a_command_failing_three_times_still_fires():
+    history = []
+    for _ in range(3):
+        history += [_row("PreToolUse", "Bash", {"command": "y"}),
+                    _row("PostToolUse", "Bash", {"command": "y"}, error=True)]
+    assert recur_stuck(calls_from_history(history)) is True
+
+
+def test_two_adjacent_genuinely_dangling_pres_still_fire():
+    """The abandonment signal itself is untouched: two unresolved Pres with no Post at all are
+    still a stuck run -- what changed is only that a MATCHING Post now pairs."""
+    history = [_row("PreToolUse", "Bash", {"command": "z"}),
+               _row("PreToolUse", "Bash", {"command": "z"}),
+               _row("PreToolUse", "Read", {"file_path": "/y"}),
+               _row("PostToolUse", "Read", {"file_path": "/y"})]
+    assert recur_stuck(calls_from_history(history)) is True
+
+
+# ---- every fired primitive names a reachable discharge ----------------------------------------
+def test_every_fired_primitive_names_its_release_operator_discharge():
+    """`canon_gate` offers the ackblock discharge to EVERY fired primitive, but the affordance was
+    spelled out only in `timeout`'s hand-written hint. A fired `canon.recur` therefore named no
+    reachable way out, so a false positive re-fired at every subsequent Stop until the rows aged
+    out of the recency window. A mechanism that exists but is invisible reads exactly like a
+    mechanism that is missing, so the clause is generated per id rather than written per entry."""
+    history = [_row("PreToolUse", "Bash", {"command": "q"}),
+               _row("PostToolUse", "Bash", {"command": "q"}, error=True),
+               _row("PreToolUse", "Bash", {"command": "q"}),
+               _row("PostToolUse", "Bash", {"command": "q"}, error=True)]
+    fired = list(fired_primitives(history))
+    assert {cid for cid, _, _ in fired} == {"timeout", "recur"}
+    for cid, _stop_text, retry_hint in fired:
+        assert f"makoto release.operator {cid}:" in retry_hint, cid

--- a/tests/test_dispatch_configchange_blocking.py
+++ b/tests/test_dispatch_configchange_blocking.py
@@ -86,6 +86,24 @@ def test_manifest_hit_on_stripped_path_blocks(tmp_path):
     assert len(rows) == 1
     assert rows[0]["pattern_fires"] == ["gate.configchange_transition"]
     assert rows[0]["findings"][0]["level"] == "error"
+    # The blocking tier's own audit row must record that it BLOCKED. This was a hardcoded
+    # `exit_code=0` on the path that prints `{"decision": "block"}`, so every block fire read as
+    # a clean exit to anything mining the trail -- the ledger misreporting the one event it
+    # exists to record, while the sibling advisory row derived the same field honestly.
+    assert rows[0]["exit_code"] == 2
+
+
+def test_the_advisory_tier_still_records_a_clean_exit(tmp_path):
+    """PAIRED. `exit_code` must DISCRIMINATE the two tiers, not just be 2 everywhere -- an
+    advisory fire does not block and must not claim it did."""
+    state_dir = tmp_path / "makoto_state"
+    settings_path = _write_settings(tmp_path, pre=False, post=False, stop=False)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    rc, out = _run_json(state_dir, _payload(tmp_path, settings_path))
+    assert rc == 0 and out == b""
+    rows = _audit_rows(state_dir)
+    assert rows[0]["pattern_fires"] == ["gate.configchange_advisory"]
+    assert rows[0]["exit_code"] == 0
 
 
 def test_manifest_present_but_this_path_not_in_it_stays_advisory(tmp_path):

--- a/tests/test_gate_shape.py
+++ b/tests/test_gate_shape.py
@@ -134,7 +134,11 @@ EXPECTED_FUNCTION_COUNTS = {                               # top-level def count
                                                             # 35->30, 2026-07-09: _callee_chain/_scratch_roots/
                                                             # _under/_is_scratch/_read extracted to
                                                             # _stdlib_ast_helpers.py
-    "canonTimeoutRecur.py": 15,                            # engine + adapter merged (canon_gate lives here)
+    "canonTimeoutRecur.py": 17,                            # engine + adapter merged (canon_gate lives here);
+                                                            # 15->17, 2026-08-16 (#17 port): _pairing_input
+                                                            # (dunder-insensitive Pre<->Post pairing identity)
+                                                            # + _release_clause (per-primitive release.operator
+                                                            # affordance, generated from the id)
     "canonFingerprints.py": 1,                             # thin adapter; atoms/decode live in _canonAtoms.py
     "canonFingerprintsAdvisory.py": 1,                     # thin adapter; atoms/decode live in _canonAtoms.py
     "contractOrder.py": 5,

--- a/tests/test_hostdialect.py
+++ b/tests/test_hostdialect.py
@@ -1,0 +1,182 @@
+"""#19 (camelCase host dialects): the host-dialect boundary (makoto.core.hostdialect).
+
+A Cursor-style host loads Claude-Code-compatible hook wiring but delivers the event name in
+camelCase (`preToolUse`, `postToolUse`). Before the boundary existed, dispatch routed on the
+exact spelling: a `postToolUse` event fell through the HANDLERS wildcard to the WRONG handler
+(_evaluate_and_gate instead of _accumulate), and the events table persisted the host's own
+spelling — leaving every history decoder that keys on `hook_event_name == "PreToolUse"/
+"PostToolUse"` (canon.timeout/canon.recur, gate.identical_retry, the claim-graph Bash-evidence
+path) silently blind for the whole session.
+
+Reproduction discipline: `test_dispatch_persists_canonical_event_for_camelcase_host` was run
+against the unfixed tree and failed (row persisted as `preToolUse`); it passes with the boundary
+in place. The unevaluable-envelope refusals (non-object payload) are pinned unchanged.
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from makoto.core import hostdialect
+from makoto.dispatch import HANDLERS
+
+
+def _setup_state(tmp_path):
+    from makoto.state.store import init_db
+    state_dir = tmp_path / "makoto_state"
+    citations = tmp_path / "CITATIONS.md"
+    citations.write_text("Smith 2020\n")
+    init_db(state_dir, citations)
+    return state_dir
+
+
+def _run_dispatch(state_dir, payload) -> tuple[int, str]:
+    env = os.environ.copy()
+    env["MAKOTO_STATE_DIR"] = str(state_dir)
+    proc = subprocess.run(
+        [sys.executable, "-m", "makoto.dispatch"],
+        input=(payload if isinstance(payload, bytes) else json.dumps(payload).encode("utf-8")),
+        capture_output=True, env=env, cwd=str(Path(__file__).parent.parent),
+    )
+    return proc.returncode, proc.stdout.decode("utf-8")
+
+
+def _events(state_dir):
+    import sqlite3
+    conn = sqlite3.connect(str(Path(state_dir) / "makoto.record.db"))
+    try:
+        return conn.execute("SELECT event_type, payload FROM events ORDER BY id").fetchall()
+    finally:
+        conn.close()
+
+
+# ---- the pure boundary -----------------------------------------------------------------------
+def test_canonical_event_folds_camelcase_to_known_name():
+    assert hostdialect.canonical_event("preToolUse", HANDLERS) == "PreToolUse"
+    assert hostdialect.canonical_event("postToolUse", HANDLERS) == "PostToolUse"
+    assert hostdialect.canonical_event("stop", HANDLERS) == "Stop"
+
+
+def test_canonical_event_exact_match_wins_and_unknown_stays_none():
+    assert hostdialect.canonical_event("PreToolUse", HANDLERS) == "PreToolUse"
+    assert hostdialect.canonical_event("beforeShellExecution", HANDLERS) is None
+    assert hostdialect.canonical_event(None, HANDLERS) is None
+    assert hostdialect.canonical_event(42, HANDLERS) is None
+
+
+def test_alias_index_is_derived_and_refuses_case_collisions():
+    idx = hostdialect.alias_index({"PreToolUse", "pretooluse"})
+    assert "pretooluse" not in idx  # ambiguous fold refused; exact match still decides
+    idx2 = hostdialect.alias_index({"PreToolUse", "Stop"})
+    assert idx2 == {"pretooluse": "PreToolUse", "stop": "Stop"}
+
+
+def test_normalize_payload_fills_protocol_fields_only_when_absent():
+    out, notes = hostdialect.normalize_payload(
+        {"hook_event_name": "preToolUse", "conversation_id": "c1",
+         "tool_name": "Shell", "tool_input": {"command": "ls"}},
+        HANDLERS)
+    assert out["hook_event_name"] == "PreToolUse"
+    assert out["session_id"] == "c1"
+    assert out["tool_name"] == "Bash"
+    assert notes == {"hook_event_name": "preToolUse", "session_id": "conversation_id",
+                     "tool_name": "Shell"}
+    # a host already speaking the protocol: untouched, empty notes
+    proto = {"hook_event_name": "PreToolUse", "session_id": "s",
+             "tool_name": "Bash", "tool_input": {"command": "ls"}}
+    out2, notes2 = hostdialect.normalize_payload(proto, HANDLERS)
+    assert out2 == proto and notes2 == {}
+
+
+def test_normalize_payload_never_aliases_shell_without_command_evidence():
+    out, notes = hostdialect.normalize_payload(
+        {"hook_event_name": "PreToolUse", "session_id": "s",
+         "tool_name": "Shell", "tool_input": {"something_else": 1}}, HANDLERS)
+    assert out["tool_name"] == "Shell" and "tool_name" not in notes
+
+
+def test_normalize_payload_decodes_string_tool_output_and_wraps_scalars():
+    out, _ = hostdialect.normalize_payload(
+        {"hook_event_name": "postToolUse", "session_id": "s", "tool_name": "Bash",
+         "tool_input": {"command": "x"}, "tool_output": json.dumps({"stdout": "hi"})}, HANDLERS)
+    assert out["tool_response"] == {"stdout": "hi"}
+    out2, _ = hostdialect.normalize_payload(
+        {"hook_event_name": "postToolUse", "session_id": "s", "tool_name": "Bash",
+         "tool_input": {"command": "x"}, "tool_output": "plain text"}, HANDLERS)
+    assert out2["tool_response"] == {"output": "plain text"}
+
+
+def test_normalize_payload_never_synthesizes_last_assistant_message():
+    out, _ = hostdialect.normalize_payload(
+        {"hook_event_name": "stop", "session_id": "s"}, HANDLERS)
+    assert "last_assistant_message" not in out
+
+
+def test_normalize_payload_copy_is_deep_on_nested_tool_dicts():
+    src = {"hook_event_name": "PreToolUse", "session_id": "s",
+           "tool_name": "Bash", "tool_input": {"command": "x"}}
+    out, _ = hostdialect.normalize_payload(src, HANDLERS)
+    assert out["tool_input"] == src["tool_input"]
+    assert out["tool_input"] is not src["tool_input"]
+
+
+# ---- dispatch integration: the reproduction of #19's downstream blindness --------------------
+def test_dispatch_persists_canonical_event_for_camelcase_host(tmp_path):
+    """THE #19 reproduction: a camelCase envelope must be persisted (wrapper event_type AND
+    payload hook_event_name) in the protocol spelling, so history decoders keying on
+    `== "PreToolUse"/"PostToolUse"` are not blind to the whole session."""
+    state_dir = _setup_state(tmp_path)
+    rc, _ = _run_dispatch(state_dir, {
+        "hook_event_name": "preToolUse", "session_id": "c1", "cwd": "/tmp",
+        "tool_name": "Bash", "tool_input": {"command": "echo hi"}})
+    assert rc == 0
+    rows = _events(state_dir)
+    assert len(rows) == 1
+    etype, payload_raw = rows[0]
+    assert etype == "PreToolUse", f"wrapper event_type persisted as {etype!r}"
+    assert json.loads(payload_raw)["hook_event_name"] == "PreToolUse"
+
+
+def test_dispatch_protocol_host_ingests_its_own_bytes(tmp_path):
+    """A protocol-speaking host's raw payload is persisted byte-identical (no rewrite)."""
+    state_dir = _setup_state(tmp_path)
+    payload = {"hook_event_name": "PreToolUse", "session_id": "s1", "cwd": "/tmp",
+               "tool_name": "Bash", "tool_input": {"command": "echo hi"}}
+    raw = json.dumps(payload)
+    rc, _ = _run_dispatch(state_dir, raw.encode("utf-8"))
+    assert rc == 0
+    assert _events(state_dir)[0][1] == raw
+
+
+def test_dispatch_rewritten_payload_raw_keeps_non_ascii_unescaped(tmp_path):
+    """8fec86e regression pin: the normalized persisted row must not \\uXXXX-escape non-ASCII —
+    the Pre-tier keyword prefilter reads it as a raw substring."""
+    state_dir = _setup_state(tmp_path)
+    rc, _ = _run_dispatch(state_dir, {
+        "hook_event_name": "preToolUse", "session_id": "s1", "cwd": "/tmp",
+        "tool_name": "Bash", "tool_input": {"command": "echo héllo"}})
+    assert rc == 0
+    assert "héllo" in _events(state_dir)[0][1]
+
+
+def test_dispatch_non_object_payload_still_fails_closed(tmp_path):
+    """The tamper path is NOT relaxed: valid-JSON-non-object still blocks (exit 2)."""
+    state_dir = _setup_state(tmp_path)
+    rc, _ = _run_dispatch(state_dir, b'["not", "an", "object"]')
+    assert rc == 2
+
+
+def test_dispatch_notes_dialect_once_per_session(tmp_path):
+    state_dir = _setup_state(tmp_path)
+    for _ in range(2):
+        rc, _ = _run_dispatch(state_dir, {
+            "hook_event_name": "preToolUse", "session_id": "c9", "cwd": "/tmp",
+            "tool_name": "Bash", "tool_input": {"command": "echo hi"}})
+        assert rc == 0
+    markers = list((Path(state_dir) / "host_dialect").glob("*.json"))
+    assert len(markers) == 1
+    facts = (Path(state_dir) / "dispatch_errors.jsonl")
+    n = sum(1 for ln in facts.read_text().splitlines()
+            if "host_dialect" in ln) if facts.exists() else 0
+    assert n == 1, f"dialect noted {n} times; must be once per session"

--- a/tests/test_install_measured_reports.py
+++ b/tests/test_install_measured_reports.py
@@ -1,0 +1,129 @@
+"""#20 (uninstall reports false success) -- every install/uninstall/status report field is
+MEASURED (a post-condition re-read from disk), never asserted, and removal keys on the SAME
+functional predicate reporting uses (`wiring.entry_owned_by_makoto`), so install and uninstall
+are inverses and uninstall/status can no longer contradict each other.
+
+The original defect: `_unwire_claude_hooks` keyed on the `_makoto_managed` flag ALONE. Claude
+Code re-serializes settings.json from a schema-parsed representation that drops unknown keys --
+including `_makoto_managed` -- while KEEPING the hook entries. After one such rewrite the filter
+matched nothing: uninstall removed zero entries, forever, while printing
+`{"unwired": true, ...}` -- and `makoto status`, run immediately after, printed
+`hooks_wired: true`.
+
+Reproduction discipline: `test_uninstall_removes_decayed_flagless_entries_and_reports_measured`
+and `test_uninstall_and_status_agree_after_flag_decay` were run against the unfixed tree and
+failed exactly on the reported defect (unwired claimed True while the functional entries
+remained), then passed with the fix.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from makoto import install as inst
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+    monkeypatch.delenv("MAKOTO_DISABLE_PATTERNS", raising=False)
+    return home
+
+
+def _decayed_settings(home) -> Path:
+    """settings.json as Claude Code re-serializes it: makoto's functional hook entries kept,
+    the `_makoto_managed` flags dropped. Plus one user entry that must survive uninstall."""
+    settings = home / ".claude" / "settings.json"
+    dispatch = str(home / ".claude" / "makoto_state" / "dispatch.sh")
+    entry = {"matcher": "*", "hooks": [{"type": "command", "command": dispatch}]}
+    user = {"matcher": "*", "hooks": [{"type": "command", "command": "python3 -m makoto.status"}]}
+    settings.write_text(json.dumps({
+        "theme": "dark",
+        "hooks": {"PreToolUse": [entry, user], "PostToolUse": [entry], "Stop": [entry]},
+    }, indent=2) + "\n", encoding="utf-8")
+    return settings
+
+
+def test_uninstall_removes_decayed_flagless_entries_and_reports_measured(fake_home, capsys):
+    settings = _decayed_settings(fake_home)
+    assert inst.cmd_uninstall() == 0
+    report = json.loads(capsys.readouterr().out)
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    # THE #20 reproduction: the three decayed functional entries must actually be gone...
+    for evt in ("PreToolUse", "PostToolUse", "Stop"):
+        assert not any(inst._entry_dispatches_to_makoto(h)
+                       for h in data.get("hooks", {}).get(evt, [])), evt
+    # ...and the report must agree with the measured world.
+    assert report["hook_entries_removed"] == 3
+    assert report["unwired"] is True
+    # the user's own makoto-CLI hook survives (the security fix's ownership bound)
+    assert any("makoto.status" in json.dumps(h)
+               for h in data.get("hooks", {}).get("PreToolUse", []))
+
+
+def test_uninstall_and_status_agree_after_flag_decay(fake_home, capsys):
+    """uninstall's `unwired` and status's `hooks_wired` are the same measured predicate."""
+    _decayed_settings(fake_home)
+    assert inst.cmd_uninstall() == 0
+    unwired = json.loads(capsys.readouterr().out)["unwired"]
+    assert inst.cmd_status() == 0
+    hooks_wired = json.loads(capsys.readouterr().out)["hooks_wired"]
+    assert unwired == (not hooks_wired) == True  # noqa: E712  -- the exact reported contradiction
+
+
+def test_uninstall_reports_nothing_removed_when_nothing_was(fake_home, capsys):
+    settings = fake_home / ".claude" / "settings.json"
+    settings.write_text('{"theme": "dark"}\n', encoding="utf-8")
+    assert inst.cmd_uninstall() == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["hook_entries_removed"] == 0
+    assert report["conventions_removed"] is False   # no CLAUDE.md block existed to strip
+    assert report["unwired"] is True
+
+
+def test_install_reports_are_postconditions(fake_home, capsys):
+    assert inst.cmd_install() == 0
+    report = json.loads(capsys.readouterr().out)
+    state_dir = fake_home / ".claude" / "makoto_state"
+    assert report["state_dir_present"] is True and state_dir.is_dir()
+    assert report["dispatch_shim_installed"] == (state_dir / "dispatch.sh").exists()
+    assert report["makoto_db_initialized"] == (state_dir / "makoto.record.db").exists()
+    assert report["settings_wired"] is True
+    assert report["conventions_written"] is True
+    # and install -> uninstall is an inverse round-trip on the hooks
+    assert inst.cmd_uninstall() == 0
+    report2 = json.loads(capsys.readouterr().out)
+    assert report2["unwired"] is True and report2["hook_entries_removed"] == 3
+
+
+def test_install_absorbs_hand_wired_dispatch_but_not_user_cli(fake_home, capsys):
+    settings = fake_home / ".claude" / "settings.json"
+    hand = {"matcher": "*", "hooks": [{"type": "command",
+                                       "command": "python3 -m makoto.dispatch"}]}
+    user = {"matcher": "*", "hooks": [{"type": "command",
+                                       "command": "python3 -m makoto.reference_integrity"}]}
+    settings.write_text(json.dumps({"hooks": {"PreToolUse": [hand, user]}}) + "\n",
+                        encoding="utf-8")
+    assert inst.cmd_install() == 0
+    capsys.readouterr()
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    pre = data["hooks"]["PreToolUse"]
+    assert sum(1 for h in pre if inst._entry_dispatches_to_makoto(h)) == 1  # absorbed, once
+    assert any("reference_integrity" in json.dumps(h) for h in pre)         # user hook kept
+
+
+def test_status_separates_requested_vs_effective_mutes(fake_home, capsys, monkeypatch):
+    """8fec86e's status fix: an id registered on the Stop edge too (gate.contract_order) cannot
+    be fully muted by MAKOTO_DISABLE_PATTERNS (the Stop half never consults it) -- status must
+    say so instead of claiming a complete mute."""
+    monkeypatch.setenv("MAKOTO_DISABLE_PATTERNS",
+                       "gate.contract_order,content.self_mute_guard")
+    assert inst.cmd_status() == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["patterns_disable_requested"] == ["gate.contract_order",
+                                                    "content.self_mute_guard"]
+    assert "gate.contract_order" in report["patterns_disable_ineffective"]
+    assert report["patterns_disabled"] == ["content.self_mute_guard"]

--- a/tests/test_makoto_allow_marker_parity.py
+++ b/tests/test_makoto_allow_marker_parity.py
@@ -1,0 +1,85 @@
+"""The `makoto-allow` escape hatch means the same thing everywhere it is honored.
+
+§7.5b: the marker is `makoto-allow: <reason>` -- a colon and a non-empty rationale. A bare
+`makoto-allow` does not exempt, because "an exemption without an on-the-record rationale is a
+reasonless laundering token, which is itself an empty word". That is the rule makoto INSTALLS
+INTO THE USER'S CLAUDE.md ("an on-the-record, auditable rationale, never a disguise"), and the
+rule `makoto_allowed`/`_MAKOTO_ALLOW_RX` enforces for every factory-built content check.
+
+Two AST engines -- `hollowTest` and `deadPureStatement` -- hand-rolled the test instead:
+`"makoto-allow" in line.lower()`. So a reasonless `# makoto-allow` suppressed a hollow-test or
+dead-statement finding that the identical marker could not suppress anywhere else, while BOTH
+checks' own finding text tells the author to write `# makoto-allow: <reason>`. The escape hatch
+was strictly laxer than the rule, on the one path where laxness is a bypass rather than a
+nuisance -- the same shape as the decayed `_makoto_managed` flag: a marker asserting an audit
+trail, accepted without one.
+
+One concept, one predicate. Pinned across every honoring site at once so a future site cannot
+quietly reintroduce a second strictness.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from makoto.checks import deadPureStatement, hollowTest
+from makoto.kit import makoto_allowed
+
+_CHECKS_DIR = Path(__file__).resolve().parent.parent / "makoto" / "checks"
+
+REASONED = "# makoto-allow: intentional, reviewed 2026-08-14"
+BARE = "# makoto-allow"
+COLON_ONLY = "# makoto-allow:"
+
+
+def test_the_canonical_predicate_requires_a_reason():
+    assert makoto_allowed(REASONED) is True
+    assert makoto_allowed(BARE) is False
+    assert makoto_allowed(COLON_ONLY) is False
+
+
+@pytest.mark.parametrize("marker,exempts", [(REASONED, True), (BARE, False), (COLON_ONLY, False)])
+def test_hollow_test_honors_the_canonical_marker(marker, exempts):
+    assert hollowTest._allowed(1, [marker]) is exempts
+
+
+def test_hollow_test_agrees_with_the_canonical_predicate():
+    for marker in (REASONED, BARE, COLON_ONLY, "no marker here"):
+        assert hollowTest._allowed(1, [marker]) == makoto_allowed(marker), marker
+
+
+def test_dead_pure_statement_honors_the_canonical_marker():
+    """`deadPureStatement`'s `_allowed` is a closure over the file's lines, so it is exercised
+    through `analyze_file` -- the real path, not a reimplementation of it."""
+    unmarked = "def f():\n    1 + 2\n"
+    assert deadPureStatement.analyze_file(unmarked, "m.py") != [], (
+        "control: the construct must actually fire, or the exemption cases below prove nothing")
+    assert deadPureStatement.analyze_file(f"def f():\n    1 + 2  {REASONED}\n", "m.py") == []
+    assert deadPureStatement.analyze_file(f"def f():\n    1 + 2  {BARE}\n", "m.py") != [], (
+        "a reasonless marker must not exempt a dead statement")
+
+
+def test_a_reasoned_marker_still_exempts_a_hollow_test():
+    """PAIRED. The hatch must keep working -- tightening it into uselessness would be the same
+    defect with the sign flipped."""
+    assert hollowTest._allowed(1, [f"def test_x(): pass  {REASONED}"]) is True
+
+
+def test_no_check_hand_rolls_the_marker_test():
+    """By construction, across the whole catalog: the marker's spelling lives in exactly one
+    place. A bare `"makoto-allow" in ...` membership test anywhere in `makoto/checks/` is the
+    divergence this file exists to prevent, so it is barred structurally rather than by review."""
+    offenders = []
+    for path in sorted(_CHECKS_DIR.glob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if (isinstance(node, ast.Compare)
+                    and any(isinstance(op, ast.In) for op in node.ops)
+                    and isinstance(node.left, ast.Constant)
+                    and isinstance(node.left.value, str)
+                    and "makoto-allow" in node.left.value):
+                offenders.append(f"{path.name}:{node.lineno}")
+    assert not offenders, (
+        f"hand-rolled `makoto-allow` membership test(s) at {offenders} -- use "
+        f"makoto.vocab._MAKOTO_ALLOW_RX (§7.5b requires a colon and a reason)")

--- a/tests/test_predicate_divergences.py
+++ b/tests/test_predicate_divergences.py
@@ -1,0 +1,104 @@
+"""Security fix (ported from the stale public-repo branch's 8fec86e): ONE exported, anchored,
+case-insensitive invocation-token regex (`wiring.MAKOTO_INVOCATION_RX`) answers "is this command
+makoto's" everywhere -- detection, absorption, removal, the self-mute guard, and the self-wired
+gate -- instead of a bare `"makoto" in command` substring test plus selfMuteGuard's own drifted
+hand-rolled copy.
+
+What the one regex closes, each pinned below:
+  (a) overbroad ownership: `-m makoto.status` / `-m makoto.reference_integrity` -- a user's OWN
+      makoto-CLI hooks -- satisfied the substring test, so install absorbed (deleted) them and
+      uninstall would remove them: "silently disarmed the user's own integrity hook".
+  (b) decoy suppression: a hook merely NAMING makoto (`echo makoto`) satisfied
+      `entry_dispatches_to_makoto`, so `gate.self_wired` read a stripped event as still wired --
+      a false-negative in the self-defense gate.
+  (c) selfMuteGuard's drifted copy (`makoto_state|dispatch\\.sh`, unanchored): false-BLOCKed an
+      edit to a user's own unrelated `/usr/local/bin/dispatch.sh` hook, while MISSING the plugin
+      manifest's `_dispatch_shim.sh` form entirely (gutting a plugin-packaged install was
+      invisible to the guard).
+
+Reproduction discipline: every test below marked RED-before was run against the unfixed tree and
+failed, then passed with the fix applied.
+"""
+from __future__ import annotations
+
+import json
+
+from makoto.checks import selfMuteGuard
+from makoto.substrate.wiring import (
+    MAKOTO_INVOCATION_RX,
+    entry_dispatches_to_makoto,
+    entry_owned_by_makoto,
+    event_wired,
+)
+
+
+def _entry(cmd: str) -> dict:
+    return {"hooks": [{"type": "command", "command": cmd}]}
+
+
+# ---- (a) the user's own makoto-CLI hooks are NOT makoto's dispatch ---------------------------
+def test_a_users_own_makoto_cli_hook_is_not_owned():          # RED-before
+    for cmd in ("python3 -m makoto.status",
+                "python3 -m makoto.reference_integrity --strict",
+                "makoto-lint --fix"):
+        assert entry_dispatches_to_makoto(_entry(cmd)) is False, cmd
+        assert entry_owned_by_makoto(_entry(cmd)) is False, cmd
+
+
+def test_makotos_own_installed_forms_are_owned():
+    for cmd in ("/home/u/.claude/makoto_state/dispatch.sh",
+                "C:\\Users\\u\\.claude\\MAKOTO_STATE\\DISPATCH.SH",       # case/sep variant
+                "${CLAUDE_PLUGIN_ROOT}/makoto/_dispatch_shim.sh",
+                "python3 -m makoto.dispatch",
+                "PYTHON3 -M MAKOTO.DISPATCH"):
+        assert entry_dispatches_to_makoto(_entry(cmd)) is True, cmd
+    assert entry_dispatches_to_makoto({"_makoto_managed": True}) is True
+
+
+def test_owned_and_dispatches_are_the_same_predicate():
+    """Detection and removal must answer ONE question -- a split predicate is what let a decoy
+    satisfy one side and a real invocation fail the other."""
+    assert entry_owned_by_makoto is entry_dispatches_to_makoto
+
+
+def test_module_form_does_not_swallow_other_makoto_submodules():
+    assert MAKOTO_INVOCATION_RX.search("python3 -m makoto.dispatcher_v2") is None
+    assert MAKOTO_INVOCATION_RX.search("python3 -m makoto.configchange") is not None
+
+
+# ---- (b) a decoy hook merely naming makoto must not read as wired ----------------------------
+def test_decoy_hook_naming_makoto_does_not_suppress_self_wired():   # RED-before
+    decoy = {"PreToolUse": [_entry("echo makoto is watching")]}
+    assert event_wired(decoy, "PreToolUse") is False
+    real = {"PreToolUse": [_entry("${CLAUDE_PLUGIN_ROOT}/makoto/_dispatch_shim.sh")]}
+    assert event_wired(real, "PreToolUse") is True
+
+
+# ---- (c) selfMuteGuard imports the ONE regex, not a drifted copy ------------------------------
+def test_mute_guard_uses_the_shared_invocation_regex():
+    assert selfMuteGuard._MAKOTO_CMD_RX is MAKOTO_INVOCATION_RX
+
+
+def _mute_predicate(old: str, new: str):
+    return selfMuteGuard.predicate(
+        current_event={"hook_event_name": "PreToolUse",
+                       "tool_input": {"file_path": "/home/u/.claude/settings.json",
+                                      "old_string": old, "new_string": new}},
+        history=[], pattern=selfMuteGuard.CHECK)
+
+
+def test_mute_guard_does_not_false_block_a_users_own_dispatch_sh():   # RED-before
+    old = json.dumps(_entry("/usr/local/bin/dispatch.sh"))
+    assert _mute_predicate(old, "{}") is None
+
+
+def test_mute_guard_catches_gutting_the_plugin_shim_form():           # RED-before
+    old = json.dumps(_entry("${CLAUDE_PLUGIN_ROOT}/makoto/_dispatch_shim.sh"))
+    f = _mute_predicate(old, json.dumps(_entry("true")))
+    assert f is not None and "guts makoto's hook command" in f.message
+
+
+def test_mute_guard_still_catches_gutting_the_settings_form():
+    old = json.dumps(_entry("/home/u/.claude/makoto_state/dispatch.sh"))
+    f = _mute_predicate(old, json.dumps(_entry("true")))
+    assert f is not None


### PR DESCRIPTION
## Summary

Real, unlanded work stranded on `claude/makoto-github-issues-9jtz89` (fixes for filed issues #17/#19/#20, a security-review fix, and a dedup campaign), whose base predates the directory restructure that has since landed on `main`. Each fix was re-implemented by hand against the current post-restructure layout, verified by a test reproducing the **original** defect (RED before, GREEN after).

- **#19** (camelCase host dialects): new `makoto/core/hostdialect.py` canonicalizes the hook-event envelope before anything routes/persists on it.
- **#20** (uninstall false success): removal now keys on the same predicate `status`/`install` use; install/uninstall are real inverses.
- **#17** (canon.recur false STUCK): pairing ignores harness-injected leading-dunder keys.
- **Security fix** (self-unwire risk): `MAKOTO_INVOCATION_RX` unified into one anchored, case-insensitive regex, re-anchored to this repo's **actual current** invocation forms (not copied verbatim — the stale branch referenced an old module name).
- **Dedup campaign**: ported what's still real duplication; explicitly did **not** port the old `callee_chain` merge — this session's own later import-direction firewall forbids exactly that edge, already a registered exemption.

Rebased onto the just-landed `tests=` result-shape law after it synced mid-session — one real conflict in `unsourcedWebfetch.py` (both efforts independently fixed its history decode), resolved by keeping the newer factored version.

## Verified independently (rerun on the rebased tree, not just the porting report)

- Full suite: **1793 passed, 6 skipped, 1 xfailed, exit 0** (zero regressions).
- `MAKOTO_INVOCATION_RX`: 7 real cases checked directly, including the security-critical one — a user's own `-m makoto.status` hook does **not** match.
- #19: drove the real hook shim with a camelCase envelope, then **read the persisted sqlite row directly** — confirmed canonicalized.
- HYBRID triage: both fail-mode branches re-driven, exit codes bare (0 unparseable, 2 non-object).
- Security fix/#20: ran the real `python3 -m makoto uninstall` CLI against a synthetic settings.json — confirmed only the makoto entry was removed, the user's own hook survived.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtJRGMHKr3C27EwYZdRXTd)_