### PR TITLE
Pin the import provenance the pytest config already arranges, and fix the macOS job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
   test-macos:
     # public repo only: macOS minutes bill 10x on private repos (the dev mirror)
-    if: github.repository == 'skill-labV2/Makoto'
+    if: github.repository == 'Clear-Sights/Makoto'
     name: pytest (macos, py3.13)
     runs-on: macos-latest
     steps:

--- a/tests/test_plugin_metadata.py
+++ b/tests/test_plugin_metadata.py
@@ -13,6 +13,26 @@ PLUGIN = REPO_ROOT / "plugin"
 _SEMVER_RX = re.compile(r"^\d+\.\d+\.\d+(?:[-.][\w.]+)?$")
 
 
+def test_the_package_under_test_came_from_this_checkout():
+    """A green run here is evidence about THIS tree only if `makoto` was imported from it.
+
+    A bare `python3 -m pytest` in this repository resolves `makoto` to a DIFFERENT one via a
+    stale `__editable__.makoto-2.3.0.pth` in dist-packages, so `tests/` is read from this tree
+    while the package under test comes from another -- a split-brained run that reports passes
+    about code this branch does not contain. The review corpus recorded the same shape three
+    separate times, each time as an aside to some other finding, because nothing asserted it.
+
+    The two version tests in this file compare declarations that both live in this repository,
+    so they stay green under exactly this condition. This one names where the bytes came from.
+    CI installs this checkout (`pip install -e .`) and satisfies it."""
+    import makoto
+    origin = Path(makoto.__file__).resolve()
+    assert origin.is_relative_to(PLUGIN), (
+        f"tests import makoto from {origin}, which is outside {PLUGIN}: this run grades a "
+        f"different tree. Re-run with PYTHONPATH={PLUGIN}, or remove the stale editable install"
+    )
+
+
 def _pyproject_version() -> str:
     """extract the project version from pyproject.toml without a TOML parser."""
     text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Import provenance

`pyproject.toml` already carries the right setting, with a comment naming this exact hazard:

```toml
[tool.pytest.ini_options]
pythonpath = ["plugin"]
```

It works — but nothing asserted it, so the line could be deleted and every green run afterwards would look identical. Outside pytest the hazard is still live:

```
$ python3 -c "import makoto; print(makoto.__file__)"
/home/user/makoto-dev/plugin/makoto/__init__.py
```

The two version tests in the same file cannot cover this: both read declarations out of *this* repository, so they pass unchanged while the package under test comes from somewhere else. The review corpus recorded this shape three separate times, each as an aside to some other finding, because nothing asserted it.

**Proven able to fail** — commenting out `pythonpath = ["plugin"]`:

```
FAILED tests/test_plugin_metadata.py::test_the_package_under_test_came_from_this_checkout
2 failed, 6 passed
```

restored, and `8 passed`. That is the only reason to add a check for something already correct.

## macOS CI job

```yaml
if: github.repository == 'skill-labV2/Makoto'
```

The repository moved to `Clear-Sights`, so this has been false ever since and the job reports `skipped` rather than running anywhere — the opposite of the public-repo-only intent its own comment states. Observed on the previous PR's checks: `pytest (macos, py3.13) — skipped`.

## Verification

`python3 -m pytest -q tests/` → **1904 passed, 5 skipped, 1 xfailed** (was 1903; +1 is the new assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Na3jvk1egxPxokBTNUWMFy)_