### PR TITLE
Close the surrogate fail-open; attribute every dispatch_errors row; narrow unsourced_webfetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,11 +288,37 @@ without leaking whole-file contents. It's plain JSONL — query it with `jq` or 
 | `retry_hint_emitted` | Boolean — at least one fired pattern had a non-empty `retry_hint` |
 | `findings` | Per-finding `{pattern_id, level, file, line, snippet}` |
 
+### The error log
+
+`$MAKOTO_STATE_DIR/dispatch_errors.jsonl` is the other half, and it is the half that matters when
+something goes wrong: one row per predicate that raised and per dispatch-stage can't-evaluate. Every
+row carries `plugin`, `session_id`, `tool_name`, `hook_event` and `id_source`.
+
+Those fields were missing. `audit.jsonl` has carried the session and tool since 1.0.2 and this log
+carried neither — so a *fire* was attributable and a *miss* was not, and every row here is a check
+that did not run. When 30 fail-opens landed in one day, "did they affect this session?" could not
+be answered from the record. `id_source` says how the ids were obtained (`payload`, or `raw-scan`
+when the envelope did not parse and they had to be recovered from the raw text); a recovered id
+that does not admit it was recovered is worse than no id.
+
+Row dispositions are `loud-allow` (a check did not run), `BLOCK`, `REPAIRED` (the envelope carried
+bytes that had to be fixed, and evaluation then continued normally), and `NOTE`.
+
+### A fail-open is never silent
+
+Hook stderr on exit 0 reaches the debug log only — not the transcript, not the user, not the model.
+So "loud-allow + a stderr line" was loud to nobody, and a skipped check looked exactly like a clean
+pass from every seat. Every fail-open now also emits a `systemMessage` saying the call was
+**allowed without being checked**. The direction is unchanged; only the visibility is. See
+[Courthouse docs/FAIL-DIRECTION.md](https://github.com/Clear-Sights/Courthouse/blob/main/docs/FAIL-DIRECTION.md)
+for the bench-wide policy.
+
 ### Failure mode
 
 Audit writes are best-effort. If the append fails (disk full, permission denied), dispatch prints one
 stderr line and continues with its original exit code. The audit subsystem cannot cause makoto to
 mis-block or mis-allow a tool call — a fundamental separation-of-concerns invariant.
+
 ## ConfigChange watch (advisory + evidence-gated blocking)
 
 Separate from the 15 pre-checks and 19 end-of-turn checks above: an optional `ConfigChange` hook

--- a/makoto/checks/unsourcedWebfetch.py
+++ b/makoto/checks/unsourcedWebfetch.py
@@ -7,7 +7,11 @@ pattern from training data.
 
 Predicate walks session history (events table, populated by 1.0.5 PostToolUse
 infra) and checks whether the URL appears anywhere in prior tool_response
-content. Trusted-host allowlist short-circuits well-known docs domains.
+content. Two short-circuits come first: a trusted-host allowlist for well-known
+docs domains, and -- the one that keeps the condition honest -- a URL the USER
+typed verbatim in a genuine transcript turn. "Not in a prior tool_result" is a
+proxy for "fabricated", and it is a proxy that misfires on the single most
+clearly-grounded case there is; see `_user_supplied` for the measured misfire.
 
 Knight-Leveson: stdlib re + json only; conn for events lookup is passed in.
 """
@@ -32,6 +36,42 @@ _TRUSTED_HOSTS = frozenset({
 })
 
 
+def _user_supplied(url: str, current_event: dict) -> bool:
+    """True iff `url` appears VERBATIM in a genuine user turn of this session's transcript.
+
+    THE TRIGGER-NARROWING THAT MAKES THIS CHECK MEAN WHAT IT SAYS. The mined defect is a
+    FABRICATED url -- one the agent invented from a plausible host+path pattern in training data.
+    The implemented condition was "never seen in a prior tool_result", and those are not the same
+    set. A url the human typed into chat has never been in a tool_result either, so the check fired
+    on it: measured live, on a url the user supplied directly, denied as never-seen. That is not a
+    near-miss of the target, it is a different target -- and it fires precisely when the agent is
+    doing the most obviously correct thing available to it, which is the worst possible time for a
+    gate to be wrong, because the user watched them supply the url.
+
+    A url the user typed is grounded BY DEFINITION: its provenance is the oracle, and no tool call
+    can improve on that. So the exemption is not a softening of the check, it is the check finally
+    matching its own stated subject.
+
+    Verbatim, and only verbatim. Substring containment in the user's own words is the whole test --
+    no normalization, no host-only match, no prefix match. A host-only match would exempt every
+    path under any domain the user ever mentioned, which is the fabrication this check exists to
+    catch, one directory deeper.
+
+    Spoof-resistant by construction, because the turns come from `ledger.user_turn_texts`, which
+    admits only host-written, non-synthetic, non-tool-result user entries. The agent cannot write
+    itself a permission slip: a tool result carrying the url is not a user turn, and that
+    distinction is enforced where the transcript is read, not here.
+    """
+    try:
+        from makoto.state.ledger import user_turn_texts
+        turns = user_turn_texts(current_event.get("transcript_path"))
+    except Exception:
+        # Absence of evidence, never evidence of absence: an unreadable transcript leaves the
+        # check exactly as strict as it was before this exemption existed.
+        return False
+    return any(url in turn for turn in turns)
+
+
 def _webfetch_url(current_event: dict) -> Optional[str]:
     if current_event.get("hook_event_name") != "PreToolUse":
         return None
@@ -43,6 +83,9 @@ def _webfetch_url(current_event: dict) -> Optional[str]:
     # Trusted-host short-circuit
     host = urlparse(url).netloc.lower()
     if host in _TRUSTED_HOSTS or any(host.endswith("." + th) for th in _TRUSTED_HOSTS):
+        return None
+    # Oracle short-circuit: the user typed this url themselves. See `_user_supplied`.
+    if _user_supplied(url, current_event):
         return None
     return url
 
@@ -58,12 +101,13 @@ def _url_grounded_in_history(url: str, history: list) -> bool:
 predicate = claim_vs_history_predicate(
     claim_rxs=(), neg_ref_rx=None, grounded_in_history=_url_grounded_in_history,
     tool_gate=_webfetch_url,
-    message="row {id} ({description}): URL never seen in this session",
+    message=("row {id} ({description}): this URL was never returned by a prior tool call in "
+             "this session, and the user never typed it"),
 )
 
 
 from makoto.registry import Check as _Check
-RETRY_HINT = 'Run WebSearch first; only WebFetch URLs that prior search results actually returned. Fabricated URLs typically reflect plausible host+path patterns from training data, not real pages.'
-DESCRIPTION = 'WebFetch URL never seen in any prior tool_result this session'
+RETRY_HINT = 'Run WebSearch first; only WebFetch URLs that prior search results actually returned, or that the user gave you verbatim. Fabricated URLs typically reflect plausible host+path patterns from training data, not real pages.'
+DESCRIPTION = 'WebFetch URL neither returned by a prior tool_result nor supplied verbatim by the user'
 
 CHECK = _Check(id='content.unsourced_webfetch', applies_at="Pre", posture="BLOCK", predicate_module=__name__, keywords=('http://', 'https://'), retry_hint=RETRY_HINT, description=DESCRIPTION, eats=frozenset({"current_event", "history", "pattern"}), tests="CLAIM_VS_HISTORY")

--- a/makoto/core/wire.py
+++ b/makoto/core/wire.py
@@ -1,0 +1,163 @@
+"""makoto.core.wire -- the byte boundary: raw hook stdin -> a str the rest of Makoto can persist.
+
+ONE domain: everything between "the host wrote bytes into our pipe" and "dispatch has a Python
+str". Stdlib-only, no makoto-internal imports, so anything may depend on it.
+
+WHY THIS MODULE EXISTS (the live crash it closes)
+`dispatch.main()` opened with `sys.stdin.read()`. Under the C/POSIX locale -- which is what a hook
+subprocess actually gets, since no interactive shell has exported LANG for it -- CPython enables
+UTF-8 mode (PEP 540) and gives `sys.stdin` the `surrogateescape` error handler. Any byte the host
+wrote that is not valid UTF-8 therefore does not raise and does not get replaced: it is smuggled in
+as a LONE SURROGATE, one per bad byte, `0xDC00 + byte`.
+
+That str parses as JSON, routes, and reaches `_ingest_event`, where sqlite3 encodes bind
+parameters to UTF-8 STRICTLY and raises::
+
+    UnicodeEncodeError: 'utf-8' codec can't encode character '\\udc9d'
+                        in position 143: surrogates not allowed
+
+`\\udc9d` is byte 0x9D -- a CP1252/Latin-1 byte in a file being written, or a multi-byte sequence
+the host truncated. `main()`'s catch-all then recorded a `loud-allow` fact and returned 0, so the
+tool call proceeded WITH NO CHECK HAVING RUN. Measured live: 30 such loud-allows in one day, every
+one of them Makoto failing open on its own bug. A gate that vanishes on malformed input was never
+a gate on that input.
+
+The same byte reaches the sibling plugins through the same door and they disagree about what it
+means -- Ward's `ast.parse` fails and it hard-DENIES a benign file with "cannot be parsed
+independently"; Gyroscope's `derive_id` raises inside a per-clause `except Exception: continue`
+and the clause silently abstains. Three plugins, one bad byte, three different verdicts, none of
+them about the pending action. That is why the fix is at the boundary and not at any one crash
+site: a lone surrogate must never exist downstream of this module.
+
+WHAT THIS IS NOT
+Not a sanitizer for hostile input and not a re-encoder. It makes exactly one guarantee -- no
+surrogate code point survives -- and it makes that guarantee ON THE RECORD: both entry points
+report how many code points they replaced, so "the payload was repaired" is a fact a caller can
+log rather than a silent rewrite of the agent's evidence.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from typing import Any
+
+# U+FFFD REPLACEMENT CHARACTER: the standard "a code point was here and it was not representable"
+# marker. Chosen over dropping the code point so byte offsets in a payload stay roughly meaningful
+# and so a repaired region is visible in the log rather than invisible.
+REPLACEMENT = "�"
+
+# The whole surrogate range, high and low alike. The byte decode below routes its own
+# surrogates straight back through here; this regex also closes the OTHER door -- a well-formed
+# UTF-8 payload whose JSON *text* contains an unpaired `\ud89d` escape, which `json.loads`
+# faithfully turns into a real lone surrogate. One of those doors is the host's encoding and the
+# other is the host's JSON writer; both end in the same sqlite3 raise, so both are closed here.
+_SURROGATE_RX = re.compile("[\ud800-\udfff]")
+
+
+def scrub_text(text: str) -> tuple[str, int]:
+    """Return (text with every surrogate code point replaced, number replaced).
+
+    Fast path is a search, not a substitution: the overwhelmingly common case is a clean payload,
+    and this runs on every hook event of every session.
+    """
+    if not _SURROGATE_RX.search(text):
+        return text, 0
+    replaced = len(_SURROGATE_RX.findall(text))
+    return _SURROGATE_RX.sub(REPLACEMENT, text), replaced
+
+
+def scrub(value: Any) -> tuple[Any, int]:
+    """Recursively scrub every str inside a parsed JSON value; return (value, total replaced).
+
+    Dict KEYS are scrubbed too. A surrogate in a key is rarer than one in a value but reaches the
+    same encoder, and a key that cannot be serialized fails the whole row rather than one field.
+
+    Containers are rebuilt only when something below them actually changed, so a clean payload --
+    the normal case -- comes back as the same objects it went in as.
+    """
+    if isinstance(value, str):
+        return scrub_text(value)
+    if isinstance(value, dict):
+        out, total = {}, 0
+        for k, v in value.items():
+            if isinstance(k, str):
+                k, n = scrub_text(k)
+                total += n
+            v, n = scrub(v)
+            total += n
+            out[k] = v
+        return (out, total) if total else (value, 0)
+    if isinstance(value, list):
+        items, total = [], 0
+        for item in value:
+            item, n = scrub(item)
+            total += n
+            items.append(item)
+        return (items, total) if total else (value, 0)
+    return value, 0
+
+
+def read_stdin(stream=None) -> tuple[str, int]:
+    """Read the hook envelope off stdin as BYTES and decode it to a surrogate-free str.
+
+    Returns (text, replaced). Reading `.buffer` rather than the text wrapper is the load-bearing
+    part: it takes the decode away from whatever error handler the ambient locale happened to
+    install. A stream without a `.buffer` (a StringIO under test, a host that hands us text) is
+    read as text and scrubbed instead -- same guarantee, one door further in.
+    """
+    stream = stream if stream is not None else sys.stdin
+    buffer = getattr(stream, "buffer", None)
+    if buffer is not None:
+        try:
+            data = buffer.read()
+        except (AttributeError, ValueError, OSError):
+            # A closed or non-binary buffer: fall through to the text path rather than making the
+            # hook's first act a crash.
+            data = None
+        if data is not None:
+            return _decode_counting(data)
+    return scrub_text(stream.read() or "")
+
+
+def _decode_counting(data: bytes) -> tuple[str, int]:
+    """Decode `data` as UTF-8, returning (text, number of undecodable BYTES repaired).
+
+    Strict first, on purpose: a clean payload reports zero repairs by construction, so the count can
+    never be inflated by a U+FFFD the host legitimately sent. A number that cries wolf gets ignored,
+    and takes the next real one with it.
+    """
+    try:
+        return scrub_text(data.decode("utf-8"))
+    except UnicodeDecodeError:
+        pass
+    # `surrogateescape`, then scrub -- NOT `errors="replace"`.
+    #
+    # `replace` emits ONE U+FFFD per malformed RUN, so a truncated three-byte sequence like
+    # b"\xe2\x82" (two undecodable bytes) reported 1, and the field is called "bytes repaired".
+    # An observability number whose name does not match its arithmetic is the kind of thing that
+    # gets trusted right up until someone reconciles two counts and cannot.
+    #
+    # `surrogateescape` maps each undecodable BYTE to exactly one lone surrogate, so counting the
+    # surrogates counts bytes -- which is what the field says. Scrubbing them immediately is what
+    # keeps the module's one guarantee: no surrogate leaves here. It also retires the
+    # `data.count(b"\xef\xbf\xbd")` correction entirely, since surrogateescape never touches a
+    # U+FFFD the host legitimately sent.
+    return scrub_text(data.decode("utf-8", errors="surrogateescape"))
+
+
+def harden_stderr() -> None:
+    """Pin stderr to a never-raising error handler.
+
+    Every fail-open path in `dispatch` ends in a `print(..., file=sys.stderr)` that interpolates an
+    exception message. When the exception is itself about an unencodable character, that print can
+    raise -- turning the on-the-record fact into a second, unrecorded crash and taking the hook's
+    exit code with it. The reporting path must be the one thing that cannot fail.
+
+    Best-effort: `reconfigure` needs a TextIOWrapper, and a stderr that is something else is left
+    alone rather than replaced.
+    """
+    for stream in (sys.stderr, sys.stdout):
+        try:
+            stream.reconfigure(errors="replace")
+        except (AttributeError, ValueError, OSError):
+            pass

--- a/makoto/dispatch.py
+++ b/makoto/dispatch.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import importlib
 import json
 import os
+import re
 import sys
 import time
 from dataclasses import asdict, replace
@@ -28,6 +29,7 @@ from pathlib import Path
 from typing import Optional
 
 from makoto.core import hostdialect
+from makoto.core import wire
 from makoto.vocab import Finding
 from makoto.state.store import _state_dir
 from makoto.state import citations
@@ -110,16 +112,109 @@ class _Unevaluable(Exception):
     """A dispatch-stage can't-evaluate condition, recorded as an on-the-record fact (never silent)."""
 
 
-def _dispatch_fact(state_dir: Path, stage: str, reason: str, *, blocked: bool) -> None:
+# Recovering the ids from raw stdin when the envelope did not parse. Deliberately a flat scan of
+# the top-level shape Claude Code actually emits and nothing cleverer: this runs precisely when the
+# payload is NOT trustworthy JSON, so a real parser is not available and a greedy one would invent
+# structure. A miss yields "" and the row says `id_source: ""` -- honest silence, never a guess
+# presented as a reading.
+_RAW_ID_RXS = {
+    "session_id": re.compile(r'"session_id"\s*:\s*"([^"\\]{1,128})"'),
+    "tool_name": re.compile(r'"tool_name"\s*:\s*"([^"\\]{1,64})"'),
+    "hook_event_name": re.compile(r'"hook_event_name"\s*:\s*"([^"\\]{1,64})"'),
+}
+
+
+def _ids_from_raw(payload_raw: str) -> dict:
+    """Best-effort {session_id, tool_name, hook_event} recovered from unparsed stdin text."""
+    found = {}
+    for field, rx in _RAW_ID_RXS.items():
+        m = rx.search(payload_raw or "")
+        if m:
+            found[field] = m.group(1)
+    if not found:
+        return {}
+    return {"session_id": found.get("session_id", ""),
+            "tool_name": found.get("tool_name", ""),
+            "hook_event": found.get("hook_event_name", ""),
+            "id_source": "raw-scan"}
+
+
+def _ids_from_payload(payload) -> dict:
+    """{session_id, tool_name, hook_event} read from a parsed envelope, or {} if there isn't one."""
+    if not isinstance(payload, dict):
+        return {}
+    return {"session_id": str(payload.get("session_id") or ""),
+            "tool_name": str(payload.get("tool_name") or ""),
+            "hook_event": str(payload.get("hook_event_name") or ""),
+            "id_source": "payload"}
+
+
+def _dispatch_fact(state_dir: Path, stage: str, reason: str, *, blocked: bool,
+                   ids: dict | None = None, disposition: str | None = None) -> None:
     """HYBRID fail-mode: record an on-the-record can't-evaluate fact + a guaranteed-loud stderr line.
     NEVER silent. `blocked` marks a tamper-block vs a loud-allow in the recorded fact. The stderr line
     is the loud floor; the audit-file write is best-effort (the fact-writer must never itself crash
-    the hook)."""
-    disposition = "BLOCK" if blocked else "loud-allow"
+    the hook).
+
+    `ids` carries the session/tool attribution (see `audit.append_error`). Every caller supplies it
+    -- from the parsed payload where there is one, from `_ids_from_raw` where there isn't. A
+    can't-evaluate fact that cannot be tied to a session is a fact nobody can act on: the row exists
+    to answer "was THIS session affected", and unattributed rows answer that with a shrug.
+
+    `disposition` overrides the recorded label for the one case that is neither of the two original
+    fates: a payload that was REPAIRED and then evaluated normally. Filing that under "loud-allow"
+    would inflate exactly the count this work exists to drive to zero, and would tell a reader that
+    checks were skipped when they ran."""
+    disposition = disposition or ("BLOCK" if blocked else "loud-allow")
     print(f"makoto.dispatch: {disposition} [{stage}] {reason}", file=sys.stderr)
+    if not blocked and stage in _NOTICE_STAGES:
+        _notices.append(f"[{stage}] {reason}")
     try:
         audit.append_error(state_dir, event_id=None, pattern_id=f"dispatch.{stage}",
-                           exc=_Unevaluable(f"{disposition}: {reason}"))
+                           exc=_Unevaluable(f"{disposition}: {reason}"), **(ids or {}))
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------------------------
+# THE LOUD IN "LOUD-ALLOW". A fail-open that nobody can see is a silent one.
+#
+# `_dispatch_fact`'s stderr line was the entire "loud" half of the contract, and stderr from a hook
+# that exits 0 goes to the DEBUG LOG ONLY -- never the transcript, never the user, never the model.
+# So a can't-evaluate looked identical, from every seat, to a clean pass: the pending call
+# proceeded, no output appeared, and the one party who could have retried or reported it was the
+# only party not told. Measured: 30 loud-allows in one day, on one machine, noticed by nobody until
+# somebody went looking through the state directory for an unrelated reason.
+#
+# `systemMessage` is a universal hook-output field that IS surfaced to the user, on every event
+# that can carry output. Using it keeps the fail direction exactly where it was -- open, never
+# blocking, a broken gate must not wedge the session -- while removing the "silently".
+# Gyroscope's own shim reached the same conclusion for the same reason; this is that precedent
+# applied one layer in, to the faults that happen after carriage succeeds.
+#
+# Only faults that mean A CHECK DID NOT RUN produce a notice. A REPAIRED payload evaluated normally
+# and says nothing; a chain-tamper advisory has its own audit row and is not about this call.
+_NOTICE_STAGES = frozenset({"unparseable_payload", "db_init_failed", "db_locked", "exception"})
+_notices: list = []
+_stdout_written = False
+
+
+def _emit_notices() -> None:
+    """Write the buffered can't-evaluate notices to stdout, iff no decision already claimed it.
+
+    The wire carries exactly ONE JSON object. A decision always outranks a notice -- a deny the
+    agent must obey matters more than a report about a check that did not run -- so this is a
+    last-word emitter, and `_stdout_written` is the interlock that keeps it from ever appending a
+    second object onto a real decision and corrupting the response.
+    """
+    if _stdout_written or not _notices:
+        return
+    try:
+        detail = "; ".join(_notices[:3])
+        sys.stdout.write(json.dumps({"systemMessage": (
+            f"makoto: {len(_notices)} check-evaluation fault(s) on this call -- {detail}. "
+            f"The call was ALLOWED WITHOUT BEING CHECKED (fail-open). "
+            f"See dispatch_errors.jsonl in the makoto state dir.")}))
     except Exception:
         pass
 
@@ -150,22 +245,29 @@ def _note_host_dialect(state_dir: Path, session_id, notes: dict, host_event) -> 
         pass
     _dispatch_fact(state_dir, "host_dialect",
                    f"normalized host spellings {notes!r} (first seen as event {host_event!r}); "
-                   f"noted once for this session", blocked=False)
+                   f"noted once for this session", blocked=False, disposition="NOTE",
+                   ids={"session_id": str(session_id or ""), "hook_event": str(host_event or ""),
+                        "id_source": "payload"})
     return True
 
 
-def _self_verify_chain(state_dir: Path) -> None:
+def _self_verify_chain(state_dir: Path, ids: dict | None = None) -> None:
     """Re-derive the chain's tamper evidence at every dispatch, advisory-only. A clean or
-    absent/empty chain is silent. Never raises. See docs/adr/0005-chain-verification-rollout.md."""
+    absent/empty chain is silent. Never raises. See docs/adr/0005-chain-verification-rollout.md.
+
+    `ids` is the caller's session/tool attribution, threaded through for the same reason every
+    other fact carries it: a tamper report nobody can tie to a session is a report nobody can
+    act on."""
     try:
         from makoto.state import ledger as _ledger
         broken_at = _ledger.verify_chain()
     except Exception as exc:
-        _dispatch_fact(state_dir, "chain_verify_error", f"{type(exc).__name__}: {exc}", blocked=False)
+        _dispatch_fact(state_dir, "chain_verify_error", f"{type(exc).__name__}: {exc}",
+                       blocked=False, ids=ids)
         return
     if broken_at is not None:
         _dispatch_fact(state_dir, "chain_tamper",
-                       f"chain integrity broken at row index {broken_at}", blocked=False)
+                       f"chain integrity broken at row index {broken_at}", blocked=False, ids=ids)
 
 
 def _ensure_db_initialized(state_dir: Path, db_path: Path) -> bool:
@@ -347,7 +449,8 @@ def _run_predicates(conn, payload: dict, history: list, event_id: int,
                 # from — single source of the id, one place to keep correct.
                 findings.append(replace(finding, source_event_id=event_id))
         except Exception as exc:
-            audit.append_error(state_dir, event_id, pattern.id, exc)
+            audit.append_error(state_dir, event_id, pattern.id, exc,
+                               **_ids_from_payload(payload))
             continue
     return findings
 
@@ -481,7 +584,11 @@ def _emit_decision(findings: list[Finding], hook_event: str, stream=None,
         ))
     body = verdict.dispatch_posture(_HOOK_TO_EDGE.get(hook_event, "Pre"), folded, hook_event)
     if body:
+        global _stdout_written
         (stream or sys.stdout).write(json.dumps(body))
+        # Claim the wire so `_emit_notices` cannot append a second object behind a real decision.
+        # Set even for an injected `stream`: a caller that redirected the wire still owns it.
+        _stdout_written = True
 
 
 def _record_audit(state_dir: Path, findings: list[Finding], payload: dict) -> None:
@@ -645,27 +752,67 @@ HANDLERS: dict[str, Any] = {
 
 
 def main() -> int:
+    """Run the dispatch and then GUARANTEE the can't-evaluate notices reach the wire.
+
+    Every early `return 0` in `_dispatch` is a fail-open, and a fail-open is exactly the path whose
+    notice must not be lost, so the flush is a `finally` rather than a line before each return --
+    the same reason `_dispatch`'s own conn.close() is one.
+    """
+    try:
+        return _dispatch()
+    finally:
+        _emit_notices()
+
+
+def _dispatch() -> int:
     """orchestrator — HYBRID fail-mode (never silent, never blind-open): a tamper-shaped payload
     fails CLOSED (block, exit 2 + reason); transient infra (unparseable pipe, DB init/lock failure,
     unexpected body fault) fails LOUD-ALLOW (exit 0 + stderr); every can't-evaluate writes an
     on-the-record audit fact. See docs/archive/specs/2026-06-03-dispatch-fail-loud-hybrid-design.md.
     Routing is HANDLERS, the row table above — main() knows the common prologue (parse, verify,
     ingest) and nothing about any event."""
-    payload_raw = sys.stdin.read()
+    # The byte boundary comes FIRST, before anything reads a character. `makoto.core.wire` pins the
+    # decode to errors="replace" instead of inheriting the ambient locale's surrogateescape handler,
+    # so a host byte that is not valid UTF-8 can no longer enter as a lone surrogate and detonate
+    # later, inside sqlite3, as the loud-allow that skipped every check for that call. See
+    # makoto/core/wire.py for the measured failure this closes.
+    wire.harden_stderr()
+    payload_raw, undecodable = wire.read_stdin()
     state_dir = _state_dir()
-    _self_verify_chain(state_dir)
     payload = _parse_payload(payload_raw)
+    # Chain self-verification is advisory and session-scoped, but its two facts are rows in the
+    # same log as everything else, so it runs AFTER the parse in order to be tagged with the ids
+    # like every other row. Nothing it does depends on the payload; only its attribution does.
+    _self_verify_chain(state_dir, ids=_ids_from_payload(payload) or _ids_from_raw(payload_raw))
     if payload is _PARSE_FAILED:
         # unparseable stdin = a transient/truncated pipe (a real envelope is always valid JSON) ->
         # loud-allow; never block agent work on a pipe glitch.
-        _dispatch_fact(state_dir, "unparseable_payload", "stdin was not valid JSON", blocked=False)
+        _dispatch_fact(state_dir, "unparseable_payload", "stdin was not valid JSON", blocked=False,
+                       ids=_ids_from_raw(payload_raw))
         return 0
     if not isinstance(payload, dict):
         # valid JSON but not an object: a truncated pipe yields INVALID json, never valid-non-dict,
         # and Claude Code's envelope is always an object -> anomalous/tamper-shaped -> fail CLOSED.
         _dispatch_fact(state_dir, "non_object_payload",
-                       f"payload was {type(payload).__name__}, not a JSON object", blocked=True)
+                       f"payload was {type(payload).__name__}, not a JSON object", blocked=True,
+                       ids=_ids_from_raw(payload_raw))
         return 2
+    # The OTHER surrogate door: a payload whose bytes were valid UTF-8 but whose JSON text carried
+    # an unpaired `\uD8xx` escape, which json.loads faithfully materializes as a real lone
+    # surrogate. wire.read_stdin cannot see that one -- the escape is plain ASCII in the raw text --
+    # so the parsed object is scrubbed here, and payload_raw is re-derived from the scrubbed object
+    # so the text that gets persisted and keyword-scanned is the text that was actually evaluated.
+    payload, escaped = wire.scrub(payload)
+    if escaped:
+        payload_raw = json.dumps(payload, ensure_ascii=False)
+    if undecodable or escaped:
+        # Recorded, not silent, and NOT a loud-allow: the payload was repaired and evaluation
+        # continues normally. Distinguishing "repaired and checked" from "gave up and allowed" is
+        # the whole difference between this row and the crash row it replaces.
+        _dispatch_fact(state_dir, "unencodable_input",
+                       f"replaced {undecodable} undecodable byte(s) and {escaped} unpaired "
+                       f"surrogate escape(s); evaluation continued on the repaired payload",
+                       blocked=False, disposition="REPAIRED", ids=_ids_from_payload(payload))
     # The host-dialect boundary (makoto.core.hostdialect): one hop from whatever spelling the
     # host sent to the protocol every reader below assumes, applied here -- after the envelope
     # has been proven evaluable (parseable, an object), before ANYTHING routes on or persists it
@@ -678,6 +825,21 @@ def main() -> int:
     # still takes exactly the wildcard path it took before.
     host_event = payload.get("hook_event_name")
     payload, dialect_notes = hostdialect.normalize_payload(payload, HANDLERS)
+    # A THIRD surrogate door, and the reason this scrub is here rather than only above.
+    # `hostdialect._tool_result` runs `json.loads` on Cursor's `tool_output`, which arrives as a
+    # JSON *string*. An unpaired `\ud800` escape inside that inner document is plain ASCII in the
+    # outer payload -- invisible to `wire.read_stdin`, and invisible to the `wire.scrub` above,
+    # because at that point it is still an unparsed string. Normalization is what materializes it,
+    # so normalization is what has to be followed by a scrub. Verified by reproducing the ORIGINAL
+    # UnicodeEncodeError on a camelCase envelope after the boundary fix was already in place: the
+    # ensure_ascii=False reserialization below then carried the live surrogate straight into the
+    # sqlite3 bind. Found by an independent review pass, not by the tests that existed.
+    payload, dialect_escaped = wire.scrub(payload)
+    if dialect_escaped:
+        _dispatch_fact(state_dir, "unencodable_input",
+                       f"replaced {dialect_escaped} unpaired surrogate escape(s) materialized by "
+                       f"host-dialect normalization; evaluation continued on the repaired payload",
+                       blocked=False, disposition="REPAIRED", ids=_ids_from_payload(payload))
     if dialect_notes:
         # Persist WHAT WAS EVALUATED, not the host's spelling of it. The events table is the
         # rolling substrate every history decoder reads, and those decoders key on the PAYLOAD's
@@ -696,11 +858,13 @@ def main() -> int:
         _note_host_dialect(state_dir, payload.get("session_id"), dialect_notes, host_event)
     db_path = state_dir / "makoto.record.db"
     if not _ensure_db_initialized(state_dir, db_path):
-        _dispatch_fact(state_dir, "db_init_failed", "lazy DB init failed", blocked=False)
+        _dispatch_fact(state_dir, "db_init_failed", "lazy DB init failed", blocked=False,
+                       ids=_ids_from_payload(payload))
         return 0  # transient infra -> loud-allow
     conn = _connect_with_retry(db_path)
     if conn is None:
-        _dispatch_fact(state_dir, "db_locked", "write lock not acquired within retry budget", blocked=False)
+        _dispatch_fact(state_dir, "db_locked", "write lock not acquired within retry budget",
+                       blocked=False, ids=_ids_from_payload(payload))
         return 0  # transient infra -> loud-allow
     try:
         citations.refresh_if_stale(conn)
@@ -711,7 +875,8 @@ def main() -> int:
     except Exception as exc:
         # an unexpected fault in evaluation must never crash the hook to a non-zero exit, and must
         # never be silent -> loud-allow + fact. (Exception, not BaseException: Ctrl-C propagates.)
-        _dispatch_fact(state_dir, "exception", f"{type(exc).__name__}: {exc}", blocked=False)
+        _dispatch_fact(state_dir, "exception", f"{type(exc).__name__}: {exc}", blocked=False,
+                       ids=_ids_from_payload(payload))
     finally:
         conn.close()
     return 0

--- a/makoto/state/audit.py
+++ b/makoto/state/audit.py
@@ -120,20 +120,58 @@ def read_rows(state_root: Path, since: str | None = None) -> Iterator[dict]:
 
 
 def append_error(state_root: Path, event_id: int | None,
-                 pattern_id: str | None, exc: BaseException) -> None:
-    """append one JSON line to <state_root>/dispatch_errors.jsonl on predicate failure.
+                 pattern_id: str | None, exc: BaseException,
+                 *, session_id: str = "", tool_name: str = "",
+                 hook_event: str = "", id_source: str = "") -> None:
+    """append one JSON line to <state_root>/dispatch_errors.jsonl on predicate or dispatch failure.
 
     Spec §5.7 + v5 fix #9. SEPARATE from audit.jsonl; AuditRow shape preserved.
-    Schema: {ts, event_id, pattern_id, exc_type, exc_message}. Called by
-    dispatch._run_predicates when a predicate import or call raises (fail-open).
+    Schema: {ts, plugin, event_id, pattern_id, exc_type, exc_message, session_id, tool_name,
+    hook_event, id_source}.
+
+    THE ATTRIBUTION FIELDS ARE THE POINT, not decoration. audit.jsonl has carried `session_id` and
+    `tool_name` since 1.0.2; this log carried neither, so a crash row could name the exception but
+    not the session or the call it happened on. That gap is not a missing nicety -- it is why
+    "did this failure affect the session I am looking at?" was unanswerable after the fact for the
+    one class of row where the answer matters most, since every row here is a check that DID NOT
+    RUN. A fire is attributable and a miss was not; the log was informative in exactly the wrong
+    direction.
+
+    `id_source` records HOW the ids were obtained, because on the unparseable-payload path they
+    cannot come from a parsed envelope: "payload" means read from the parsed object, "raw-scan"
+    means recovered by scanning the raw stdin text, "" means none were available. A recovered id
+    that does not say it was recovered is worse than no id, so the provenance ships with the value.
+
+    `plugin` is constant here and deliberately so: Ward, Gyroscope and Makoto all register
+    PreToolUse `*` and all three can emit a deny, so a row that does not name its author is
+    unattributable the moment more than one of them is installed -- which is the shipped
+    Courthouse configuration.
+
+    Additive: every field is keyword-only with a default, and readers use dict.get, so pre-upgrade
+    rows keep parsing identically.
     """
     _append_jsonl(state_root, "dispatch_errors.jsonl", {
         "ts": datetime.now(timezone.utc).isoformat(),
+        "plugin": "makoto",
         "event_id": event_id,
         "pattern_id": pattern_id,
         "exc_type": type(exc).__name__,
         "exc_message": str(exc),
+        "session_id": session_id,
+        "tool_name": tool_name,
+        "hook_event": hook_event,
+        "id_source": id_source,
     })
+
+
+def read_errors(state_root: Path, since: str | None = None) -> Iterator[dict]:
+    """stream the dispatch-error log; one dict per valid JSON row. See _read_jsonl for the contract.
+
+    The reader that keeps this log from being write-only. `dispatch` uses it at Stop to answer
+    "were any checks skipped this session?" -- absence of a finding is only good news if nothing
+    was silently unable to produce one.
+    """
+    yield from _read_jsonl(state_root, "dispatch_errors.jsonl", since)
 
 
 def append_exemption(state_root: Path, *, pattern_id: str, kind: str, file: str,

--- a/makoto/state/ledger.py
+++ b/makoto/state/ledger.py
@@ -425,6 +425,50 @@ def _is_genuine_user_turn(entry: dict) -> Optional[str]:
     return text
 
 
+def user_turn_texts(transcript_path: Optional[str], *, limit: int = 4000) -> list:
+    """Every genuine, host-written, non-synthetic user turn in the transcript, oldest first.
+
+    The ORACLE channel, exposed for readers other than the ack scanner. `find_ack_block` has always
+    needed "what did the human actually type, as opposed to what could the agent have produced" --
+    contract points 1-3 of the ack rules, enforced by `_is_genuine_user_turn`. That question is not
+    specific to acks: any check that wants to distinguish a fact the human supplied from a fact the
+    agent supplied needs exactly this list, and needs it to have the same spoof-resistance.
+
+    Sharing the primitive rather than re-deriving it is the point. A second, looser reader of the
+    transcript would be a second definition of "the user said so", and the looser one would win any
+    disagreement -- which is how an agent-writable channel becomes an oracle by accident.
+
+    Never raises: an absent, unreadable or malformed transcript reads as "no user turns". Callers
+    must treat that as absence of evidence, never as evidence of absence.
+
+    `limit` bounds the scan; a transcript is unbounded in principle and this runs on a hot path.
+    """
+    if not transcript_path:
+        return []
+    p = Path(transcript_path)
+    try:
+        if not p.exists():
+            return []
+        raw = p.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    texts = []
+    for line in raw.splitlines()[:limit]:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        text = _is_genuine_user_turn(entry)
+        if text:
+            texts.append(text)
+    return texts
+
+
 def _first_fired_ts(fingerprint_id: str, *, gate_pattern_id: str = "gate.canon_fingerprints",
                     session_id: Optional[str] = None,
                     root: Optional[Path] = None) -> Optional[str]:

--- a/tests/predicates/test_unsourced_webfetch_user_supplied.py
+++ b/tests/predicates/test_unsourced_webfetch_user_supplied.py
@@ -1,0 +1,104 @@
+"""content.unsourced_webfetch fires on FABRICATION, not on "the user typed it".
+
+MEASURED MISFIRE. The check's stated subject is a hallucinated URL -- one the agent invented from a
+plausible host+path pattern in training data. Its implemented condition was "never seen in a prior
+tool_result". Those are different sets, and the gap has a resident: a URL the human typed into chat
+has never been in a tool_result either. Live, the check denied exactly that.
+
+The exemption is verbatim-only and reads the ORACLE channel (`ledger.user_turn_texts`), which
+admits only host-written, non-synthetic, non-tool-result user turns. The agent cannot write itself
+a permission slip.
+"""
+from __future__ import annotations
+import json
+
+import pytest
+
+from makoto.checks.unsourcedWebfetch import predicate
+from makoto.registry import load_precheck_catalog
+
+URL = "https://obscure-vendor.example/api/v3/reference"
+
+
+@pytest.fixture
+def check():
+    return next(c for c in load_precheck_catalog() if c.id == "content.unsourced_webfetch")
+
+
+def _transcript(tmp_path, entries) -> str:
+    p = tmp_path / "transcript.jsonl"
+    p.write_text("\n".join(json.dumps(e) for e in entries))
+    return str(p)
+
+
+def _event(url=URL, transcript_path=None):
+    return {"hook_event_name": "PreToolUse", "tool_name": "WebFetch", "session_id": "s",
+            "transcript_path": transcript_path, "tool_input": {"url": url}}
+
+
+def _user_turn(text):
+    return {"timestamp": "2026-08-19T10:00:00Z", "message": {"role": "user", "content": text}}
+
+
+def test_user_typed_url_is_not_a_fabrication(tmp_path, check):
+    """The regression. The human supplied the URL; its provenance is the oracle."""
+    t = _transcript(tmp_path, [_user_turn(f"please fetch {URL} and summarise it")])
+    assert predicate(current_event=_event(transcript_path=t), history=[], pattern=check) is None
+
+
+def test_url_in_structured_user_content_blocks_too(tmp_path, check):
+    """Real transcripts carry user content as a list of blocks, not only as a bare string."""
+    entry = {"timestamp": "2026-08-19T10:00:00Z",
+             "message": {"role": "user", "content": [{"type": "text", "text": f"see {URL}"}]}}
+    assert predicate(current_event=_event(transcript_path=_transcript(tmp_path, [entry])),
+                     history=[], pattern=check) is None
+
+
+def test_unmentioned_url_still_fires(tmp_path, check):
+    """The exemption must not blunt the check: a URL nobody supplied is still unsourced."""
+    t = _transcript(tmp_path, [_user_turn("please look up the docs for me")])
+    finding = predicate(current_event=_event(transcript_path=t), history=[], pattern=check)
+    assert finding is not None and finding.pattern_id == "content.unsourced_webfetch"
+
+
+def test_tool_result_turn_is_not_an_oracle(tmp_path, check):
+    """A tool result is the ONE user-role entry an agent can produce.
+
+    Accepting it would let the agent launder a fabricated URL into an exemption by first emitting
+    it as tool output. The distinction is enforced in `_is_genuine_user_turn`, and this test is
+    what keeps it enforced.
+    """
+    entry = {"timestamp": "2026-08-19T10:00:00Z", "toolUseResult": {"x": 1},
+             "message": {"role": "user", "content": URL}}
+    assert predicate(current_event=_event(transcript_path=_transcript(tmp_path, [entry])),
+                     history=[], pattern=check) is not None
+
+
+def test_system_reminder_turn_is_not_an_oracle(tmp_path, check):
+    """Harness-injected user-role text is not the human speaking."""
+    t = _transcript(tmp_path, [_user_turn(f"<system-reminder> context mentions {URL} </system-reminder>")])
+    assert predicate(current_event=_event(transcript_path=t), history=[], pattern=check) is not None
+
+
+def test_exemption_is_verbatim_not_host_wide(tmp_path, check):
+    """A host-only match would exempt every path under any domain the user ever mentioned --
+    the fabrication this check exists to catch, one directory deeper."""
+    t = _transcript(tmp_path, [_user_turn(f"start from {URL}")])
+    deeper = URL + "/internal/secrets"
+    assert predicate(current_event=_event(url=deeper, transcript_path=t),
+                     history=[], pattern=check) is not None
+
+
+def test_missing_transcript_leaves_the_check_exactly_as_strict(tmp_path, check):
+    """Absence of evidence is never evidence of absence: no transcript means no exemption."""
+    assert predicate(current_event=_event(transcript_path=None), history=[], pattern=check) is not None
+    missing = str(tmp_path / "nope.jsonl")
+    assert predicate(current_event=_event(transcript_path=missing),
+                     history=[], pattern=check) is not None
+
+
+def test_prior_tool_result_grounding_still_works(check):
+    """The original grounding path is untouched by the new short-circuit."""
+    history = [(1, "2026-08-19T10:00:00Z", "PostToolUse", "/tmp",
+                json.dumps({"tool_response": {"results": URL}}))]
+    assert predicate(current_event=_event(), history=history, pattern=check) is None

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -69,7 +69,13 @@ def test_dispatch_loose_comparator_emits_block_json(tmp_path):
 
 def test_dispatch_unparseable_stdin_loud_allows_with_fact(tmp_path):
     """HYBRID: unparseable stdin = a transient/truncated pipe (a real envelope is always valid JSON)
-    -> loud-ALLOW (exit 0, empty stdout) AND an on-the-record fact. Never a silent fail-open."""
+    -> loud-ALLOW (exit 0) AND an on-the-record fact. Never a silent fail-open.
+
+    The stdout assertion INVERTED on purpose. It used to require an empty wire, which made "never a
+    silent fail-open" true only of the audit file -- and hook stderr on exit 0 reaches the debug log
+    alone, so from the user's seat, the model's seat, and the transcript, a skipped check was
+    indistinguishable from a clean pass. `systemMessage` is the universal output field that is
+    actually surfaced. The fail DIRECTION is unchanged: still allow, still exit 0."""
     state_dir = _setup_state(tmp_path)
     env = os.environ.copy()
     env["MAKOTO_STATE_DIR"] = str(state_dir)
@@ -81,7 +87,9 @@ def test_dispatch_unparseable_stdin_loud_allows_with_fact(tmp_path):
         cwd=str(Path(__file__).parent.parent),
     )
     assert proc.returncode == 0
-    assert proc.stdout == b""
+    body = json.loads(proc.stdout.decode())
+    assert "ALLOWED WITHOUT BEING CHECKED" in body["systemMessage"]
+    assert "permissionDecision" not in proc.stdout.decode(), "a notice must never become a decision"
     facts = _dispatch_facts(state_dir)
     assert any(f.get("pattern_id") == "dispatch.unparseable_payload" for f in facts), facts
 
@@ -1981,7 +1989,13 @@ def test_dispatch_lazy_init_failure_fails_open_not_crash(tmp_path):
         "lazy-init failure must fail OPEN (exit 0), never crash the hook; "
         f"got rc={proc.returncode}, stderr={proc.stderr.decode('utf-8')!r}"
     )
-    assert proc.stdout == b"", "a failed-open dispatch must emit no decision"
+    # "No DECISION" is the invariant, and it still holds. What a failed-open dispatch now DOES
+    # emit is a `systemMessage` notice, because a fail-open whose only trace is stderr is
+    # invisible to the user, the model and the transcript alike.
+    out = proc.stdout.decode("utf-8")
+    assert "permissionDecision" not in out and '"decision"' not in out, (
+        f"a failed-open dispatch must emit no decision; got {out!r}")
+    assert "ALLOWED WITHOUT BEING CHECKED" in json.loads(out)["systemMessage"]
 
 
 def test_connect_with_retry_sleeps_backoff_between_attempts(monkeypatch):

--- a/tests/test_dispatch_attribution.py
+++ b/tests/test_dispatch_attribution.py
@@ -1,0 +1,143 @@
+"""Every dispatch_errors.jsonl row names its session, its tool, and its plugin.
+
+WHY THIS IS A TEST AND NOT A FIELD DEFAULT. audit.jsonl has carried `session_id` and `tool_name`
+since 1.0.2; dispatch_errors.jsonl carried neither. So a FIRE was attributable and a MISS was not
+-- and every row in this log is a check that did not run. When the question was "did that day's 30
+loud-allows affect this session?", the answer was unrecoverable from the log, because the rows that
+mattered were the ones built without the fields needed to answer.
+
+The rows also name `plugin`. Ward, Gyroscope and Makoto all register PreToolUse `*` and all three
+can deny, so in the shipped Courthouse configuration a row that does not name its author cannot be
+attributed to one after the fact.
+"""
+from __future__ import annotations
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.conftest import _setup_state, _run_dispatch
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def _errors(state_dir) -> list:
+    f = Path(state_dir) / "dispatch_errors.jsonl"
+    if not f.exists():
+        return []
+    return [json.loads(ln) for ln in f.read_text().splitlines() if ln.strip()]
+
+
+def _run_raw(state_dir, raw: bytes) -> tuple[int, str]:
+    env = os.environ.copy()
+    env["MAKOTO_STATE_DIR"] = str(state_dir)
+    proc = subprocess.run([sys.executable, "-m", "makoto.dispatch"], input=raw,
+                          capture_output=True, env=env, cwd=str(REPO_ROOT))
+    return proc.returncode, proc.stdout.decode("utf-8")
+
+
+REQUIRED = ("plugin", "session_id", "tool_name", "hook_event", "id_source")
+
+
+def test_every_row_carries_the_attribution_fields(tmp_path):
+    state_dir = _setup_state(tmp_path)
+    _run_raw(state_dir, b'{"hook_event_name":"PreToolUse","tool_name":"Write","session_id":"s-attr",'
+                        b'"cwd":"/tmp","tool_input":{"file_path":"/tmp/x.py","content":"a \x9d b"}}')
+    rows = _errors(state_dir)
+    assert rows, "the repair itself must be recorded"
+    for row in rows:
+        assert all(k in row for k in REQUIRED), f"missing attribution keys: {row}"
+        assert row["plugin"] == "makoto"
+        assert row["session_id"] == "s-attr"
+        assert row["tool_name"] == "Write"
+        assert row["hook_event"] == "PreToolUse"
+        assert row["id_source"] == "payload"
+
+
+def test_unparseable_stdin_still_recovers_the_ids(tmp_path):
+    """The row that was unattributable BY DESIGN.
+
+    An envelope that does not parse has no object to read ids from, which is exactly why these rows
+    used to carry none. A flat scan of the raw text recovers them, and `id_source: raw-scan` says so
+    -- a recovered id that does not admit it was recovered would be worse than no id at all.
+    """
+    state_dir = _setup_state(tmp_path)
+    _run_raw(state_dir, b'{"hook_event_name":"PreToolUse","tool_name":"Bash",'
+                        b'"session_id":"s-trunc","tool_input":{"comm')
+    rows = [r for r in _errors(state_dir) if r["pattern_id"] == "dispatch.unparseable_payload"]
+    assert len(rows) == 1
+    assert rows[0]["session_id"] == "s-trunc"
+    assert rows[0]["tool_name"] == "Bash"
+    assert rows[0]["id_source"] == "raw-scan"
+
+
+def test_predicate_faults_are_attributed_too(tmp_path, monkeypatch):
+    """A predicate that raises is the other half of this log, and it was equally anonymous."""
+    from makoto.state import audit
+    audit.append_error(Path(state_dir := _setup_state(tmp_path)), 7, "content.some_check",
+                       ValueError("boom"), session_id="s-pred", tool_name="Edit",
+                       hook_event="PreToolUse", id_source="payload")
+    row = _errors(state_dir)[-1]
+    assert row["session_id"] == "s-pred" and row["tool_name"] == "Edit"
+    assert row["plugin"] == "makoto" and row["exc_type"] == "ValueError"
+
+
+def test_pre_upgrade_rows_still_parse(tmp_path):
+    """Additive, not a schema break: a row written before this change has no new keys, and the
+    reader must not require them."""
+    state_dir = _setup_state(tmp_path)
+    log = Path(state_dir) / "dispatch_errors.jsonl"
+    log.write_text(json.dumps({"ts": "2026-01-01T00:00:00+00:00", "event_id": None,
+                               "pattern_id": "dispatch.exception", "exc_type": "ValueError",
+                               "exc_message": "old"}) + "\n")
+    from makoto.state import audit
+    rows = list(audit.read_errors(Path(state_dir)))
+    assert len(rows) == 1 and rows[0].get("session_id", "") == ""
+
+
+# --- the fail-open must be visible, not merely logged ----------------------------------------
+
+def test_fail_open_emits_a_user_visible_system_message(tmp_path):
+    """A loud-allow whose only "loud" is stderr is a silent one.
+
+    Hook stderr on exit 0 goes to the debug log only -- not the transcript, not the user, not the
+    model. `systemMessage` is the universal output field that IS surfaced. The fail DIRECTION is
+    unchanged (still open, still exit 0); only its visibility is.
+    """
+    state_dir = _setup_state(tmp_path)
+    code, out = _run_raw(state_dir, b'{"hook_event_name":"PreToolUse","tool_name":"Bash",'
+                                    b'"session_id":"s-vis","tool_input":{"comm')
+    assert code == 0
+    body = json.loads(out)
+    assert "ALLOWED WITHOUT BEING CHECKED" in body["systemMessage"]
+
+
+def test_a_real_decision_keeps_the_wire_to_itself(tmp_path):
+    """The wire carries exactly one JSON object. A notice must never be appended behind a deny."""
+    state_dir = _setup_state(tmp_path)
+    code, out = _run_dispatch(state_dir, {
+        "hook_event_name": "PreToolUse", "tool_name": "WebFetch", "session_id": "s-deny",
+        "cwd": "/tmp", "tool_input": {"url": "https://invented-host.example/v3/api"}})
+    assert code == 0
+    body = json.loads(out)  # would raise on a second concatenated object
+    assert body["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_clean_call_emits_no_notice(tmp_path):
+    """No fault, no message. The channel only stays credible if it is quiet by default."""
+    state_dir = _setup_state(tmp_path)
+    code, out = _run_dispatch(state_dir, {
+        "hook_event_name": "PreToolUse", "tool_name": "Read", "session_id": "s-quiet",
+        "cwd": "/tmp", "tool_input": {"file_path": "/tmp/a"}})
+    assert code == 0 and out == ""
+
+
+def test_a_repaired_payload_is_not_reported_as_unchecked(tmp_path):
+    """REPAIRED is not loud-allow. The call WAS checked, so no fail-open notice is emitted."""
+    state_dir = _setup_state(tmp_path)
+    code, out = _run_raw(state_dir, b'{"hook_event_name":"PreToolUse","tool_name":"Read",'
+                                    b'"session_id":"s-rep","cwd":"/tmp",'
+                                    b'"tool_input":{"file_path":"/tmp/a\x9d"}}')
+    assert code == 0
+    assert out == "", "a repaired-and-evaluated call must not claim it went unchecked"

--- a/tests/test_wire_surrogates.py
+++ b/tests/test_wire_surrogates.py
@@ -1,0 +1,192 @@
+"""The byte boundary: a host byte that is not valid UTF-8 must never skip a check.
+
+REGRESSION ORIGIN (live, measured). `dispatch.main()` opened with `sys.stdin.read()`. A hook
+subprocess inherits no LANG, so CPython enables UTF-8 mode and gives stdin the `surrogateescape`
+error handler; a byte the host wrote that is not valid UTF-8 therefore entered as a LONE SURROGATE
+rather than raising or being replaced. It survived `json.loads`, reached `_ingest_event`, and died
+there, because sqlite3 encodes bind parameters strictly::
+
+    UnicodeEncodeError: 'utf-8' codec can't encode character '\\udc9d'
+                        in position 143: surrogates not allowed
+
+`\\udc9d` is `0xDC00 + 0x9D` -- the surrogateescape of byte 0x9D. `main()`'s catch-all then wrote a
+`loud-allow` fact and exited 0, so the tool call PROCEEDED WITH NO CHECK HAVING RUN. 30 of these in
+one day, all of them Makoto failing open on its own bug.
+
+The tests below pin the exact reproducer bytes, not a paraphrase of them.
+"""
+from __future__ import annotations
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.conftest import _setup_state
+
+REPO_ROOT = Path(__file__).parent.parent
+
+# The literal live crash envelope. 0x9D is raw, unescaped, and invalid UTF-8 exactly as the host
+# delivered it. Byte-level, because the whole defect lived below the character level: a test that
+# built this payload with json.dumps could not reproduce it at all.
+CRASH_BYTES = (
+    b'{"hook_event_name":"PreToolUse","tool_name":"Write","session_id":"s-crash",'
+    b'"cwd":"/tmp","tool_input":{"file_path":"/tmp/x.py","content":"hello \x9d world"}}'
+)
+
+
+def _run_bytes(state_dir, raw: bytes) -> tuple[int, str, str]:
+    """Run the real dispatcher with RAW BYTES on stdin. Returns (exit, stdout, stderr)."""
+    env = os.environ.copy()
+    env["MAKOTO_STATE_DIR"] = str(state_dir)
+    proc = subprocess.run([sys.executable, "-m", "makoto.dispatch"], input=raw,
+                          capture_output=True, env=env, cwd=str(REPO_ROOT))
+    return proc.returncode, proc.stdout.decode("utf-8"), proc.stderr.decode("utf-8", "replace")
+
+
+def _errors(state_dir) -> list:
+    f = Path(state_dir) / "dispatch_errors.jsonl"
+    if not f.exists():
+        return []
+    return [json.loads(ln) for ln in f.read_text().splitlines() if ln.strip()]
+
+
+def test_undecodable_byte_no_longer_crashes_the_dispatcher(tmp_path):
+    """The live reproducer: exit 0, and NOT ONE UnicodeEncodeError anywhere."""
+    state_dir = _setup_state(tmp_path)
+    code, _out, err = _run_bytes(state_dir, CRASH_BYTES)
+    assert code == 0
+    assert "UnicodeEncodeError" not in err
+    assert not [r for r in _errors(state_dir) if "UnicodeEncodeError" in r.get("exc_message", "")]
+
+
+def test_undecodable_byte_is_repaired_not_allowed_unchecked(tmp_path):
+    """The substantive claim: the payload is REPAIRED and evaluation continues.
+
+    A row saying `loud-allow` would mean the call went through unchecked, which is the defect. The
+    disposition is the assertion -- exit 0 alone cannot tell the two apart.
+    """
+    state_dir = _setup_state(tmp_path)
+    _run_bytes(state_dir, CRASH_BYTES)
+    rows = [r for r in _errors(state_dir) if r["pattern_id"] == "dispatch.unencodable_input"]
+    assert len(rows) == 1
+    assert rows[0]["exc_message"].startswith("REPAIRED:")
+    assert "loud-allow" not in rows[0]["exc_message"]
+
+
+def test_repaired_event_still_reaches_the_predicates(tmp_path):
+    """The point of repairing rather than bailing: the CHECK STILL RUNS on the repaired payload.
+
+    Same undecodable byte, but the content now also carries a real violation. Before the fix this
+    envelope died in `_ingest_event` and the fabricated-URL check never saw it.
+    """
+    state_dir = _setup_state(tmp_path)
+    raw = (b'{"hook_event_name":"PreToolUse","tool_name":"WebFetch","session_id":"s-live",'
+           b'"cwd":"/tmp","tool_input":{"url":"https://invented-host\x9d.example/v3/api"}}')
+    code, out, _err = _run_bytes(state_dir, raw)
+    assert code == 0
+    assert "content.unsourced_webfetch" in out, "the check must fire on the repaired payload"
+
+
+def test_unpaired_surrogate_escape_is_also_closed(tmp_path):
+    """The OTHER door: valid UTF-8 bytes whose JSON text carries an unpaired \\uD8xx escape.
+
+    `wire.read_stdin` cannot see this one -- the escape is plain ASCII in the raw text -- so it is
+    `wire.scrub` on the parsed object that closes it. Both doors end at the same sqlite3 raise, so
+    a fix for only one of them is not a fix.
+    """
+    state_dir = _setup_state(tmp_path)
+    raw = (b'{"hook_event_name":"PreToolUse","tool_name":"Write","session_id":"s-esc",'
+           b'"cwd":"/tmp","tool_input":{"file_path":"/tmp/y.py","content":"hi \\ud89d there"}}')
+    code, _out, err = _run_bytes(state_dir, raw)
+    assert code == 0
+    assert "UnicodeEncodeError" not in err
+    rows = [r for r in _errors(state_dir) if r["pattern_id"] == "dispatch.unencodable_input"]
+    assert len(rows) == 1 and "1 unpaired surrogate escape" in rows[0]["exc_message"]
+
+
+def test_legitimate_replacement_char_is_not_counted_as_damage(tmp_path):
+    """A payload that genuinely contains U+FFFD is CLEAN and must produce no repair row.
+
+    Decoding straight to errors="replace" and counting U+FFFD would report damage here forever. A
+    repair count that cries wolf gets ignored, and the next real one goes with it.
+    """
+    state_dir = _setup_state(tmp_path)
+    payload = {"hook_event_name": "PreToolUse", "tool_name": "Write", "session_id": "s-fffd",
+               "cwd": "/tmp", "tool_input": {"file_path": "/tmp/z.py", "content": "legit � char"}}
+    code, _out, _err = _run_bytes(state_dir, json.dumps(payload).encode("utf-8"))
+    assert code == 0
+    assert [r for r in _errors(state_dir) if r["pattern_id"] == "dispatch.unencodable_input"] == []
+
+
+def test_clean_payload_takes_the_strict_path_unchanged(tmp_path):
+    """An ordinary envelope must be untouched: no repair row, no notice, empty wire."""
+    state_dir = _setup_state(tmp_path)
+    payload = {"hook_event_name": "PreToolUse", "tool_name": "Read", "session_id": "s-ok",
+               "cwd": "/tmp", "tool_input": {"file_path": "/tmp/a"}}
+    code, out, _err = _run_bytes(state_dir, json.dumps(payload).encode("utf-8"))
+    assert code == 0 and out == ""
+    assert _errors(state_dir) == []
+
+
+# --- unit-level guarantees of the boundary module itself ------------------------------------
+
+def test_scrub_reports_what_it_replaced():
+    from makoto.core import wire
+    text, n = wire.scrub_text("a\ud89db\udc9dc")
+    assert n == 2 and "\ud89d" not in text and "\udc9d" not in text
+
+
+def test_scrub_walks_nested_containers_and_keys():
+    from makoto.core import wire
+    value, n = wire.scrub({"k\ud89d": ["a", {"deep": "v\udc9d"}]})
+    assert n == 2
+    assert json.dumps(value)  # the whole point: it now serializes
+
+
+def test_scrub_returns_clean_input_untouched():
+    from makoto.core import wire
+    original = {"a": ["b", {"c": "d"}]}
+    value, n = wire.scrub(original)
+    assert n == 0 and value is original
+
+
+# --- found by an independent review pass, not by the tests above ------------------------------
+#
+# Both of these survived the first fix. They are kept as named regressions because each marks a
+# place where "we closed the boundary" was true and insufficient.
+
+def test_host_dialect_normalization_cannot_reintroduce_a_surrogate(tmp_path):
+    """THE THIRD DOOR. `hostdialect._tool_result` runs `json.loads` on Cursor's `tool_output`,
+    which arrives as a JSON *string*. An unpaired `\\ud800` escape inside that inner document is
+    plain ASCII in the outer payload, so neither the byte decode nor the post-parse scrub can see
+    it -- normalization is what materializes it, and the `ensure_ascii=False` reserialization then
+    carried it live into the sqlite3 bind.
+
+    Reproduced the ORIGINAL UnicodeEncodeError on a camelCase envelope with the boundary fix
+    already in place. A boundary is only a boundary if nothing downstream re-parses.
+    """
+    state_dir = _setup_state(tmp_path)
+    payload = {"hook_event_name": "postToolUse", "tool_name": "Bash", "session_id": "s-cursor",
+               "cwd": "/tmp", "tool_input": {"command": "echo hi"},
+               "tool_output": '{"error":"\\ud800 boom"}'}
+    code, _out, err = _run_bytes(state_dir, json.dumps(payload).encode("utf-8"))
+    assert code == 0
+    assert "UnicodeEncodeError" not in err
+    rows = _errors(state_dir)
+    assert not [r for r in rows if "UnicodeEncodeError" in r.get("exc_message", "")]
+    repaired = [r for r in rows if r["pattern_id"] == "dispatch.unencodable_input"]
+    assert repaired and "host-dialect normalization" in repaired[0]["exc_message"]
+
+
+def test_repair_count_is_bytes_not_malformed_runs():
+    """`errors="replace"` emits ONE U+FFFD per malformed RUN, so a truncated three-byte sequence
+    (two undecodable bytes) reported 1 -- under a field named "bytes repaired". `surrogateescape`
+    maps each bad BYTE to exactly one surrogate, so the count means what the field says."""
+    from makoto.core import wire
+    _text, n = wire._decode_counting(b"\xe2\x82")
+    assert n == 2, "two undecodable bytes must count as two"
+    _text, n = wire._decode_counting(b"x\x9dy")
+    assert n == 1
+    _text, n = wire._decode_counting("legit � char".encode("utf-8"))
+    assert n == 0, "a genuine U+FFFD is not damage"


### PR DESCRIPTION
## The crash, reproduced

A hook subprocess inherits no `LANG`, so CPython enables UTF-8 mode (PEP 540) and gives `sys.stdin` the `surrogateescape` error handler. Any host byte that is not valid UTF-8 therefore did not raise and was not replaced — it entered as a **lone surrogate**, one per bad byte, `0xDC00 + byte`. It survived `json.loads`, reached `_ingest_event`, and died there, because sqlite3 encodes bind parameters strictly:

```
UnicodeEncodeError: 'utf-8' codec can't encode character '\udc9d' in position 143: surrogates not allowed
```

`\udc9d` is byte `0x9D`. `main()`'s catch-all then recorded a `loud-allow` fact and returned 0, **so the tool call proceeded with no check having run** — 30 times in one day, every one of them Makoto failing open on its own bug.

`tests/test_wire_surrogates.py` pins the exact reproducer bytes, not a paraphrase of them.

## The fix: one boundary, three doors

`makoto/core/wire.py` reads stdin as **bytes** and guarantees no surrogate code point survives. Three doors are closed, not one:

1. **The raw byte** — the decode is taken away from the ambient locale's error handler and put under this module's control.
2. **An unpaired `\uD8xx` escape in the JSON text** — plain ASCII in the raw bytes, so the byte decode cannot see it; `json.loads` materializes it afterwards. Closed by scrubbing the parsed object.
3. **A surrogate re-introduced by `hostdialect`** — `_tool_result` runs a nested `json.loads` on Cursor's string-shaped `tool_output`, *after* the boundary scrub, and the `ensure_ascii=False` reserialization then carried it live into the sqlite3 bind.

**Door 3 survived the first fix.** It was found by an independent review pass (codex), not by the tests written alongside the original change, and it reproduced the *original* `UnicodeEncodeError` on a camelCase envelope with the boundary already in place. A boundary is only a boundary if nothing downstream re-parses.

Repairs are counted per **byte** — `surrogateescape` then scrub, not `errors="replace"`, which emits one U+FFFD per malformed *run* and so reported `1` for a truncated three-byte sequence under a field named "bytes repaired". A repaired payload is recorded as `REPAIRED`, deliberately **not** `loud-allow`: the call was checked.

## Attribution (`dispatch_errors.jsonl`)

Rows now carry `plugin`, `session_id`, `tool_name`, `hook_event`, `id_source`.

`audit.jsonl` has carried the session and tool since 1.0.2 and this log carried neither — so a *fire* was attributable and a *miss* was not, and every row here is a check that did not run. The log was informative in exactly the wrong direction. Where the envelope does not parse there is no object to read, so the ids are recovered by a flat scan of the raw text and `id_source` says `raw-scan`; a recovered id that does not admit it was recovered is worse than no id.

Additive — every field is keyword-only with a default and readers use `dict.get`, so pre-upgrade rows parse identically (pinned by a test).

## A fail-open is never silent

Hook stderr on exit 0 reaches the **debug log only** — not the transcript, not the user, not the model. So "loud-allow + a stderr line" was loud to nobody, and that is how 30 fail-opens went unnoticed. Every fail-open now also emits a `systemMessage` saying the call was **ALLOWED WITHOUT BEING CHECKED**. The fail *direction* is unchanged; only its visibility is. A real decision always outranks a notice — `_stdout_written` is the interlock that keeps the wire to exactly one JSON object.

Two existing tests asserted the silence itself (`assert proc.stdout == b""`) and were inverted, with the reason recorded in the test.

## `content.unsourced_webfetch` now matches its own subject

The mined defect is a **fabricated** URL. The implemented condition was "never seen in a prior `tool_result`" — and a URL the human typed into chat has never been in a `tool_result` either, so the check denied one. That is not a near-miss of the target; it is a different target, and it fires precisely when the agent is doing the most obviously correct thing available to it.

The exemption reads `ledger.user_turn_texts`, which admits only host-written, non-synthetic, non-tool-result user turns — so the agent cannot launder a fabricated URL into an exemption by emitting it as tool output first. **Verbatim only**: a host-only match would exempt every path under any domain the user ever mentioned, which is the fabrication this check exists to catch, one directory deeper. A missing transcript leaves the check exactly as strict as before.

## Tests

`1833 passed, 6 skipped, 1 xfailed` — full suite, green. 22 new tests across `tests/test_wire_surrogates.py`, `tests/test_dispatch_attribution.py`, `tests/predicates/test_unsourced_webfetch_user_supplied.py`.

## Related

Bench-wide policy this implements: [`Courthouse docs/FAIL-DIRECTION.md`](https://github.com/Clear-Sights/Courthouse/blob/main/docs/FAIL-DIRECTION.md). Sibling PRs on Ward and Gyroscope close the same root cause, which produced a *different* wrong verdict in each.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Na3jvk1egxPxokBTNUWMFy)_