### PR TITLE
Read the release version from the manifest, and add the 2.4.0 changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,6 @@ name: Manual Release
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to release (e.g. 2.0.0), must match a CHANGELOG.md ## [X.Y.Z] heading'
-        required: true
-        default: '2.0.0'
 
 permissions:
   contents: write
@@ -19,9 +14,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The version is READ, never typed. A hand-entered release input is exactly what cut
+      # `v2.4.0` against a manifest still declaring `2.3.0`: the tag and the number a user
+      # actually installs came from two places and nothing compared them. One source, one value,
+      # and the disagreement becomes unrepresentable rather than merely discouraged.
+      - name: Derive the version from the plugin manifest
+        id: version
+        run: |
+          VERSION=$(python3 -c "import json; print(json.load(open('plugin/.claude-plugin/plugin.json'))['version'])")
+          PACKAGED=$(python3 -c "import re, pathlib; print(re.search(r'^version\s*=\s*\"([^\"]+)\"', pathlib.Path('pyproject.toml').read_text(encoding='utf-8'), re.M).group(1))")
+          if [ "$VERSION" != "$PACKAGED" ]; then
+            echo "plugin.json declares $VERSION but pyproject.toml declares $PACKAGED" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "releasing v$VERSION"
+
       - name: Extract release notes from CHANGELOG.md
         run: |
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION="${{ steps.version.outputs.version }}"
           awk -v ver="$VERSION" '
             $0 ~ ("^## \\[" ver "\\]") {flag=1; next}
             flag && /^## \[/ {flag=0}
@@ -38,7 +49,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION="${{ steps.version.outputs.version }}"
           TAG="v$VERSION"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to makoto. Versions follow the live check inventory
 
 ## [Unreleased]
 
+## [2.4.0] — 2026-08-20
+
+### Added
+- **`PostToolUseFailure` is wired**, and `canon.recur` carries a transient budget, so a call that
+  failed for an infrastructural reason and then resolved is no longer reported as STUCK.
+- **Reproducible corpus replay** (`python3 eval/replay.py`) as release-time evidence.
+
+### Fixed
+- **Fail-open holes that turned a fired DENY into exit 0.** Two paths in `verdict`/`dispatch`
+  raised a decision and then exited successfully anyway; a denial that is not delivered is
+  indistinguishable, from the outside, from a call that was never judged.
+- **Logging failures no longer change verdicts.** A journal write that failed could flip the
+  decision it was only supposed to record, and three wrong-verdict paths alongside it.
+- **The surrogate fail-open**: undecodable bytes crashed the encoder and the crash read as
+  allow. Every `dispatch_errors` row is now attributed, and `unsourced_webfetch` was narrowed.
+- Three further decision-integrity holes in `selfMuteGuard`/`kit`.
+- `configchange` imported `Path` too late for `_resolved_config_path` to resolve.
+- `hollowTest` resolves imported assert-helpers, so its own teeth tests stop firing on helpers.
+- Reverted a transcript `islice` bound that produced a denial resting on a false fact.
+
+### Internal (no user-facing behavior change)
+- **The installed subtree is `plugin/`**, so the test suite stops shipping to users, and the
+  declared subpackages are actually built — `makoto.state`/`makoto.core` were absent from the
+  built distribution, which made the hook die on import in a real install.
+- The 102-file review corpus moved out of the public tree; two dead functions removed by
+  mechanical inventory; a per-file simplify pass across `plugin/makoto`.
+
 ## [2.3.0] — 2026-08-16
 
 ### Added

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "makoto",
   "description": "Holds Claude Code to its word — every claim checked against the agent's own logged record; faked checks blocked, not warned (four narrow advisory self-checks excepted). Two-tier catalog (15 pre-checks, 19 Stop gates), each shipped at measured zero false positives.",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "author": {"name": "Clear-Sights"},
   "homepage": "https://github.com/Clear-Sights/Makoto",
   "repository": "https://github.com/Clear-Sights/Makoto",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "makoto"
-version = "2.3.0"
+version = "2.4.0"
 description = "Integrity hook for Claude Code — holds the agent's claims against its own logged deeds and blocks faked checks; every check ships at measured zero false positives"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## The defect

`release.yml` took the version as a hand-entered `workflow_dispatch` input and never compared it to `plugin/.claude-plugin/plugin.json`. `release/v2.4.0` was cut while the plugin still declared `2.3.0`:

```
$ git show aa2e434:plugin/.claude-plugin/plugin.json | grep version
  "version": "2.3.0",
```

Separately, the workflow refuses to release without a matching `## [X.Y.Z]` CHANGELOG heading — and no `## [2.4.0]` section existed, so a 2.4.0 release would have failed at that gate regardless.

## The fix

- Delete the input; derive the version from `plugin.json`, so tag and declared version cannot disagree. The step fails the release if `plugin.json` and `pyproject.toml` drift.
- Bump both to `2.4.0`.
- Add the `## [2.4.0]` changelog section, written from the actual 26-commit range `8fdcb9b..aa2e434` rather than from memory — the fail-open holes that turned a fired DENY into exit 0, the surrogate fail-open, journal failures changing verdicts, the `plugin/` installed-subtree move, and the `PostToolUseFailure` wiring.

## Verification

- `PYTHONPATH=plugin python3 -m pytest -q tests/` → **1903 passed, 5 skipped, 1 xfailed**
  (`PYTHONPATH` pinned deliberately: a stale editable install otherwise resolves `makoto` to another tree)
- Workflow parses; trigger is `{'workflow_dispatch': None}` with the derive step present
- The CHANGELOG extractor's `awk` gate now finds a `## [2.4.0]` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Na3jvk1egxPxokBTNUWMFy)_