### PR TITLE
Port #75: move design-history prose to linked ADRs

### DIFF
--- a/docs/adr/0001-advisory-first-ledger-self-verification.md
+++ b/docs/adr/0001-advisory-first-ledger-self-verification.md
@@ -1,0 +1,13 @@
+# 0001. Advisory-first ledger self-verification
+
+## Status
+
+Accepted.
+
+## Decision and context
+
+Task 2 slice 3 was owned under the principle that “Makoto should read its own ledger for verification — its things literally depend on it.” Makoto re-derives the chain's own tamper-evidence at every dispatch, at the same every-event cadence Assay's kernel ran.
+
+The owner decision on 2026-07-07 was advisory-first, block-after-soak. This ships advisory only: an on-the-record dispatch fact plus a stderr line, never a block, until real-session soak evidence earns the flip to block. That flip must itself be a later, separately-certified change.
+
+A clean or absent/empty chain is vacuously silent under `verify_chain`'s own contract. Verification never raises: a verification fault must not crash the hot path it protects.

--- a/docs/adr/0002-bound-the-transient-events-buffer.md
+++ b/docs/adr/0002-bound-the-transient-events-buffer.md
@@ -1,0 +1,13 @@
+# 0002. Bound the transient events buffer
+
+## Status
+
+Accepted.
+
+## Decision and context
+
+The `events` table is a transient evidence buffer, not a durable log. Its only production reader is `_select_recent`, which never looks back past a one-hour same-session window. Anything older is dead weight.
+
+Makoto keeps a small multiple of that window and prunes the rest on every ingest. This hard-bounds the table to approximately one working window's worth of rows regardless of how many sessions accumulate, so the database cannot grow without limit.
+
+Durable cross-session state lives in the ledger and commitments; the fire (blocking-event) log lives in `audit.jsonl`. Neither is touched by this pruning.

--- a/docs/adr/0003-enable-stop-gates-after-corpus-validation.md
+++ b/docs/adr/0003-enable-stop-gates-after-corpus-validation.md
@@ -1,0 +1,18 @@
+# 0003. Enable Stop gates after corpus validation
+
+## Status
+
+Accepted.
+
+## Decision and context
+
+Both Stop gates block live by default and are governed by one switch:
+
+- completion: `UNFULFILLED`, where X was claimed produced but X is absent;
+- advance: `SELF-CONTRADICTING`, where universal completion was claimed over an undischarged commitment.
+
+Each was validated false-positive-clean on the 1,335-session honest corpus. For completion, production-claim binding drove worst-case false positives from 9.00% to a self-healing 2.42%, with true positives intact at 6/6 and the contamination canary passing.
+
+Advance flipped live on 2026-06-01 after recording zero fires across all 1,335 sessions with the proposal-menu, code-fence, and optional-parenthetical sourcing guards. Every residual false positive had traced to a never-built proposal the AI recommended, never a genuine commitment; genuine commitments discharged when their files were touched. True-positive behavior remained intact: an undischarged firm promise plus universal-done still fires. The reason-bound retraction path clears legitimately dropped promises so honest reprioritization does not false-block.
+
+`MAKOTO_DISABLE_GATES=1` returns both gates to shadow mode, still audited but not blocking. It is the single escape valve if a real-session false block surfaces.

--- a/docs/adr/0004-unify-check-discovery-with-structural-block-eligibility.md
+++ b/docs/adr/0004-unify-check-discovery-with-structural-block-eligibility.md
@@ -1,0 +1,19 @@
+# 0004. Unify check discovery with structural block eligibility
+
+## Status
+
+Accepted.
+
+## Decision and context
+
+`makoto.registry` is the sole discovery path for every edge. On 2026-08-16, `schema.load_prechecks` was retired. The Pre-tier predicate loop, Stop-finding loop, and `_blocking_gate_ids()` now call `load_checks(edge=...)` directly, leaving no second catalog or `schema.py`-owned TOML/adapter layer in the hot path. `load_precheck_catalog()` is the Pre-tier convenience wrapper replacing `schema.load_prechecks()`'s old default-path behavior.
+
+Stop-edge discovery has run entirely through the registry since 2026-07-10. The former `load_stopchecks()`/`GATE`-export mechanism, relocated here on 2026-07-09 from the deleted `stopchecks/__init__.py` compatibility shim, was then retired entirely. Every check that exported a `GATE` now expresses the same Stop-edge surface as a plain `CHECK`, or as an `EXTRA_CHECKS` entry for `contractOrder.py`'s dual Pre+Stop surface.
+
+`may_block=True` preserves the blocking eligibility that the presence of `GATE` used to imply. A Stop-edge check is blocking-eligible only when both `may_block is True` and `posture == BLOCK`: two independent signals, not one. Before `may_block`, blocking eligibility was `posture == BLOCK` alone; the field restores the structural layer provided by the old export-presence mechanism. A check without a `GATE` could never enter `_blocking_gate_ids()` regardless of posture. Accordingly, `staleEstablisher.py` and `undeclaredFalsifiable.py` deliberately remain `may_block=False`, so their pattern ids cannot enter the blocking-eligible set even if posture is mistagged. Pre-tier checks never set the field; `_blocking_gate_ids()` only consults Stop-edge checks.
+
+Every former gate reaches the pipeline regardless of its finding's own level or posture. The actual BLOCK-versus-ADVISE split remains inside `_emit_decision` and `_worst_finding`, keyed on each `Finding.level`.
+
+The blocking-id derivation is lazy and memoized. The loader imports every `checks/*.py` module, while Pre/PostToolUse dispatches never consult this set; a module-level constant would charge that import cost on every event. Stop dispatches load the same modules through `run_stop_checks` anyway, so laziness changes no Stop behavior.
+
+The additive `keywords`, `retry_hint`, `description`, and `predicate_module` fields were introduced in the SPEC-C item 2 Pre-tier cutover, backported from public on 2026-07-10. They were consumed by `schema.load_prechecks()`'s loader-backed default path and by the Pre-tier predicates, which read `pattern.retry_hint` and `pattern.description` directly to build their findings. Stop-tier checks use their safe empty defaults. `predicate_module` is conventionally the module's own `__name__`, never a hand-typed dotted string.

--- a/docs/adr/0005-distinguish-meta-enforcement-tampering.md
+++ b/docs/adr/0005-distinguish-meta-enforcement-tampering.md
@@ -1,0 +1,19 @@
+# 0005. Distinguish meta enforcement tampering
+
+## Status
+
+Accepted.
+
+## Decision and context
+
+`Check.layer` is an `"object" | "meta"` axis defaulting to `"object"`. The decision followed a session pass in which the proposed grouping of `envGatedAudit`, `selfMuteGuard`, `integritySuppressionFlag`, and `selfWiredCheck` was narrowed on re-examination.
+
+`meta` marks a check whose only possible trigger is tampering with Makoto's own audit or enforcement machinery. `object` watches claims and artifacts about the assistant's own work. This is a distinct axis: the assistant lying about its work is different from the assistant disabling the mechanism that would catch the lie.
+
+It is not a blanket tag for checks that mention integrity or audit concepts. `envGatedAudit.py` and `integritySuppressionFlag.py` are general-purpose detectors: they detect any environment-gated audit code or integrity-named suppression flag in a TOML file, regardless of whether Makoto is involved. They deliberately remain `object`. Tagging them `meta` and stripping their `makoto-allow` escape hatch would regress real false-positive tuning documented in each file's “ACKNOWLEDGED FN” sections for cases that are not self-referential.
+
+Only `content.self_mute_guard` and `gate.self_wired` are unambiguously meta because they can fire only on Makoto's own `settings.json` or hook wiring.
+
+`layer="meta"` participates in `makoto.verdict.apply()`'s fold rules. A raw BLOCK from a meta check floors at ASK under LOOSE or SILENT posture instead of softening further. A loose posture setting must not suppress detection of tampering with the mechanism that enforces posture itself. `dispatch._meta_check_ids()` and `dispatch._finding_layer()` thread the layer through `_emit_decision` and `verdict.recheck_certificate`.
+
+`content.self_mute_guard` is Pre-tier with `level="error"`; because Pre-tier is invariantly BLOCK, the floor is live for it today. `gate.self_wired` is Stop-tier ADVISE and never BLOCK, so the floor is present but currently inert. `tests/test_meta_layer.py` asserts that the two known meta ids remain tagged, catching drift if either is untagged or a new Makoto-self-referential check ships untagged.

--- a/docs/adr/0006-wire-live-plan-declaration-and-advancement.md
+++ b/docs/adr/0006-wire-live-plan-declaration-and-advancement.md
@@ -1,0 +1,17 @@
+# 0006. Wire live plan declaration and advancement
+
+## Status
+
+Accepted.
+
+## Decision and context
+
+The SPEC-5 live plan wiring on 2026-07-23 closed two halves of the same gap: declaration and advancement.
+
+Previously, the only way to populate a plan was for `.claude/makoto-plan.jsonl` to exist before `SessionStart` fired; nothing let Claude declare a plan mid-session. Even a plan declared at SessionStart could never close: `Plan.mark_done` and `plan.persist_plan` had no live callers. Once any plan existed, `gate.contract_order`'s Stop remainder would therefore block every subsequent Stop forever because `contractOrder.py`'s Pre and Stop sides only read the plan.
+
+Both halves use the same resolution contract as `contractOrder.py`'s Pre gap guard, `_event_location` and `Plan.resolve`, imported rather than duplicated. The orchestrator has no L2 import firewall; `contractOrder.py`'s own docstring scopes that firewall to discovered Stop GATE modules, which `dispatch.py` is not.
+
+The wiring is a no-op when the tool is not a locating tool, nothing resolves, or, on the advancement side, no plan is declared. A locating write of the artifact declares or redeclares it live with latest-wins semantics and the same falsifiability gate as `declare_plan`. A locating call at an open node's own `where` marks it done.
+
+Task #19c on 2026-07-10 additionally made the harness's own `TaskCreate` and `TaskUpdate` calls the ground-truth source for the plan-item store that the prose sourcer only approximates. An explicit create opens `task:<id>`; an explicit completed or deleted transition discharges it; `planItemDrift.py`'s advisory Stop reminder surfaces anything still open. It shares the ledger write's fail-open umbrella.

--- a/docs/adr/0007-normalize-host-dialects-at-the-dispatch-boundary.md
+++ b/docs/adr/0007-normalize-host-dialects-at-the-dispatch-boundary.md
@@ -1,0 +1,17 @@
+# 0007. Normalize host dialects at the dispatch boundary
+
+## Status
+
+Accepted.
+
+## Decision and context
+
+The `makoto.core.hostdialect` boundary converts whatever spelling the host sent into the protocol every downstream reader assumes. It is applied after the envelope has proven evaluable — parseable and an object — and before anything routes on or persists it. Routing, gates, history, commitments, and audit therefore see one canonical payload instead of each learning a second dialect.
+
+Cursor loads Claude-Code-compatible hook wiring but delivers camelCase names such as `preToolUse`. Under wildcard-law routing, that spelling ran the wrong handler and persisted a row every history decoder was blind to, tracked as issue #19.
+
+The unevaluable-envelope refusals remain unchanged. Normalization only adjusts known events' capitalization, and `canonical_event` can return only a name already in `HANDLERS`; a genuinely unknown event still follows the same wildcard path as before.
+
+Makoto persists what it evaluated, not the host's original spelling. The events table is the rolling substrate every history decoder reads, and those decoders key on the payload's `hook_event_name` and `tool_name`. Ingesting a raw dialect envelope would leave `event.identical_retry`, `canon.recur`, `canon.timeout`, and the claim-graph Bash evidence path reading zero matching rows for a Cursor session: admitted live, then invisible to every history-derived gate.
+
+The serialized payload is rewritten only when normalization changed something, so a host already speaking the protocol still ingests its own bytes byte-identically. Serialization uses `ensure_ascii=False`: the default would escape non-ASCII as `\uXXXX`, but `_keyword_hit` prefilters the Pre catalog with a raw substring scan. An escaped row could match a non-ASCII keyword on a protocol host and silently miss it on a dialect host, reproducing the exact “check that reads nothing” failure this boundary prevents.

--- a/docs/adr/0008-retire-legacy-pattern-id-aliases.md
+++ b/docs/adr/0008-retire-legacy-pattern-id-aliases.md
@@ -1,0 +1,9 @@
+# 0008. Retire legacy pattern-id aliases
+
+## Status
+
+Accepted.
+
+## Decision and context
+
+The 2026-07-10 epoch reset made canonical `family.name` forms the only pattern ids. The legacy-id alias closure was retired with the alias table itself. Operator state and configurations predating the reset were archived or wiped, so nothing remaining needs to resolve through old ids.

--- a/docs/adr/0009-render-decisions-with-per-edge-wire-tables.md
+++ b/docs/adr/0009-render-decisions-with-per-edge-wire-tables.md
@@ -1,0 +1,15 @@
+# 0009. Render decisions with per-edge wire tables
+
+## Status
+
+Accepted.
+
+## Decision and context
+
+The posture pipeline replaced the old single ad-hoc `{"decision":"block"}` shape that `main()` used identically for every edge. It folds the worst fired outcome through the configured `MAKOTO_MODE` posture and renders it through `verdict.dispatch_posture`'s per-edge table.
+
+A BLOCK carries the finding's message and JIT hint — convention text, `makoto-allow` hatch, and conventions pointer — as the decision detail, the same text `_build_decision` formerly placed in `retry_hint`. An ADVISE or ASK at an edge with no table entry, and the absence of findings, both write nothing, preserving the former no-decision behavior.
+
+`PostToolUse` was missing from the hook-to-edge map until Task 3's test-delta redirect became the first PostToolUse caller of `_emit_decision`. Before that caller existed, the defect was latent: the default-to-Pre fallback would have rendered the wrong edge's wire shape, including `hookEventName="PreToolUse"`, for a PostToolUse response. The explicit Post edge prevents that fallback.
+
+While building the D9 demo corpus, the test-delta redirect exposed a second gap. Its finding rendered correctly on the wire but was invisible to the audit trail and ledger chain, contradicting Task 2's invariant that every dispatch audit row is chain-appended. The redirect therefore records its finding through `_record_audit` as well as emitting it.

--- a/makoto/dispatch.py
+++ b/makoto/dispatch.py
@@ -154,13 +154,9 @@ def _note_host_dialect(state_dir: Path, session_id, notes: dict, host_event) -> 
 
 
 def _self_verify_chain(state_dir: Path) -> None:
-    """Task 2 slice 3 (owner: "Makoto should read its own ledger for verification -- its things
-    literally depend on it"). Re-derives the chain's own tamper-evidence at every dispatch, the
-    same every-event cadence Assay's kernel ran. OWNER DECISION (2026-07-07): advisory-first,
-    block-after-soak -- this ships ADVISORY ONLY (an on-the-record dispatch fact + a stderr line,
-    never a block) until real-session soak evidence earns the flip to block, itself a later,
-    separately-certified change. A clean or absent/empty chain is vacuously silent (verify_chain's
-    own contract). NEVER RAISES: a verification fault must not crash the hot path it protects."""
+    """Verify the ledger chain on every dispatch, advisory-only and never raising.
+
+    See docs/adr/0001-advisory-first-ledger-self-verification.md for the rollout decision."""
     try:
         from makoto.state import ledger as _ledger
         broken_at = _ledger.verify_chain()
@@ -213,12 +209,8 @@ def _connect_with_retry(db_path: Path):
     return None
 
 
-# The events table is a TRANSIENT evidence buffer, not a durable log: the only production
-# reader is _select_recent, which never looks back past a 1-hour same-session window. Anything
-# older is dead weight. We keep a small multiple of that window and prune the rest on every
-# ingest, which hard-bounds the table to ~one working window's worth of rows regardless of how
-# many sessions accumulate — the DB cannot grow without limit. Durable cross-session state lives
-# in ledger/commitments; the fire (blocking-event) log lives in audit.jsonl. Neither is touched.
+# The events table is a bounded transient evidence buffer, not a durable log.
+# See docs/adr/0002-bound-the-transient-events-buffer.md for the retention rationale.
 _EVENT_RETENTION_HOURS_DEFAULT = 1.5   # just over the 1-hour _select_recent read window (must stay >= it)
 
 
@@ -283,53 +275,25 @@ def _keyword_hit(pattern, raw_payload: str) -> bool:
 
 
 def _disabled_pattern_ids() -> frozenset[str]:
-    """parse MAKOTO_DISABLE_PATTERNS=<id>,<id>,... into a frozenset of pattern ids.
+    """Parse disabled canonical pattern ids; legacy aliases are not supported.
 
-    Epoch reset (2026-07-10): ids are their canonical family.name forms only -- the legacy-id
-    alias closure was retired with the alias table itself (operator state and configs predating
-    the reset are archived or wiped, so nothing left resolves through old ids)."""
+    See docs/adr/0008-retire-legacy-pattern-id-aliases.md for the epoch-reset decision."""
     raw = os.environ.get("MAKOTO_DISABLE_PATTERNS", "")
     return frozenset(p.strip() for p in raw.split(",") if p.strip())
 
 
 def _gates_enabled() -> bool:
-    """Both Stop gates — completion (UNFULFILLED: claimed X produced, X absent) and advance
-    (SELF-CONTRADICTING: claimed UNIVERSAL completion over an undischarged commitment) — BLOCK
-    live by default, governed by one switch. Each is validated FP-clean on the 1335-session
-    honest corpus:
-      - completion: production-claim binding drove worst-case FP 9.00% -> self-healing 2.42%,
-        TP intact (6/6), contamination canary passing.
-      - advance (flipped live 2026-06-01): 0 fires across all 1335 sessions after the
-        proposal-menu / code-fence / optional-parenthetical sourcing guards — every residual
-        FP traced to a never-built PROPOSAL the AI recommended, never a genuine commitment
-        (each of which discharged when its file was touched); TP intact (an undischarged firm
-        promise + universal-done still fires), the reason-bound retraction path clears
-        legitimately-dropped promises so honest re-prioritization never false-blocks.
-    MAKOTO_DISABLE_GATES=1 returns BOTH to shadow (still audited, no block) — the single escape
-    valve if a real-session false-block ever surfaces."""
+    """Return whether the corpus-validated Stop gates may block live.
+
+    See docs/adr/0003-enable-stop-gates-after-corpus-validation.md for the evidence and escape valve."""
     return os.environ.get("MAKOTO_DISABLE_GATES", "").strip().lower() not in ("1", "true", "yes", "on")
 
 
 @lru_cache(maxsize=1)
 def _blocking_gate_ids() -> frozenset:
-    """The Stop-gate finding ids eligible to reach `_emit_decision` at all (BLOCK or surfaced
-    ADVISE) when gates are enabled -- misnamed by history (kept for callers/tests already using
-    it), but NOT a hand-synced literal: DERIVED from `Check.may_block` via
-    `checks._loader.load_checks(edge="Stop")` (2026-07-10, retiring the former
-    `load_stopchecks()`/`GATE`-export mechanism). `may_block=True` marks exactly the checks that
-    used to export a `GATE` -- every one of them reaches this pipeline regardless of its own
-    `.level`/posture (the actual BLOCK-vs-ADVISE split happens inside `_emit_decision`/
-    `_worst_finding`, keyed on each Finding's own `.level`, unchanged by this migration).
-    `staleEstablisher`/`undeclaredFalsifiable` stay `may_block=False` ON PURPOSE: their
-    pattern_id must never enter this set at all, a STRUCTURAL exclusion independent of whatever
-    `.level` their own `run()` might ever compute -- the former GATE-export-presence mechanism
-    provided the exact same guarantee; this preserves it under the unified loader rather than
-    collapsing to a single posture-only signal.
+    """Derive and memoize the structurally blocking-eligible Stop-check ids.
 
-    Lazy + memoized: the loader imports every checks/*.py module, and Pre/PostToolUse dispatches
-    (the per-event hot path) never consult this set — as a module-level constant they paid that
-    import cost on every event. Stop dispatches load the same modules via run_stop_checks
-    anyway, so laziness changes no Stop behavior."""
+    See docs/adr/0004-unify-check-discovery-with-structural-block-eligibility.md for the loader migration."""
     return frozenset(c.id for c in load_checks(edge="Stop") if c.may_block)
 
 
@@ -368,10 +332,8 @@ def _run_predicates(conn, payload: dict, history: list, event_id: int,
     Predicate exceptions are captured to dispatch_errors.jsonl (audit.append_error)
     and skipped — they must never block agent work.
     """
-    # 2026-08-16: sourced directly from the checks/ catalog via registry --
-    # schema.load_prechecks() (the TOML/adapter shim) is retired. See
-    # tests/test_pre_tier_block_invariant.py for the BLOCK-only invariant this used to enforce
-    # at load time.
+    # The registry is the sole catalog; tests pin the Pre tier's BLOCK-only invariant.
+    # See docs/adr/0004-unify-check-discovery-with-structural-block-eligibility.md.
     patterns = load_precheck_catalog()
     disabled = _disabled_pattern_ids()
     candidates = [p for p in patterns
@@ -448,10 +410,8 @@ _OUTCOME_RANK = {verdict.BLOCK: 3, verdict.ASK: 2, verdict.ADVISE: 1, verdict.AL
 # serves both, keyed by the SAME edge string "Stop"/"SubagentStop" it also echoes as hook_name).
 _HOOK_TO_EDGE = {"PreToolUse": "Pre", "PostToolUse": "Post", "Stop": "Stop",
                 "SubagentStop": "SubagentStop"}
-# "PostToolUse" was missing until Task 3's test-delta redirect became the first PostToolUse
-# caller of _emit_decision -- previously latent (the .get(..., "Pre") fallback silently rendered
-# the WRONG edge's wire shape, with hookEventName="PreToolUse" on a PostToolUse response, had
-# anything ever called _emit_decision from the PostToolUse branch before now).
+# PostToolUse must have its own wire edge rather than falling back to Pre.
+# See docs/adr/0009-render-decisions-with-per-edge-wire-tables.md for the latent-fallback history.
 
 
 def _recheck_certificate_enabled() -> bool:
@@ -612,18 +572,8 @@ def _accumulate(conn, payload, payload_raw, event_id, state_dir) -> None:
                         retry_hint="")
         _ledger.record_update(conn, payload, event_id=event_id,
                               session_id=sid, root=state_dir)
-        # SPEC-5 live plan wiring (2026-07-23), two halves of the same gap: DECLARE and ADVANCE.
-        # Before this, the ONLY way to populate a plan was a `.claude/makoto-plan.jsonl` already
-        # sitting on disk BEFORE SessionStart fired -- nothing let Claude declare a plan
-        # mid-session at all -- AND even a SessionStart-declared plan could never CLOSE: Plan.
-        # mark_done/plan.persist_plan previously had zero live callers, so gate.contract_order's
-        # Stop remainder would block every subsequent Stop forever once any plan existed
-        # (contractOrder.py's Pre/Stop sides only ever READ the plan). Both halves key off the
-        # SAME resolution contractOrder.py's Pre-gap-guard already uses (`_event_location`/
-        # `Plan.resolve`), imported rather than duplicated -- this orchestrator carries no
-        # L2-import firewall (contractOrder.py's own docstring scopes that firewall to discovered
-        # Stop GATE modules, which dispatch.py is not). A no-op when the tool isn't a locating
-        # one, nothing resolves, or (advance side) no plan is declared.
+        # Live writes both declare and advance plans through contractOrder's shared resolution.
+        # See docs/adr/0006-wire-live-plan-declaration-and-advancement.md for the stranded-plan history.
         if payload.get("tool_name") in _LOCATING_TOOLS:
             from makoto.state import plan as _plan
             loc = _event_location(payload.get("tool_name", ""), payload.get("tool_input") or {})
@@ -640,11 +590,8 @@ def _accumulate(conn, payload, payload_raw, event_id, state_dir) -> None:
                         if nid is not None and nid in plan_obj.open_nodes():
                             plan_obj.mark_done(nid)
                             _plan.persist_plan(conn, sid, plan_obj)
-        # Task #19c (2026-07-10): the harness's own TaskCreate/TaskUpdate calls are the
-        # GROUND-TRUTH source for the plan-item store the prose sourcer only approximates
-        # -- an explicit create opens `task:<id>`, an explicit completed/deleted
-        # transition discharges it, and planItemDrift.py's ADVISORY Stop reminder then
-        # surfaces anything still open. Same fail-open umbrella as the ledger write.
+        # Harness task events are the ground truth for the plan-item store.
+        # See docs/adr/0006-wire-live-plan-declaration-and-advancement.md for the source decision.
         if payload.get("tool_name") in ("TaskCreate", "TaskUpdate"):
             from makoto.state import plan as _plan_items
             _plan_items.record_task_event(conn, sid, payload)
@@ -652,10 +599,8 @@ def _accumulate(conn, payload, payload_raw, event_id, state_dir) -> None:
             delta_finding = replace(delta_finding, source_event_id=event_id)
             _emit_decision([delta_finding], payload.get("hook_event_name", ""),
                            permission_mode=payload.get("permission_mode"))
-            # Found while building the D9 demo corpus: without this, the delta redirect's
-            # own finding was invisible to the audit trail and the chain -- contradicting
-            # Task 2's "every dispatch audit row is chain-appended" invariant. The redirect
-            # fired on the wire correctly; it just never left a record of having fired.
+            # Audit the delta finding as well as rendering it.
+            # See docs/adr/0009-render-decisions-with-per-edge-wire-tables.md for the discovered gap.
             _record_audit(state_dir, [delta_finding], payload)
     except Exception as exc:
         print(f"makoto.dispatch: ledger update failed (non-fatal): {exc}",
@@ -728,32 +673,13 @@ def main() -> int:
         _dispatch_fact(state_dir, "non_object_payload",
                        f"payload was {type(payload).__name__}, not a JSON object", blocked=True)
         return 2
-    # The host-dialect boundary (makoto.core.hostdialect): one hop from whatever spelling the
-    # host sent to the protocol every reader below assumes, applied here -- after the envelope
-    # has been proven evaluable (parseable, an object), before ANYTHING routes on or persists it
-    # -- so routing, gates, history, commitments and audit all see one canonical payload rather
-    # than each learning a second dialect. Cursor loads Claude-Code-compatible hook wiring but
-    # delivers camelCase (`preToolUse`): under the wildcard-law routing that ran the WRONG
-    # handler and persisted a row every history decoder was blind to (#19). The unevaluable-
-    # envelope refusals ABOVE are untouched: this normalizes a known event's capitalization, and
-    # `canonical_event` can only return a name already in HANDLERS, so a genuinely unknown event
-    # still takes exactly the wildcard path it took before.
+    # Normalize known host dialects before routing or persistence.
+    # See docs/adr/0007-normalize-host-dialects-at-the-dispatch-boundary.md for the boundary decision.
     host_event = payload.get("hook_event_name")
     payload, dialect_notes = hostdialect.normalize_payload(payload, HANDLERS)
     if dialect_notes:
-        # Persist WHAT WAS EVALUATED, not the host's spelling of it. The events table is the
-        # rolling substrate every history decoder reads, and those decoders key on the PAYLOAD's
-        # `hook_event_name`/`tool_name` -- ingesting the raw dialect envelope would leave
-        # `event.identical_retry`, `canon.recur`/`canon.timeout` and the claim-graph Bash
-        # evidence path reading zero matching rows for a Cursor session: admitted live, then
-        # invisible to every history-derived gate afterwards. Only rewritten when normalization
-        # actually changed something: a host already speaking the protocol still ingests its own
-        # bytes, byte-identical.
-        # ensure_ascii=False: the default escapes non-ASCII to \uXXXX, and this text is also what
-        # `_keyword_hit` prefilters the Pre catalog against as a raw substring scan -- an escaped
-        # row would make a non-ASCII keyword match on a protocol host and silently miss on a
-        # dialect host, the exact "a check that reads nothing" failure mode this boundary exists
-        # to prevent.
+        # Persist the normalized payload that was evaluated; preserve non-ASCII for keyword scans.
+        # See docs/adr/0007-normalize-host-dialects-at-the-dispatch-boundary.md for why.
         payload_raw = json.dumps(payload, ensure_ascii=False)
         _note_host_dialect(state_dir, payload.get("session_id"), dialect_notes, host_event)
     db_path = state_dir / "makoto.record.db"

--- a/makoto/registry.py
+++ b/makoto/registry.py
@@ -12,17 +12,8 @@ to import, has no `CHECK`, or whose `CHECK` fails this shape check is silently s
 (SPEC-5 Task 2 Step 6) is the one check whose job is to surface that skip as a finding instead
 of silence.
 
-This module is now the SOLE discovery path for both edges (2026-08-16): `schema.load_prechecks`
-has been retired, and `dispatch.py`'s Pre-tier predicate loop, Stop-finding loop, and
-`_blocking_gate_ids()` all call `load_checks(edge=...)` directly -- no second catalog, no
-schema.py-owned TOML/adapter layer left in the hot path. Stop-edge discovery has run entirely
-through this module since 2026-07-10 (the former `load_stopchecks()`/`GATE`-export mechanism,
-itself relocated here 2026-07-09 from the deleted `stopchecks/__init__.py` compat shim, was
-retired entirely then; every check that used to export a `GATE` now expresses the same Stop-edge
-surface as a plain `CHECK` (or an `EXTRA_CHECKS` entry for `contractOrder.py`'s dual Pre+Stop
-surface), with `may_block=True` where `GATE`'s presence used to imply blocking-eligibility -- see
-`Check.may_block`'s own docstring). `load_precheck_catalog()` (below) is the Pre-tier convenience
-wrapper that replaces `schema.load_prechecks()`'s old default-path behavior."""
+This module is the sole discovery path for every edge. See
+docs/adr/0004-unify-check-discovery-with-structural-block-eligibility.md for the migration history."""
 from __future__ import annotations
 
 import importlib
@@ -48,24 +39,12 @@ class Check:
     loader only duck-types `.id` / `.applies_at` / `.posture`, so a module exporting its own
     richer dataclass is equally discoverable.
 
-    `may_block` (added when `load_stopchecks()`/`GATE` was retired -- DESIGN DECISION): a Stop-edge
-    check is blocking-eligible only when BOTH `may_block is True` AND `posture == BLOCK` --
-    two independent signals, not one. Before this field existed, blocking-eligibility was
-    `posture == BLOCK` alone; `may_block` restores the second, structural layer the old
-    `GATE`-export-presence mechanism used to provide (a check with no `GATE` export could
-    never enter `_blocking_gate_ids()`, regardless of its posture -- see
-    `staleEstablisher.py`/`undeclaredFalsifiable.py`, which stay `may_block=False` on purpose:
-    their pattern_id must never enter the blocking-eligible set even if `posture` were ever
-    mistagged). A Pre-tier CHECK never sets this; it reads back False and is irrelevant there
-    (`_blocking_gate_ids()` only ever consults Stop-edge checks).
+    `may_block` is the Stop edge's structural blocking-eligibility signal, independent of posture.
+    See docs/adr/0004-unify-check-discovery-with-structural-block-eligibility.md for why both signals exist.
 
-    `keywords`/`retry_hint`/`description`/`predicate_module` (SPEC-C item 2, Pre-tier cutover,
-    backported from public 2026-07-10): additive fields consumed only by `schema.load_prechecks()`'s
-    loader-backed default path and by the Pre-tier predicates themselves (which read
-    `pattern.retry_hint`/`pattern.description` directly to build their Finding). A Stop-tier CHECK
-    never sets them and reads them back as their safe empty defaults. `predicate_module` is
-    conventionally set to the module's own `__name__` at CHECK-construction time
-    (self-referential, never a hand-typed/stale dotted string).
+    `keywords`/`retry_hint`/`description`/`predicate_module` are additive Pre-tier fields; Stop
+    checks retain their safe empty defaults. See
+    docs/adr/0004-unify-check-discovery-with-structural-block-eligibility.md for their cutover history.
 
     `eats` is the check's exact declared input signature. Stop checks name GateContext fields or
     derived properties; Pre checks use the flat predicate vocabulary current_event/history/
@@ -77,30 +56,8 @@ class Check:
     module/factory does not use that shape's required evidence primitive. Genuine one-offs keep
     the empty default only when their id and reason are registered explicitly in that law.
 
-    `layer` ("object" | "meta", default "object" -- DESIGN DECISION, session pass after the
-    envGatedAudit/selfMuteGuard/integritySuppressionFlag/selfWiredCheck grouping was proposed and
-    then narrowed on re-examination): "meta" marks a check whose ONLY possible trigger is
-    tampering with Makoto's own audit/enforcement machinery -- as opposed to "object", which
-    watches claims/artifacts about the assistant's OWN WORK. This is a real, distinct axis (is
-    the assistant lying about its work vs. is the assistant disabling the thing that would catch
-    the lie), but it is NOT a blanket tag for "checks that mention integrity/audit concepts" --
-    envGatedAudit.py and integritySuppressionFlag.py are GENERAL-PURPOSE detectors (any env-gated
-    audit code, any integrity-named suppression flag in a .toml, regardless of whether it has
-    anything to do with Makoto itself) and were deliberately left "object" rather than "meta":
-    tagging them meta and stripping their `makoto-allow` escape hatch would regress real FP-
-    tuning work (see each file's own "ACKNOWLEDGED FN" sections) for a case that isn't actually
-    self-referential. Only `content.self_mute_guard` and `gate.self_wired` are unambiguously
-    meta -- both can ONLY ever fire on Makoto's own settings.json/hook-wiring, nothing else.
-    `layer="meta"` is wired into `makoto.verdict.apply()`'s fold rules: a raw BLOCK from a meta
-    check floors at ASK under LOOSE/SILENT posture instead of softening further -- a loose
-    posture setting must not be able to suppress detection of tampering with the mechanism that
-    enforces posture itself (`dispatch._meta_check_ids()`/`dispatch._finding_layer()`, threaded
-    through `dispatch._emit_decision` and `verdict.recheck_certificate`). `content.self_mute_guard`
-    is Pre-tier with `level="error"` (Pre-tier is invariantly BLOCK), so this floor is LIVE for it
-    today; `gate.self_wired` is Stop-tier ADVISE (never BLOCK), so the floor is present but
-    currently inert for it. `tests/test_meta_layer.py` still asserts the two known-meta check ids
-    are tagged, catching drift if either is ever un-tagged or a new Makoto-self-referential check
-    ships untagged."""
+    `layer` distinguishes checks of the assistant's work from checks of Makoto's own enforcement.
+    See docs/adr/0005-distinguish-meta-enforcement-tampering.md for the scope and posture-floor decision."""
     id: str
     applies_at: str
     posture: str
@@ -248,11 +205,7 @@ def load_checks(edge: Optional[str] = None, *, package_dir: Optional[Path] = Non
 
 
 def load_precheck_catalog(*, package_dir: Optional[Path] = None) -> list:
-    """Every live Pre-tier `CHECK` with a `predicate_module` set -- the keyword-prefiltered
-    detector catalog `dispatch._run_predicates` (and `install.py`/`__main__.py`'s catalog
-    inspection commands) consume. Replaces `schema.load_prechecks()`'s old default-path
-    behavior (retired 2026-08-16): the invariant it used to enforce at load time (every
-    Pre-tier check must be `posture == BLOCK` -- makoto has no non-blocking Pre tier) is no
-    longer re-checked here on every hot-path call; it is pinned instead by
-    `tests/test_pre_tier_block_invariant.py`, which asserts it against this exact catalog."""
+    """Return live Pre-tier predicate checks; tests pin their BLOCK-only invariant.
+
+    See docs/adr/0004-unify-check-discovery-with-structural-block-eligibility.md for the cutover."""
     return [c for c in load_checks(edge="Pre", package_dir=package_dir) if c.predicate_module]


### PR DESCRIPTION
Same prose-to-ADR extraction landed on `makoto-dev` (PR #86), applied by hand against this repo's own current `dispatch.py`/`registry.py` — this repo carries github-issue fixes dev doesn't, so the dev diff couldn't be applied mechanically.

Compresses long inline docstrings/comments to a short summary plus a pointer to a new `docs/adr/*.md` file carrying the full design history. No behavioral change — diff is comment/docstring-only, verified by review.

- `dispatch.py`: 783 → 709 lines
- `registry.py`: 258 → 211 lines
- 9 new ADR files under `docs/adr/`

Full suite: 1796 passed, 5 skipped, 1 xfailed (unchanged from baseline, independently rerun).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtJRGMHKr3C27EwYZdRXTd)_