### PR TITLE
Point the sequence seat at Keel

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ install from the [Courthouse](https://github.com/Clear-Sights/Courthouse) market
 | Engine | Judges | One line |
 |---|---|---|
 | [**Ward**](https://github.com/Clear-Sights/Ward) | the pending **act** | nothing outright bad happens |
-| [**Gyroscope**](https://github.com/Clear-Sights/Gyroscope) | the **sequence** | a session neither capsizes nor gets lost |
+| [**Keel**](https://github.com/Clear-Sights/Keel) | the **sequence** | a session neither capsizes nor gets lost |
 | **Makoto** (this repo) | the **statement** | words aren't empty |
 
 ## Non-plugin install (power users)

--- a/plugin/makoto/state/audit.py
+++ b/plugin/makoto/state/audit.py
@@ -144,7 +144,7 @@ def append_error(state_root: Path, event_id: int | None,
     means recovered by scanning the raw stdin text, "" means none were available. A recovered id
     that does not say it was recovered is worse than no id, so the provenance ships with the value.
 
-    `plugin` is constant here and deliberately so: Ward, Gyroscope and Makoto all register
+    `plugin` is constant here and deliberately so: Ward, Keel and Makoto all register
     PreToolUse `*` and all three can emit a deny, so a row that does not name its author is
     unattributable the moment more than one of them is installed -- which is the shipped
     Courthouse configuration.


### PR DESCRIPTION
The sibling that judges the sequence ships as **Keel** from v2.0.0 (Keel #11). Its repository is renamed and GitHub redirects the old links.

## The rule applied

A mention that tells a reader **where to go now** is renamed. A mention that records **what was observed** keeps the name it was observed under — renaming measured evidence would make the record say something that was never measured.

**Renamed** (live pointers): the sibling table in `README.md`, and the bench statement in `plugin/makoto/state/audit.py` about who else registers `PreToolUse *` in the shipped marketplace configuration.

**Left alone** (measured): `plugin/makoto/core/wire.py` recounts the lone-surrogate incident with the verdict each plugin gave at the time; `plugin/makoto/checks/hollowTest.py` and `tests/test_hollow_test_analyzer.py` record which tests the analyzer was measured firing on; `plugin/makoto/dispatch.py` cites a precedent as it stood. Courthouse's `docs/FAIL-DIRECTION.md` carries the one note explaining the two names, so it is stated once for the bench rather than at every mention.

## Verification

`python3 -m pytest -q` → **1904 passed, 5 skipped, 1 xfailed**.

No version bump: this changes descriptive text only, and Courthouse's pin at `v2.4.0` is unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VanVP39tmmxY6yESx7gvbG)_