### PR TITLE
docs: point the Siblings section at the renamed Courthouse marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ python -m makoto uninstall                   # removes old settings.json entries
 
 Makoto is one of three engines that split one taxonomy — act, sequence, statement — and share
 nothing else. Each installs alone; none inherits or implies the others' coverage. All three
-install from the [Tribunal](https://github.com/Clear-Sights/Tribunal) marketplace:
-`claude plugin marketplace add Clear-Sights/Tribunal`.
+install from the [Courthouse](https://github.com/Clear-Sights/Courthouse) marketplace:
+`claude plugin marketplace add Clear-Sights/Courthouse`.
 
 | Engine | Judges | One line |
 |---|---|---|


### PR DESCRIPTION
README-only: the Siblings section's marketplace link and install command now reference Clear-Sights/Courthouse (renamed from Tribunal).

---
_Generated by [Claude Code](https://claude.ai/code/session_017BNMFots5HGn4cTQMWQSxr)_