### PR TITLE
Keep failure evidence out of success-shaped state; budget transients beyond canon.recur

### DIFF
--- a/makoto/checks/canonTimeoutRecur.py
+++ b/makoto/checks/canonTimeoutRecur.py
@@ -18,7 +18,9 @@ Two primitives are installed:
 
   * canon.timeout — `timed_out_at_turn_end`: the turn closed with the LAST decoded call in a
     direct error state (interrupted or a self-emitted error code) — NOT "any call errored
-    somewhere", because a resolved-then-fixed error must stay silent.
+    somewhere", because a resolved-then-fixed error must stay silent. One confidently transient,
+    non-interrupted failure is also silent; an explicit harness interruption and deterministic or
+    uncertain errors retain the one-call bar.
   * canon.recur   — `recur_stuck`: the SAME tool call (identical tool_name + byte-identical
     tool_input) re-issued in a CONSECUTIVE run of length >=2 where EVERY call in that run is in
     a direct error state — a stuck retry loop with nothing changed between attempts. A run of
@@ -85,7 +87,7 @@ import json
 from typing import Iterable, List
 
 from makoto.vocab import Finding
-from makoto.kit import classify_failure, decode_history_event
+from makoto.kit import classify_failure, decode_history_event, failure_terminal_result
 
 # A Call is one paired tool event in protocol form: {"name": tool_name, "input": tool_input,
 # "result": tool_response} — tool_input/tool_response are kept as full DICTS (not the flattened
@@ -233,8 +235,17 @@ def timed_out_at_turn_end(calls: list) -> bool:
     Sequence-level, NOT per-call EXISTS: the signal is "left unresolved AT TURN-END", not "an
     error occurred somewhere in the turn". A call that errored but was RESOLVED before the turn
     closed — a later call succeeded, e.g. a flaky command re-run that finally passed — is not a
-    silent unresolved error, so it stays silent."""
-    return bool(calls) and timed_out(calls[-1])
+    silent unresolved error, so it stays silent. Likewise, one non-interrupted failure whose error
+    text is confidently transient is a recoverable blip, not an unresolved-error turn end. An
+    explicit harness interruption still fires even when its accompanying text sounds transient;
+    deterministic and uncertain errors retain the ordinary one-call bar."""
+    if not calls:
+        return False
+    last = calls[-1]
+    if interrupted(last):
+        return True
+    error = self_error_code(last)
+    return bool(error) and classify_failure(str(error)) is not False
 
 
 def _canon_input(inp) -> str:
@@ -284,10 +295,7 @@ def _decode_row(row):
     ti = ev.get("tool_input")
     ti = ti if isinstance(ti, dict) else {}
     if etype == "PostToolUseFailure":
-        return ("PostToolUse", name, ti, {
-            "error": ev.get("error") or "tool call failed",
-            "interrupted": bool(ev.get("is_interrupt")),
-        })
+        return ("PostToolUse", name, ti, failure_terminal_result(ev))
     if etype == "PostToolUse":
         tr = ev.get("tool_response")
         return ("PostToolUse", name, ti, tr if isinstance(tr, dict) else {})
@@ -356,7 +364,8 @@ CANON_SEQ_PRIMITIVES: dict = {
     "timeout": (
         timed_out_at_turn_end,
         "A tool call ended in a direct error state — interrupted or a self-emitted error code — "
-        "and the turn closed without resurfacing or resolving it.",
+        "and the turn closed without resurfacing or resolving it; confidently transient, "
+        "non-interrupted failures receive one retry opportunity.",
         # Task 0b part (a): the OLD hint said "...or state explicitly why the error is acceptable"
         # -- a discharge the detector cannot honor. timed_out_at_turn_end reads ONLY calls[-1]
         # (purely structural); prose can never change it. The two REAL discharges: a later

--- a/makoto/checks/claimedRunningAbsent.py
+++ b/makoto/checks/claimedRunningAbsent.py
@@ -7,7 +7,7 @@ from makoto.vocab import (
     _NEGATION_RX, _ADV_FORWARD_RX, _SENTENCE_SPLIT_RX,
 )
 from makoto.substrate.claims import _code_spans
-from makoto.kit import decode_history_event
+from makoto.kit import decode_history_event, failure_terminal_result
 
 # gate.claimed_running -- the assistant claims an ONGOING running/live/listening/serving state
 # for a process/service ("the server is running", "it's up and running", "now listening on port
@@ -97,10 +97,7 @@ def _bash_postuse_calls(history):
         tool_input = ev.get("tool_input")
         cmd = str(tool_input.get("command", "") or "") if isinstance(tool_input, dict) else ""
         if event_type == "PostToolUseFailure":
-            yield cmd, {
-                "interrupted": bool(ev.get("is_interrupt")),
-                "error": ev.get("error"),
-            }, True
+            yield cmd, failure_terminal_result(ev), True
             continue
         tr = ev.get("tool_response")
         yield cmd, (tr if isinstance(tr, dict) else {}), False
@@ -110,14 +107,16 @@ def _latest_process_call_failed(history) -> Optional[bool]:
     """None iff no process-lifecycle-shaped Bash call (_PROCESS_LIFECYCLE_CMD_RX) ever ran this
     session -- the claim has zero grounding. Else True/False for whether the MOST RECENT such
     call ended in a direct agnostic error state: `interrupted`, a recorded non-zero exit code, or
-    a PostToolUseFailure top-level `error` terminal -- protocol fields only, with no exit-code
-    SEMANTICS guess beyond "non-zero" and no language token. Latest-wins, like
+    a PostToolUseFailure terminal -- protocol fields only, with no exit-code SEMANTICS guess
+    beyond "non-zero" and no language token. The failure event type itself is sufficient evidence;
+    its optional error text need not be present, and `failure_terminal_result` supplies generic
+    text only so every decoder receives one stable shape. Latest-wins, like
     record.ledger.latest_testrun: a later clean re-check supersedes an earlier failed attempt."""
     verdict = None
     for cmd, tr, is_failure_terminal in _bash_postuse_calls(history):
         if not _PROCESS_LIFECYCLE_CMD_RX.search(cmd):
             continue
-        direct_error = is_failure_terminal and "error" in tr
+        direct_error = is_failure_terminal
         interrupted = tr.get("interrupted") is True
         exit_code = tr.get("exitCode", tr.get("exit"))
         verdict = bool(direct_error or interrupted or (exit_code is not None and exit_code != 0))

--- a/makoto/checks/identicalRetryInterdiction.py
+++ b/makoto/checks/identicalRetryInterdiction.py
@@ -25,7 +25,7 @@ import json
 from typing import Optional
 
 from makoto.kit import classify_failure
-from makoto.kit import bash_output_text, decode_history_event
+from makoto.kit import bash_output_text, decode_history_event, failure_terminal_result
 from makoto.vocab import Finding
 from makoto.registry import Check
 
@@ -59,7 +59,7 @@ def _most_recent_completed_bash_call(history) -> Optional[tuple]:
         return None
     ti = ev.get("tool_input", {}) or {}
     if event_type == "PostToolUseFailure":
-        return ti, str(ev.get("error") or "tool call failed")
+        return ti, failure_terminal_result(ev)["error"]
     tr = ev.get("tool_response", {}) or {}
     text = bash_output_text(tr) if isinstance(tr, dict) else str(tr)
     return ti, text

--- a/makoto/checks/runIntentUnfulfilled.py
+++ b/makoto/checks/runIntentUnfulfilled.py
@@ -4,7 +4,7 @@ from typing import Optional
 from makoto.vocab import Finding
 from makoto.vocab import _RUN_INTENT_CLAIM_RX, _RUN_INTENT_IDIOM_VETO_RX, _NEGATION_RX
 from makoto.substrate.claims import _code_spans
-from makoto.kit import decode_history_row
+from makoto.kit import decode_history_event, decode_history_row
 
 # gate.run_promised -- the forward-looking sibling of gate.claimed_running: the immediately PRIOR
 # turn's own message promised a first-person run-intent action ("I'll run the tests", "I'm going
@@ -87,7 +87,7 @@ def _last_stop_index(history) -> Optional[int]:
     documents them ("Gates evaluate on Stop AND SubagentStop")."""
     idx = None
     for i, row in enumerate(history or ()):
-        ev = decode_history_row(row)
+        ev = decode_history_event(row)
         if isinstance(ev, dict) and ev.get("hook_event_name") in ("Stop", "SubagentStop"):
             idx = i
     return idx
@@ -97,7 +97,7 @@ def _bash_call_after(history, idx: int) -> bool:
     """True iff a settled Bash terminal appears anywhere after position `idx` in `history`.
     Success is irrelevant: this gate asks whether the promised run happened, not whether it won."""
     for row in list(history or ())[idx + 1:]:
-        ev = decode_history_row(row)
+        ev = decode_history_event(row)
         # INCLUDE failed terminals: ran-and-failed still discharges a promise merely to run.
         if (isinstance(ev, dict)
                 and ev.get("hook_event_name") in ("PostToolUse", "PostToolUseFailure")

--- a/makoto/dispatch.py
+++ b/makoto/dispatch.py
@@ -534,11 +534,19 @@ def _admit_plan(conn, payload, payload_raw, event_id, state_dir) -> None:
 
 
 def _accumulate(conn, payload, payload_raw, event_id, state_dir) -> None:
-    """PostToolUse / PostToolUseFailure — accumulation: store the event (already done by
-    _ingest_event upstream so history-walking predicates can see successful and failed settled
-    calls) and record the `update` ledger row (Write/Edit touch, Bash result; latest-wins).
-    No predicate evaluation and no block — settled tool events accumulate, never decide.
+    """Settled-tool accumulation, with failure evidence kept out of success-shaped state.
+
+    Both PostToolUse terminals have already been stored by ``_ingest_event`` before this handler
+    runs, so history-walking decoders can see successes and failures alike.  Only a successful
+    PostToolUse may mutate the update ledger, advance a plan, record a task event, or emit a test
+    delta.  PostToolUseFailure is evidence that the operation did *not* land; retaining it in
+    history while returning here prevents a failed Write/Bash from discharging gates or
+    latest-wins clobbering an earlier real result.
+
+    No predicate evaluation and no block — settled tool events accumulate evidence, never decide.
     See docs/adr/0013-posttooluse-accumulation.md for the migration history."""
+    if payload.get("hook_event_name") == "PostToolUseFailure":
+        return
     try:
         from makoto.state import ledger as _ledger
         from makoto.kit import bash_output_text, is_test_runner

--- a/makoto/kit.py
+++ b/makoto/kit.py
@@ -236,6 +236,24 @@ def decode_history_event(row):
     return ev
 
 
+def failure_terminal_result(ev) -> dict:
+    """Normalize a PostToolUseFailure event to the shared result-dict shape.
+
+    The shape is always ``{"error": <non-empty str>, "interrupted": <bool>}``.  A terminal
+    whose optional error detail is absent gets the deliberately generic ``"tool call failed"``
+    fallback: the event type is itself evidence that the call failed, but generic wording stays
+    unclassified by :func:`classify_failure` and therefore cannot invent a deterministic retry
+    block.  Keeping this normalization here prevents history decoders from drifting on whether a
+    missing error means failure, success, or uncertainty.
+    """
+    event = ev if isinstance(ev, dict) else {}
+    error = event.get("error")
+    return {
+        "error": str(error) if error else "tool call failed",
+        "interrupted": bool(event.get("is_interrupt")),
+    }
+
+
 def bash_output_text(tool_response) -> str:
     """extract captured stdout+stderr from a Bash tool_response.
 

--- a/makoto/substrate/_canonAtoms.py
+++ b/makoto/substrate/_canonAtoms.py
@@ -38,7 +38,13 @@ from typing import Dict, Iterable, List, Tuple
 
 from makoto.vocab import _SUCCESS_SUMMARY_RX
 from makoto.substrate.claims import whole_suite_pass_claim
-from makoto.kit import bash_output_text, decode_history_event, is_failing_testrun
+from makoto.kit import (
+    bash_output_text,
+    classify_failure,
+    decode_history_event,
+    failure_terminal_result,
+    is_failing_testrun,
+)
 from makoto.core._shell import (
     _effective_argv,
     _git_subcommand,
@@ -72,10 +78,7 @@ def _decode_row(row):
     ti = ev.get("tool_input")
     ti = ti if isinstance(ti, dict) else {}
     if event_type == "PostToolUseFailure":
-        tr = {
-            "error": ev.get("error") or "tool call failed",
-            "interrupted": bool(ev.get("is_interrupt")),
-        }
+        tr = failure_terminal_result(ev)
     else:
         tr = ev.get("tool_response")
         tr = tr if isinstance(tr, dict) else {}
@@ -299,8 +302,22 @@ def _existing(calls: Iterable[Call], pred) -> bool:
 
 
 def atom_tool_timeout(calls, text) -> bool:
-    return _existing(calls, lambda c: c["result"].get("interrupted") is True
-                     or bool(c["result"].get("error") or c["result"].get("error_code")))
+    """A harness interruption or non-transient direct error occurred.
+
+    One confidently transient, non-interrupted failure terminal is deliberately excluded: it is
+    evidence that the call failed, but not enough evidence that the turn timed out. Explicit
+    harness aborts still count even when their accompanying error text looks transient, while
+    deterministic and uncertain errors retain the ordinary one-call bar. This matches
+    canon.timeout's transient budget without hiding interrupted calls from the fingerprint atoms.
+    """
+    def _is_timeout(c):
+        result = c["result"]
+        if result.get("interrupted") is True:
+            return True
+        error = result.get("error") or result.get("error_code")
+        return bool(error) and classify_failure(str(error)) is not False
+
+    return _existing(calls, _is_timeout)
 
 
 def atom_test_run_red(calls, text) -> bool:

--- a/tests/lib/test_io.py
+++ b/tests/lib/test_io.py
@@ -4,7 +4,8 @@ import purity is enforced by tests/test_import_direction.py, seam 7.)"""
 
 def test_io_exports_renamed_symbols():
     from makoto import kit as mio
-    for name in ("raw_payload_str", "bash_output_text", "is_failing_testrun", "is_test_runner"):
+    for name in ("raw_payload_str", "bash_output_text", "is_failing_testrun", "is_test_runner",
+                 "failure_terminal_result"):
         assert callable(getattr(mio, name)), name
 
 
@@ -21,6 +22,17 @@ def test_io_behaviour_preserved():
     assert is_failing_testrun("=== 681 passed, 3 xfailed ===") is False
     assert is_test_runner("python -m pytest tests/ -q") is True
     assert is_test_runner("cat tests/old_failure.log") is False
+
+
+def test_failure_terminal_result_has_one_stable_shape_and_safe_fallback():
+    from makoto.kit import classify_failure, failure_terminal_result
+
+    assert failure_terminal_result({"error": "Connection error", "is_interrupt": True}) == {
+        "error": "Connection error", "interrupted": True,
+    }
+    missing_detail = failure_terminal_result({"is_interrupt": False})
+    assert missing_detail == {"error": "tool call failed", "interrupted": False}
+    assert classify_failure(missing_detail["error"]) is None
 
 
 # --- behavioral cases redistributed verbatim from the dissolved tests/predicates/test_helpers.py (idealization: name<->content) ---

--- a/tests/test_campaign_dedup.py
+++ b/tests/test_campaign_dedup.py
@@ -45,6 +45,21 @@ def test_identical_retry_sees_a_wrapper_only_row_like_its_sibling():
     assert _most_recent_completed_bash_call([row]) is not None
 
 
+def test_failure_terminal_result_is_one_shared_normalizer():
+    from makoto.kit import failure_terminal_result
+    from makoto.checks import canonTimeoutRecur, claimedRunningAbsent
+    from makoto.checks import identicalRetryInterdiction
+    from makoto.substrate import _canonAtoms
+
+    for module in (
+        canonTimeoutRecur,
+        claimedRunningAbsent,
+        identicalRetryInterdiction,
+        _canonAtoms,
+    ):
+        assert module.failure_terminal_result is failure_terminal_result
+
+
 # ---- dd5c436: shared lexicon + pushed-branch extraction ---------------------------------------
 def test_offer_and_first_person_regexes_are_the_one_vocab_object():
     from makoto.vocab import _OFFER_COND_RX, _FIRST_PERSON_RX

--- a/tests/test_canon_fingerprints.py
+++ b/tests/test_canon_fingerprints.py
@@ -168,6 +168,24 @@ def test_nosrc_green_timeout():
            [_SOURCE_EDIT_ROW, _GREEN_ROW, _TIMEOUT_ROW], "")
 
 
+def test_nosrc_green_timeout_silent_on_one_transient_failure_terminal():
+    """Verification-only turn: green tests, no source edits, then one recoverable MCP blip."""
+    transient = {"payload": {
+        "hook_event_name": "PostToolUseFailure",
+        "tool_name": "mcp__svc__poll",
+        "tool_input": {"query": "status"},
+        "error": "Connection error",
+        "is_interrupt": False,
+    }}
+    history = [_GREEN_ROW, transient]
+    atoms = compute_atoms(calls_from_history(history), "")
+    assert atoms["test_run_green"] is True
+    assert atoms["source_edited"] is False
+    assert atoms["tool_timeout"] is False
+    assert "nosrc_green_timeout" not in _fired_names(history, "")
+    assert canon_fingerprint_block_gate("", history) == []
+
+
 def test_notestedit_destruct():
     _check("notestedit_destruct", [_DESTRUCTIVE_ROW], "",
            [_TEST_EDIT_ROW, _DESTRUCTIVE_ROW], "")

--- a/tests/test_canon_primitives.py
+++ b/tests/test_canon_primitives.py
@@ -230,6 +230,24 @@ def test_decode_row_normalizes_posttoolusefailure_with_real_error_text():
         {"error": "Connection error", "interrupted": True})
 
 
+def test_timeout_at_turn_end_silent_on_last_transient_failure_terminal():
+    row = _failure_tuple_row(1, "mcp__svc__poll", {"query": "status"},
+                             "Connection error")
+    assert timed_out_at_turn_end(calls_from_history([row])) is False
+
+
+def test_timeout_at_turn_end_fires_on_last_validation_error_failure_terminal():
+    row = _failure_tuple_row(1, "mcp__svc__poll", {"query": "status"},
+                             "ValidationError: invalid tool input")
+    assert timed_out_at_turn_end(calls_from_history([row])) is True
+
+
+def test_timeout_at_turn_end_interrupted_failure_still_fires_with_transient_error_text():
+    row = _failure_tuple_row(1, "mcp__svc__poll", {"query": "status"},
+                             "Connection error", is_interrupt=True)
+    assert timed_out_at_turn_end(calls_from_history([row])) is True
+
+
 def test_issue_28_transient_eeo_failure_rows_do_not_fire_recur():
     same = {"query": "status"}
     changed = {"query": "status, please retry"}

--- a/tests/test_claimed_running_gate.py
+++ b/tests/test_claimed_running_gate.py
@@ -138,6 +138,13 @@ def test_failed_process_start_terminal_is_misreported_not_unsubstantiated():
     assert "most recently recorded" in f.message
 
 
+def test_failure_terminal_without_error_text_is_still_failure_evidence():
+    hist = [_failure("npm run dev", error=None, is_interrupt=False)]
+    assert _latest_process_call_failed(hist) is True
+    f = claimed_running_gate("I started the server. It is now running.", history=hist)
+    assert f is not None and "most recently recorded" in f.message
+
+
 def test_successful_post_with_benign_error_key_is_not_a_failure_terminal():
     hist = [_post("npm run dev", stdout="listening", exitCode=0, error=None)]
     assert _latest_process_call_failed(hist) is False

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -399,6 +399,41 @@ def test_dispatch_posttooluse_write_records_ledger_touch(tmp_path):
     assert row is not None and row["kind"] == "touched", f"expected touched row; got {row!r}"
 
 
+def test_dispatch_failed_write_stays_in_history_without_recording_a_touch(tmp_path):
+    """PostToolUseFailure is failure evidence, not a successful filesystem update.
+
+    The terminal must remain in ``events`` for history decoders, but must not create the
+    success-shaped ``touched`` row that completion/dropped/advance gates treat as discharge.
+    """
+    import sqlite3
+    from makoto.state import ledger
+
+    state_dir = _setup_state(tmp_path)
+    payload = {
+        "hook_event_name": "PostToolUseFailure",
+        "tool_name": "Write",
+        "session_id": "failed_ledger_write",
+        "cwd": str(tmp_path),
+        "tool_input": {"file_path": "src/never-created.py", "content": "x"},
+        "error": "permission denied",
+        "is_interrupt": False,
+    }
+    rc, out = _run_dispatch(state_dir, payload)
+    assert rc == 0 and out == ""
+
+    conn = sqlite3.connect(str(state_dir / "makoto.record.db"))
+    try:
+        assert ledger.read_key(conn, "src/never-created.py") is None
+        event_type, raw = conn.execute(
+            "SELECT event_type, payload FROM events WHERE session_id = ?",
+            ["failed_ledger_write"],
+        ).fetchone()
+    finally:
+        conn.close()
+    assert event_type == "PostToolUseFailure"
+    assert json.loads(raw)["error"] == "permission denied"
+
+
 def test_dispatch_posttooluse_bash_records_ledger_value(tmp_path):
     """PostToolUse Bash -> a `value` ledger row keyed by the path token in the command."""
     import sqlite3
@@ -421,6 +456,56 @@ def test_dispatch_posttooluse_bash_records_ledger_value(tmp_path):
         conn.close()
     assert row is not None and row["kind"] == "value", f"expected value row; got {row!r}"
     assert "120 tests/auth_test.py" in (row["value"] or "")
+
+
+def test_dispatch_failed_terminal_does_not_clobber_prior_failing_testrun(tmp_path):
+    """A failed hook terminal has no runner output and cannot supersede a real red result."""
+    import sqlite3
+    from makoto.kit import is_failing_testrun
+    from makoto.state import ledger
+
+    state_dir = _setup_state(tmp_path)
+    sid = "failed_testrun_terminal"
+    command = "python -m pytest tests/ -q"
+    red = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "session_id": sid,
+        "cwd": str(tmp_path),
+        "tool_input": {"command": command},
+        "tool_response": {
+            "stdout": "=== 2 failed, 9 passed in 3.0s ===",
+            "stderr": "",
+            "exitCode": 1,
+        },
+    }
+    failed_terminal = {
+        "hook_event_name": "PostToolUseFailure",
+        "tool_name": "Bash",
+        "session_id": sid,
+        "cwd": str(tmp_path),
+        "tool_input": {"command": command},
+        "error": "Connection error",
+        "is_interrupt": False,
+    }
+    assert _run_dispatch(state_dir, red) == (0, "")
+    assert _run_dispatch(state_dir, failed_terminal) == (0, "")
+
+    conn = sqlite3.connect(str(state_dir / "makoto.record.db"))
+    try:
+        latest = ledger.latest_testrun(conn, sid)
+        source_event_id = conn.execute(
+            "SELECT source_event_id FROM ledger WHERE session_id = ? AND kind = 'testrun'",
+            [sid],
+        ).fetchone()[0]
+        event_types = [row[0] for row in conn.execute(
+            "SELECT event_type FROM events WHERE session_id = ? ORDER BY id", [sid]
+        )]
+    finally:
+        conn.close()
+    assert is_failing_testrun(latest) is True
+    assert source_event_id == 1
+    assert event_types == ["PostToolUse", "PostToolUseFailure"]
 
 
 def test_dispatch_test_delta_redirect_advises_on_newly_failing_test(tmp_path):
@@ -683,6 +768,59 @@ def test_dispatch_contract_order_gate_silent_after_locating_write_advances_the_p
     rc, out = _run_dispatch(state_dir, stop)
     assert rc == 0
     assert out == "", f"contract_order must stay silent once the only declared node is advanced: {out}"
+
+
+def test_dispatch_failed_locating_write_leaves_plan_node_open(tmp_path):
+    """A failed Write at a node's ``where`` is not plan progress; the Stop remainder stays."""
+    import sqlite3
+    from makoto.state import plan as plan_store
+
+    state_dir = _setup_state(tmp_path)
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    (claude_dir / "makoto-plan.jsonl").write_text(
+        '{"what":"Write","passthrough":"auth.py","where":"auth.py","id":"n1"}\n'
+    )
+    session = "contract_order_failed_advance"
+    start = {
+        "hook_event_name": "SessionStart",
+        "session_id": session,
+        "cwd": str(tmp_path),
+        "source": "startup",
+    }
+    assert _run_dispatch(state_dir, start) == (0, "")
+    failed_write = {
+        "hook_event_name": "PostToolUseFailure",
+        "session_id": session,
+        "cwd": str(tmp_path),
+        "tool_name": "Write",
+        "tool_input": {"file_path": "auth.py", "content": "def login(): ...\n"},
+        "error": "permission denied",
+        "is_interrupt": False,
+    }
+    assert _run_dispatch(state_dir, failed_write) == (0, "")
+
+    conn = sqlite3.connect(str(state_dir / "makoto.record.db"))
+    try:
+        stored = plan_store.load_plan(conn, session)
+    finally:
+        conn.close()
+    assert stored is not None
+    assert stored.open_nodes() == {"n1"}
+
+    stop = {
+        "hook_event_name": "Stop",
+        "session_id": session,
+        "cwd": str(tmp_path),
+        "last_assistant_message": "Done for now.",
+    }
+    rc, out = _run_dispatch(state_dir, stop)
+    assert rc == 0 and out
+    rows = [json.loads(line) for line in (state_dir / "audit.jsonl").read_text().splitlines()]
+    contract_fires = [row for row in rows if "gate.contract_order" in row.get("pattern_fires", [])]
+    assert contract_fires
+    assert any("n1" in finding["message"] for finding in contract_fires[-1]["findings"]
+               if finding["pattern_id"] == "gate.contract_order")
 
 
 def test_dispatch_contract_order_gate_still_blocks_on_the_untouched_sibling_node(tmp_path):

--- a/tests/test_run_intent_gate.py
+++ b/tests/test_run_intent_gate.py
@@ -7,6 +7,8 @@ never containing the row for the Stop currently being evaluated, so a promise ma
 only ever be checked starting at the NEXT one. FP-safe by design: closed first-person-auxiliary +
 closed process-lifecycle-verb lexicon (mirroring gate.claimed_running's own verb set), plus the
 usual quoted/negated/question/idiom clause guards."""
+import json
+
 from makoto.checks.runIntentUnfulfilled import (
     run_promised_gate, _run_intent_claim, _last_stop_index, _bash_call_after,
 )
@@ -38,6 +40,11 @@ def _failure(cmd="pytest -q", *, error="Connection error", is_interrupt=False):
     return {"payload": {"hook_event_name": "PostToolUseFailure", "tool_name": "Bash",
                          "tool_input": {"command": cmd}, "error": error,
                          "is_interrupt": is_interrupt}}
+
+
+def _wrapper_typed(event_type, **payload):
+    """A production events-table row whose event type lives only on the wrapper column."""
+    return (1, "ts", event_type, "/repo", json.dumps(payload))
 
 
 # --- TP: _run_intent_claim recognizes the claim shape (every aux x every verb family) ---
@@ -209,6 +216,12 @@ def test_last_stop_index_counts_subagent_stop_too():
     assert _last_stop_index(hist) == 0
 
 
+def test_last_stop_index_sees_a_wrapper_typed_stop_row():
+    hist = [_wrapper_typed(
+        "Stop", session_id="s1", last_assistant_message="I'll run the tests now.")]
+    assert _last_stop_index(hist) == 0
+
+
 def test_last_stop_index_empty_history():
     assert _last_stop_index([]) is None
 
@@ -225,6 +238,13 @@ def test_bash_call_after_true_when_bash_follows():
 
 def test_bash_call_after_true_when_failed_bash_terminal_follows():
     hist = [_stop("I'll run the tests now."), _failure("pytest -q")]
+    assert _bash_call_after(hist, 0) is True
+
+
+def test_bash_call_after_sees_a_wrapper_typed_terminal_row():
+    hist = [_stop("I'll run the tests now."), _wrapper_typed(
+        "PostToolUse", tool_name="Bash", tool_input={"command": "pytest -q"},
+        tool_response={"stdout": "1 passed", "exitCode": 0})]
     assert _bash_call_after(hist, 0) is True
 
 
@@ -274,6 +294,16 @@ def test_silent_when_prior_stop_made_no_promise():
 
 def test_silent_when_a_bash_call_discharges_it():
     hist = [_stop("I'll run the tests now."), _post("pytest -q", exitCode=0)]
+    assert run_promised_gate(history=hist) is None
+
+
+def test_silent_when_wrapper_typed_bash_call_discharges_it():
+    """ADR 0039 shape: wrapper-only event types must not make the gate false-fire."""
+    hist = [_wrapper_typed(
+                "Stop", session_id="s1", last_assistant_message="I'll run the tests now."),
+            _wrapper_typed(
+                "PostToolUse", tool_name="Bash", tool_input={"command": "pytest -q"},
+                tool_response={"stdout": "1 passed", "exitCode": 0})]
     assert run_promised_gate(history=hist) is None
 
 


### PR DESCRIPTION
Follow-up to #33 from a max-effort review; all six correctness findings were reproduced against the real code paths before fixing, and each carries a regression fixture.

The lost invariant: **a failed call is evidence of failure**. #33 correctly delivered `PostToolUseFailure` into history, but routing it through the shared `_accumulate` let failed calls masquerade as successes in success-shaped state:

- `_accumulate` now returns early for failure terminals — the event stays in history for every decoder, but a failed Write can no longer discharge `gate.completion`/`gate.dropped`/`gate.advance`, a failed test-runner re-run can no longer latest-wins-clobber a recorded failing testrun (false green passed before), and a failed locating Write can no longer mark a plan node done under `gate.contract_order`.
- The transient ship bar extends to the other paths that gained failure input: `atom_tool_timeout` ignores confidently transient failures (a verification-only turn with one connection blip could false-block the certified-0-FP `nosrc_green_timeout`), and `canon.timeout` stays silent when the turn's last call failed confidently transiently — #33's own motivating scenario still hard-blocked.
- `runIntentUnfulfilled` migrates to `kit.decode_history_event` like every sibling (the ADR 0039 wrapper-row blindness could false-fire the blocking `gate.run_promised`).
- The failure-terminal normalization — four drifted copies — collapses into one documented `kit.failure_terminal_result`; the dead `"error" in tr` clause in `claimed_running` is resolved explicitly.

Validation: full suite `1803 passed, 5 skipped, 1 xfailed` (13 new regressions over #33's 1790), canon certification modules re-run explicitly (222 passed), verified independently after authoring.

---
_Generated by [Claude Code](https://claude.ai/code/session_017BNMFots5HGn4cTQMWQSxr)_