### PR TITLE
Wire Check.layer into the posture fold: meta BLOCK immunity

### DIFF
--- a/makoto/dispatch.py
+++ b/makoto/dispatch.py
@@ -333,6 +333,31 @@ def _blocking_gate_ids() -> frozenset:
     return frozenset(c.id for c in load_checks(edge="Stop") if c.may_block)
 
 
+@lru_cache(maxsize=1)
+def _meta_check_ids() -> frozenset:
+    """The ids of every check declaring `layer="meta"` -- a check whose only possible trigger is
+    tampering with Makoto's own audit/enforcement machinery. DERIVED from `Check.layer` via
+    `load_checks()` across every edge -- never hand-synced, matching `_blocking_gate_ids()`'s own
+    discipline, so a check tagged meta is picked up here automatically, not by memory."""
+    return frozenset(
+        c.id for edge in ("Pre", "Post", "Stop", "SubagentStop", "SessionStart")
+        for c in load_checks(edge=edge) if getattr(c, "layer", "object") == "meta"
+    )
+
+
+def _finding_layer(outcome, finding, mode, permission_mode) -> str:
+    """Returns "meta" only on the exact branch where verdict.apply's meta-BLOCK floor can bind
+    (a raw BLOCK, from a meta-tagged check, under LOOSE/SILENT posture, not oversight-clamped) --
+    so the default STRICT hot path never pays the `_meta_check_ids()` catalog-derivation cost."""
+    if outcome != verdict.BLOCK or mode not in ("loose", "silent"):
+        return "object"
+    if verdict.is_oversight_clamped(permission_mode):
+        return "object"
+    if finding.pattern_id in _meta_check_ids():
+        return "meta"
+    return "object"
+
+
 def _run_predicates(conn, payload: dict, history: list, event_id: int,
                     state_dir: Path, payload_raw: str) -> list[Finding]:
     """keyword-prefilter the catalog, invoke each candidate predicate, collect Findings.
@@ -481,7 +506,8 @@ def _emit_decision(findings: list[Finding], hook_event: str, stream=None,
             detail = f"{detail}\n{hint}"
     mode = verdict.posture()
     folded = verdict.apply(verdict.Decision(outcome, detail), mode,
-                           permission_mode=permission_mode)
+                           permission_mode=permission_mode,
+                           layer=_finding_layer(outcome, finding, mode, permission_mode))
     if _recheck_certificate_enabled():
         # CONTENT law (opt-in): pure data assembly from locals already in scope — the raw
         # pre-fold inputs paired with the post-fold claim — rechecked BEFORE the wire write so

--- a/makoto/registry.py
+++ b/makoto/registry.py
@@ -91,16 +91,16 @@ class Check:
     tuning work (see each file's own "ACKNOWLEDGED FN" sections) for a case that isn't actually
     self-referential. Only `content.self_mute_guard` and `gate.self_wired` are unambiguously
     meta -- both can ONLY ever fire on Makoto's own settings.json/hook-wiring, nothing else.
-    `layer="meta"` has exactly ONE consumer today: `tests/test_meta_layer.py` asserts the two
-    known-meta check ids are tagged, catching drift if either is ever un-tagged or a new
-    Makoto-self-referential check ships untagged. It does NOT (yet) change enforcement/posture-
-    folding behavior -- selfMuteGuard's makoto-allow immunity is already hardcoded in its own
-    predicate (never calls the shared `makoto_allowed` path), and selfWiredCheck is Stop-tier
-    ADVISE (never BLOCK) and never reads `makoto-allow` at all, so neither needs the fold logic
-    touched to be correct. Wiring `layer` into `makoto.verdict.apply()`'s fold rules
-    (e.g. a meta BLOCK never softening below ASK under LOOSE/SILENT) is a separate, higher-
-    blast-radius change affecting all 32 checks' shared fold path -- deliberately NOT bundled
-    into this additive schema field."""
+    `layer="meta"` is wired into `makoto.verdict.apply()`'s fold rules: a raw BLOCK from a meta
+    check floors at ASK under LOOSE/SILENT posture instead of softening further -- a loose
+    posture setting must not be able to suppress detection of tampering with the mechanism that
+    enforces posture itself (`dispatch._meta_check_ids()`/`dispatch._finding_layer()`, threaded
+    through `dispatch._emit_decision` and `verdict.recheck_certificate`). `content.self_mute_guard`
+    is Pre-tier with `level="error"` (Pre-tier is invariantly BLOCK), so this floor is LIVE for it
+    today; `gate.self_wired` is Stop-tier ADVISE (never BLOCK), so the floor is present but
+    currently inert for it. `tests/test_meta_layer.py` still asserts the two known-meta check ids
+    are tagged, catching drift if either is ever un-tagged or a new Makoto-self-referential check
+    ships untagged."""
     id: str
     applies_at: str
     posture: str

--- a/makoto/verdict.py
+++ b/makoto/verdict.py
@@ -124,7 +124,7 @@ def is_oversight_clamped(permission_mode) -> bool:
     return permission_mode in _REDUCED_OVERSIGHT_MODES
 
 
-def apply(outcome, posture_value, *, permission_mode=None) -> str:
+def apply(outcome, posture_value, *, permission_mode=None, layer="object") -> str:
     """Intent: Fold the configured posture over a raw check outcome into the final posture the host
     acts on — softening or hardening what a check flagged, never escalating a check that found none.
 
@@ -144,6 +144,13 @@ def apply(outcome, posture_value, *, permission_mode=None) -> str:
     `permission_mode` (D6, optional, additive): when `is_oversight_clamped(permission_mode)`,
     `posture_value` is IGNORED and the STRICT rule applies instead -- see the module-level
     comment above `_REDUCED_OVERSIGHT_MODES` for why softening in these two modes is unsafe.
+
+    `layer` (optional, additive, default "object"): a check whose only possible trigger is
+    tampering with Makoto's own audit/enforcement machinery declares ``layer="meta"``. A raw
+    BLOCK from a meta check floors at ASK under LOOSE/SILENT instead of softening further --
+    a loose posture setting must not be able to suppress detection of tampering with the very
+    mechanism that enforces posture. Placed after the D6 oversight clamp, which already returns
+    the raw outcome and still wins; object-layer (the default) folds exactly as before.
     """
     if outcome not in _OUTCOMES:
         return ALLOW
@@ -151,6 +158,8 @@ def apply(outcome, posture_value, *, permission_mode=None) -> str:
         return ALLOW
     if is_oversight_clamped(permission_mode):
         return outcome                      # forced STRICT: honor the raw outcome unchanged
+    if outcome == BLOCK and layer == "meta" and posture_value in (SILENT, LOOSE):
+        return ASK                          # meta BLOCK floors at ASK, never softer
     if posture_value == SILENT:
         return ALLOW
     if posture_value == LOOSE:
@@ -389,7 +398,7 @@ def recheck_certificate(certificate: VerdictCertificate) -> tuple[str, str]:
     not a per-check fault that can safely be ignored.
     """
     # Local so the later F4 wiring can import this module from dispatch without an import cycle.
-    from makoto.dispatch import _jit_hint, _worst_finding
+    from makoto.dispatch import _finding_layer, _jit_hint, _worst_finding
 
     worst = _worst_finding(list(certificate.findings))
     if worst is None:
@@ -405,6 +414,7 @@ def recheck_certificate(certificate: VerdictCertificate) -> tuple[str, str]:
             Decision(outcome, detail),
             certificate.mode,
             permission_mode=certificate.permission_mode,
+            layer=_finding_layer(outcome, finding, certificate.mode, certificate.permission_mode),
         )
         reconstructed = (str(folded), getattr(folded, "detail", ""))
 

--- a/tests/test_dispatch_posture_integration.py
+++ b/tests/test_dispatch_posture_integration.py
@@ -93,3 +93,49 @@ def test_posttooluse_still_refreshes_and_records_without_capture(tmp_path):
         assert ledger_rows > 0, "record_update must still run on PostToolUse"
     finally:
         conn.close()
+
+
+def test_meta_block_finding_floors_at_ask_under_loose_and_silent(tmp_path):
+    """content.self_mute_guard (layer="meta") fires BLOCK on a self-mute attempt. Under LOOSE or
+    SILENT posture, an object-layer BLOCK would soften to ADVISE or vanish to ALLOW -- but a meta
+    finding must floor at ASK instead: a loose posture setting must not suppress detection of
+    tampering with the mechanism that enforces posture itself."""
+    state_dir = _setup_state(tmp_path)
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "session_id": "posture_meta",
+        "cwd": str(tmp_path),
+        "tool_name": "Write",
+        "tool_input": {
+            "file_path": ".claude/settings.json",
+            "content": '{"MAKOTO_DISABLE": "1"}',
+        },
+    }
+    for mode in ("loose", "silent"):
+        rc, out = _run_dispatch(state_dir, payload, extra_env={"MAKOTO_MODE": mode})
+        assert rc == 0
+        assert out, f"expected a rendered body under MAKOTO_MODE={mode}, got empty stdout"
+        body = json.loads(out)
+        assert body["hookSpecificOutput"]["permissionDecision"] == "ask", (
+            f"meta BLOCK must floor at ask under MAKOTO_MODE={mode}, got {body!r}"
+        )
+
+
+def test_object_layer_block_still_softens_under_loose(tmp_path):
+    """Control: an object-layer (non-meta) BLOCK still softens normally under LOOSE -- the meta
+    floor must not leak into ordinary checks' folding."""
+    state_dir = _setup_state(tmp_path)
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "session_id": "posture_object",
+        "cwd": "/tmp",
+        "tool_input": {
+            "file_path": "constitution/integrity/checks/v.py",
+            "content": 'def check(x):\n    return x.startswith("ok")\n',
+        },
+    }
+    rc, out = _run_dispatch(state_dir, payload, extra_env={"MAKOTO_MODE": "loose"})
+    assert rc == 0
+    body = json.loads(out) if out else {}
+    decision = body.get("hookSpecificOutput", {}).get("permissionDecision")
+    assert decision != "deny", "object-layer BLOCK should have softened under LOOSE, not stayed deny"


### PR DESCRIPTION
## Summary

Ported directly onto the public repo (not via `scripts/publish_public.sh`, which would have deleted this repo's own already-merged github-issues-fix work that never made it back to `makoto-dev` — caught before pushing, see below).

`Check.layer` (`"object"`|`"meta"`) existed but was purely decorative. This wires the property its own docstring had always named: a `"meta"` check can no longer have a BLOCK finding softened below ASK by a LOOSE or SILENT posture.

## Important context

Attempting to land this via the normal `makoto-dev` → public sync script would have **deleted** this repo's own already-merged github-issues-fix work (`hostdialect.py`, the canon-pairing fix, `install.py`'s rewrite, the dedup campaign — all landed via `#23`, never back-ported to `makoto-dev`). Caught before pushing by reviewing the sync diff; the sync was aborted and this fix applied by hand instead. `makoto-dev` and this repo have now diverged in a way that needs reconciling — flagged for follow-up, not resolved by this PR.

## Verified independently

- RED-then-GREEN: with the fix stashed, the wire-level test failed with `KeyError('permissionDecision')` (LOOSE softened the meta BLOCK below ask entirely); restored, 2 passed.
- Full suite: **1796 passed, 5 skipped, 1 xfailed, exit 0**. Diffed the skipped-test lists before/after this change specifically and found them identical — a pre-existing skip-count discrepancy (5 vs. an earlier session's 6) is environmental flakiness on one test, unrelated to this change.
- Drove the real hook entrypoint manually under both `MAKOTO_MODE=loose` and `MAKOTO_MODE=silent` — both floor at `ask`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtJRGMHKr3C27EwYZdRXTd)_