### PR TITLE
Close MAKOTO_INVOCATION_RX's _dispatch_configchange_shim.sh over-match

### DIFF
--- a/makoto/substrate/wiring.py
+++ b/makoto/substrate/wiring.py
@@ -28,9 +28,17 @@ PLUGIN_MANIFEST_RELPATH = os.path.join("hooks", "hooks.json")
 # makoto's own hook-command invocation tokens -- anchored to the forms it actually installs, and
 # ONLY those: `~/.claude/makoto_state/dispatch.sh` (settings.json wiring, two-segment path so a
 # bare `dispatch.sh` living anywhere else does not match), `${CLAUDE_PLUGIN_ROOT}/makoto/
-# _dispatch_shim.sh` and `_dispatch_configchange_shim.sh` (the plugin-manifest shim forms -- see
-# hooks/hooks.json), and the module forms `-m makoto.dispatch` / `-m makoto.configchange` (the
-# two hook entrypoints; `\b` so `makoto.dispatcher_v2` never matches).
+# _dispatch_shim.sh` (the ONE plugin-manifest shim form -- see hooks/hooks.json, which wires
+# every declared event to that single script), and the module forms `-m makoto.dispatch` /
+# `-m makoto.configchange` (the two hook entrypoints; `\b` so `makoto.dispatcher_v2` never
+# matches).
+#
+# Deliberately does NOT admit `_dispatch_configchange_shim.sh`: this layout has no such script
+# (configchange is reached as `-m makoto.configchange`, its adapter merged into
+# makoto/configchange.py). An ownership predicate that recognizes a filename nothing installs is
+# a standing licence to delete a file makoto did not write -- the exact over-match this regex
+# exists to close, so the alternative is dropped rather than kept "just in case". If a
+# configchange shim is ever installed, this regex is the one place that has to learn about it.
 #
 # This ONE regex is the single source for "is this command makoto's" -- exported for
 # `checks/selfMuteGuard` to import rather than maintain its own copy. Two regexes answering one
@@ -45,7 +53,7 @@ PLUGIN_MANIFEST_RELPATH = os.path.join("hooks", "hooks.json")
 # case-sensitive replacement would silently un-recognize a form makoto had already installed.
 MAKOTO_INVOCATION_RX = re.compile(
     r"makoto_state[/\\]dispatch\.sh"
-    r"|_dispatch(?:_configchange)?_shim\.sh"
+    r"|_dispatch_shim\.sh"
     r"|-m\s+makoto\.(?:dispatch|configchange)\b",
     re.IGNORECASE)
 

--- a/tests/test_self_wired_check.py
+++ b/tests/test_self_wired_check.py
@@ -117,6 +117,19 @@ def test_entry_dispatches_to_makoto_matches_install_semantics():
     assert _entry_dispatches_to_makoto("not-a-dict") is False
 
 
+def test_invocation_regex_does_not_admit_a_shim_this_layout_never_installs():
+    """This layout reaches configchange as `-m makoto.configchange` (merged into
+    makoto/configchange.py) -- it has no `_dispatch_configchange_shim.sh`. Recognizing that
+    filename as makoto's own would be a standing licence to delete a file makoto never wrote,
+    the exact over-match MAKOTO_INVOCATION_RX exists to close."""
+    assert _entry_dispatches_to_makoto(
+        {"hooks": [{"type": "command",
+                     "command": "sh /some/path/_dispatch_configchange_shim.sh"}]}) is False
+    assert _entry_dispatches_to_makoto(
+        {"hooks": [{"type": "command",
+                     "command": "${CLAUDE_PLUGIN_ROOT}/makoto/_dispatch_shim.sh"}]}) is True
+
+
 def test_check_export_shape():
     assert CHECK.id == "gate.self_wired"
     assert CHECK.applies_at == "Stop"


### PR DESCRIPTION
Comparing this session's dev-side port of the security fix (`makoto-dev#87`) against public's existing regex surfaced a real, live gap: public's `MAKOTO_INVOCATION_RX` still admits `_dispatch_configchange_shim.sh`, a script this layout has never installed (configchange is reached as `-m makoto.configchange`, merged into `makoto/configchange.py`). Recognizing that filename as makoto's own is a standing licence to delete a file makoto never wrote.

RED confirmed before the fix (fix stashed, real pytest run): `AssertionError: assert True is False`. GREEN after: 27/27 in `test_self_wired_check.py`, full suite 1797 passed, 5 skipped, 1 xfailed, exit 0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtJRGMHKr3C27EwYZdRXTd)_