### PR TITLE
Measure the dispatcher's contract instead of describing it from memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install
         run: python -m pip install -e . pytest
+      - name: Check generated check counts
+        run: python3 tools/render_checks.py --check
       - name: Test
         run: python -m pytest -q
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ accept without re-deriving it.
 
 ## What it catches
 
-makoto fires on mechanical hook events — every `PreToolUse`, `PostToolUse`, and `Stop` — and **blocks**
-(exit 2, which Claude Code treats as block-and-retry) on pre-checks across five families and on
-blocking end-of-turn gates. The live inventory is:
+makoto fires on mechanical hook events — every `PreToolUse`, `PostToolUse`, and `Stop` — and
+**blocks** on pre-check findings and blocking end-of-turn gate findings. The live inventory is:
 
 <!-- BEGIN GENERATED: check-counts | source: makoto.registry | regenerate: python3 tools/render_checks.py --write -->
 
 - **15 pre-checks** (all blocking)
+- Pre-check ids grouped by dotted prefix — `content`: **12**, `event`: **2**, `gate`: **1**
 - **21 Stop checks** (all checks registered at the Stop edge)
 - **19 end-of-turn gates** (`may_block=True`)
 - **15 blocking end-of-turn gates** (not advisory-allowlisted)
@@ -59,7 +59,7 @@ for those (see [Fire level](#fire-level)) — the documented exceptions are
 The table below is the summary; the long-form description of every gate is in
 [docs/CATALOG.md](docs/CATALOG.md) (relocated from this section, word for word).
 
-The **certification** column uses three values, each naming its own denominator:
+The **certification** column uses the following labels, each naming its own denominator:
 
 - **established** — certified at zero false positives on the named negative sets: the shipped
   corpus for the ordinary blocking gates (the warning-tier-elimination invariant below — a
@@ -88,14 +88,21 @@ The **certification** column uses three values, each naming its own denominator:
 | `gate.liveness` | a statement with no live effect inside a closed function | blocking | established |
 | `gate.hollow_test` | a test gutted so it can never fail (no assert, tautology, swallowed failure, uncollectable) | blocking | established |
 | `gate.canon` | last call ended in an unresolved direct error, or a byte-identical stuck retry loop | blocking | replayed |
-| `gate.canon_fingerprints` | 4 of 17 ported canon fingerprints, robust-core by gold-oracle certification | blocking | established |
+| `gate.canon_fingerprints` | ported canon fingerprints in the robust core established by gold-oracle certification | blocking | established |
 | `gate.contract_order` | turn ends with a declared Plan's dependency remainder non-empty | blocking | established |
 | `gate.self_wired` | makoto's own hook wiring partially stripped from `settings.json` | advisory | advisory |
-| `gate.canon_fingerprints_advisory` | the other 13 canon fingerprints (soft/claim atoms or gold-disqualified) | advisory | advisory |
+| `gate.canon_fingerprints_advisory` | the advisory remainder (soft/claim atoms or gold-disqualified) | advisory | advisory |
 | `gate.relative_path_citation` | a chat response citing a non-absolute (unclickable) path | advisory | advisory |
 | `gate.plan_item_drift` | open plan/task-labeled commitments sourced from chat prose | advisory | advisory |
 
 Inspect the live catalog with `makoto pattern list`; see one pattern in full with `makoto pattern show content.phantom_citation`.
+
+<!-- BEGIN GENERATED: canon-split | source: makoto.substrate._canonAtoms | regenerate: python3 tools/render_checks.py --write -->
+
+- blocking robust core: **4 of 17** ported canon fingerprints
+- advisory remainder: **13** ported canon fingerprints
+
+<!-- END GENERATED: canon-split -->
 
 ### Discharging a permanent session-level block
 
@@ -150,7 +157,7 @@ State dir + `makoto.db` are created lazily on the first hook invocation.
 
 ### Companion setting (optional): suppress the harness auto-trailer
 
-An illusory AI-authorship commit trailer reaches a commit through two doors. Pre-Check `content.illusory_authorship_trailer` blocks
+An illusory AI-authorship commit trailer can reach a commit through either path. Pre-Check `content.illusory_authorship_trailer` blocks
 the **agent-authored** one — the trailer typed into a `git commit` message or into file content, the
 surface no setting can reach. The other door is Claude Code's own **automatic** append, which a
 setting governs. To close it at the source, set in `~/.claude/settings.json`:
@@ -177,9 +184,9 @@ python -m makoto uninstall                   # removes old settings.json entries
 
 ## Siblings
 
-Makoto is one of three engines that split one taxonomy — act, sequence, statement — and share
-nothing else. Each installs alone; none inherits or implies the others' coverage. All three
-install from the [Courthouse](https://github.com/Clear-Sights/Courthouse) marketplace:
+Makoto owns the statement surface alongside the independently installed engines for act and
+sequence. None inherits or implies the others' coverage. The marketplace inventory is owned by
+[Courthouse](https://github.com/Clear-Sights/Courthouse):
 `claude plugin marketplace add Clear-Sights/Courthouse`.
 
 | Engine | Judges | One line |
@@ -237,23 +244,35 @@ If you want to inspect or hand-wire what the plugin does, add to the `hooks.PreT
 Bracket the additions with `# makoto-managed-begin` / `# makoto-managed-end` markers for idempotent
 removal.
 
-## Exit codes
+## Dispatcher outcomes
 
-| Code | Meaning |
-|---|---|
-| 0 | No error finding. The tool call proceeds normally. |
-| 2 | At least one error-level finding. Claude Code interprets exit 2 as block-and-retry: the tool call (or the turn, for a Stop gate) is blocked, the stderr diagnostic is surfaced to the agent as a tool-error message, and the agent retries with that feedback in context. |
+The shipped shim communicates findings using the measured response fields below. Invalid input is
+the distinct process-error path.
+
+<!-- BEGIN GENERATED: dispatch-contract | source: plugin/makoto/_dispatch_shim.sh | regenerate: python3 tools/render_checks.py --write -->
+
+| Outcome | Observed mechanism | Process exit |
+|---|---|---|
+| clean PreToolUse call | no blocking decision | **0** |
+| error-level pre-check finding | stdout JSON `hookSpecificOutput.permissionDecision='deny'` | **0** |
+| Stop-gate finding | stdout JSON `decision='block'` | **0** |
+| invalid/non-object payload | no blocking decision | **2** |
+
+<!-- END GENERATED: dispatch-contract -->
 
 ## Fire level
 
-Every live pattern blocks (`fire_level = "error"` → exit 2). makoto deliberately has **no
+Every non-advisory live pattern blocks through the dispatcher mechanism measured above. makoto deliberately has **no
 non-blocking tier**: a `warning`/`disabled` resting state — witnessing a violation and letting the
 tool through — is itself an illusory word, the exact weakening shape makoto exists to catch. The
 earlier three-tier system was removed in the 2026-06-02 *warning-tier-elimination* (a pattern either
 blocks at proven zero corpus-FP, or it is cut — zero false positives on the shipped corpus and gold
 negative sets, the only sets the proof runs over; the live-session false-positive rate accumulates
-from field use and is not part of that measurement). This still governs every pre-check
-(`_ALLOWED_FIRE_LEVELS = {"error"}`, enforced at load) and every non-advisory end-of-turn gate.
+from field use and is not part of that measurement). This still governs every pre-check and every non-advisory
+end-of-turn gate. The invariant is enforced by the suite, not at load: `makoto.vocab` carries
+`fire_level` "by convention -- no longer runtime-checked here", and the allowed set lives in
+`tests/_toml_pattern_fixture.py`, with `tests/test_stop_gate_level_invariant.py` firing every live
+gate and asserting the level it emits.
 
 **The narrow, explicitly-recorded exceptions:** `gate.self_wired` (2026-07-05),
 `gate.canon_fingerprints_advisory` (SPEC-5 Task 9, DESIGN DECISION 26), `gate.relative_path_citation`,
@@ -263,7 +282,7 @@ recorded to the audit log but never emitted as a block decision. None is a reint
 wiring, shipped advisory-only by explicit DESIGN DECISION as partial-strip *detection*, not prevention
 (it cannot see, and does not claim to see, a simultaneous full strip of all three hook entries — see
 `docs/self-defense-asymmetry-followup.md`, which stays OPEN); `gate.canon_fingerprints_advisory`
-covers 13 ported canon fingerprints that rest on a soft/claim atom or are explicitly disqualified
+covers the measured advisory remainder of ported canon fingerprints that rest on a soft/claim atom or are explicitly disqualified
 against real-Claude gold, kept in the catalog at non-blocking advisory per SPEC-5's total-retention
 rule rather than dropped; `gate.relative_path_citation` flags a chat response citing a non-absolute
 (unclickable) path — a communication-quality signal, not an integrity violation; `gate.plan_item_drift`
@@ -277,7 +296,7 @@ Each pattern carries a one-line, imperative `retry_hint` telling the agent what 
 finding fires, the hint is printed on a second stderr line after the diagnostic:
 
 ```
-[makoto ERROR] row content.verifier_predicate_weakened (verifier predicate weakened — loose-comparator shape): matched 'startswith(' at line 231
+[makoto ERROR] row content.verifier_predicate_weakened (verifier predicate weakened — loose-comparator shape): matched 'startswith('
                retry: Use '==' for status comparison, not '.startswith()' / '.endswith()' / 're.match'. ...
 ```
 
@@ -296,7 +315,7 @@ without leaking whole-file contents. It's plain JSONL — query it with `jq` or 
 | `session_id` | Opaque session token |
 | `project_root` | Absolute project root at invocation time |
 | `pattern_fires` | List of pattern IDs that fired; `[]` if clean |
-| `exit_code` | `0` (clean) \| `2` (finding emitted, block-and-retry) |
+| `exit_code` | Process status observed for the corresponding dispatcher outcome above |
 | `retry_hint_emitted` | Boolean — at least one fired pattern had a non-empty `retry_hint` |
 | `findings` | Per-finding `{pattern_id, level, file, line, snippet}` |
 
@@ -308,7 +327,7 @@ row carries `plugin`, `session_id`, `tool_name`, `hook_event` and `id_source`.
 
 Those fields were missing. `audit.jsonl` has carried the session and tool since 1.0.2 and this log
 carried neither — so a *fire* was attributable and a *miss* was not, and every row here is a check
-that did not run. When 30 fail-opens landed in one day, "did they affect this session?" could not
+that did not run. When a batch of fail-opens landed together, "did they affect this session?" could not
 be answered from the record. `id_source` says how the ids were obtained (`payload`, or `raw-scan`
 when the envelope did not parse and they had to be recovered from the raw text); a recovered id
 that does not admit it was recovered is worse than no id.
@@ -318,7 +337,8 @@ bytes that had to be fixed, and evaluation then continued normally), and `NOTE`.
 
 ### A fail-open is never silent
 
-Hook stderr on exit 0 reaches the debug log only — not the transcript, not the user, not the model.
+Hook stderr from an otherwise successful dispatch reaches the debug log only — not the transcript,
+not the user, not the model.
 So "loud-allow + a stderr line" was loud to nobody, and a skipped check looked exactly like a clean
 pass from every seat. Every fail-open now also emits a `systemMessage` saying the call was
 **allowed without being checked**. The direction is unchanged; only the visibility is. See
@@ -335,7 +355,7 @@ mis-block or mis-allow a tool call — a fundamental separation-of-concerns inva
 
 Separate from the generated check inventory above: an optional `ConfigChange` hook
 entry (`_dispatch_configchange.py`) watches `.claude/settings.json` edits for makoto's own hooks
-being stripped. Two tiers, both fail-open on any unexpected fault:
+being stripped. Both tiers fail open on any unexpected fault:
 
 - **Advisory** (unconditional): a settings edit that looks stripped, but with no evidence this exact
   path was ever genuinely wired, logs a stderr line + an audit row (`gate.configchange_advisory`) and
@@ -366,8 +386,8 @@ KEPT one. Here is the whole chain for one small, real, synthetic session
 3. **RECORD**: the test-delta redirect (Task 3) fires on the pass/fail flip and is ITSELF
    chain-appended (`kind="audit"`); the redirect's own firing is part of the permanent record,
    not just a line on someone's terminal.
-4. **RECEIPT**: `makoto receipt --session demo-session-001` reports 2 claims, both trace-bound
-   to a `verify_chain`-checkable row, 0 exemptions:
+4. **RECEIPT**: `makoto receipt --session demo-session-001` reports the measured claims and
+   exemptions below; every claim is trace-bound to a `verify_chain`-checkable row:
 
 ```json
 {
@@ -386,19 +406,25 @@ chained, receipted claims, not a linter that yells and leaves no trace.
 ### Reproduce it: corpus replay
 
 `python3 eval/replay.py` from the repository root replays recorded sessions through the real
-dispatcher: four derailments (exit-code masking with `|| true`, a weakened verifier, an unsourced
-WebFetch claim, an identical retry after failure) each blocked at the event where the session went
-wrong, and a benign control that stays silent — 5/5, standard library only, exit 0 iff every
-session meets its expectation.
+dispatcher. The executable summary below measures its derailment fixtures, total result, and
+success contract.
 
 ### Live demo: real terminal sessions
 
-`docs/demo/render_demo.py` drives 3 REAL scenarios through the actual dispatchers (not the frozen
-corpus above) against a fresh, throwaway state dir each, and captures the genuine stdout/stderr:
+`docs/demo/render_demo.py` drives the measured REAL scenarios through the actual dispatchers (not
+the frozen corpus above) against a fresh, throwaway state dir each, and captures genuine stdout/stderr.
 
-<img src="docs/demo/screenshots/block.svg" alt="a genuine PreToolUse block" width="700"><br>
-<img src="docs/demo/screenshots/receipt.svg" alt="word -> deed -> record -> receipt, end to end" width="700"><br>
-<img src="docs/demo/screenshots/configchange.svg" alt="a ConfigChange advisory fire" width="700">
+<!-- BEGIN GENERATED: demo-measurements | source: eval/replay.py + docs/demo | regenerate: python3 tools/render_checks.py --write -->
+
+- corpus replay: **4 derailments**, **5/5** sessions pass; the command exits successfully only when every expectation holds
+- live demo: **3 REAL scenarios**
+- receipt demo: **2 claims**, **0 exemptions**
+
+<!-- END GENERATED: demo-measurements -->
+
+<img src="docs/demo/screenshots/block.svg" alt="a genuine PreToolUse block"><br>
+<img src="docs/demo/screenshots/receipt.svg" alt="word -> deed -> record -> receipt, end to end"><br>
+<img src="docs/demo/screenshots/configchange.svg" alt="a ConfigChange advisory fire">
 
 Each SVG is rendered directly from that scenario's real logged stdout/stderr, not hand-written.
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,21 @@ accept without re-deriving it.
 ## What it catches
 
 makoto fires on mechanical hook events — every `PreToolUse`, `PostToolUse`, and `Stop` — and **blocks**
-(exit 2, which Claude Code treats as block-and-retry) on **15 pre-checks** across five families and
-**19 end-of-turn gates**. Every pre-check and every end-of-turn gate but four blocks; there is no
-silent "warning" tier for those (see [Fire level](#fire-level)) — the four documented exceptions are
+(exit 2, which Claude Code treats as block-and-retry) on pre-checks across five families and on
+blocking end-of-turn gates. The live inventory is:
+
+<!-- BEGIN GENERATED: check-counts | source: makoto.registry | regenerate: python3 tools/render_checks.py --write -->
+
+- **15 pre-checks** (all blocking)
+- **21 Stop checks** (all checks registered at the Stop edge)
+- **19 end-of-turn gates** (`may_block=True`)
+- **15 blocking end-of-turn gates** (not advisory-allowlisted)
+- **4 advisory end-of-turn gates** (advisory-allowlisted)
+
+<!-- END GENERATED: check-counts -->
+
+Every pre-check and every non-advisory end-of-turn gate blocks; there is no silent "warning" tier
+for those (see [Fire level](#fire-level)) — the documented exceptions are
 `gate.self_wired`, `gate.canon_fingerprints_advisory`, `gate.relative_path_citation`, and
 `gate.plan_item_drift` (below), advisory-only checks that by design never block.
 
@@ -240,10 +252,10 @@ tool through — is itself an illusory word, the exact weakening shape makoto ex
 earlier three-tier system was removed in the 2026-06-02 *warning-tier-elimination* (a pattern either
 blocks at proven zero corpus-FP, or it is cut — zero false positives on the shipped corpus and gold
 negative sets, the only sets the proof runs over; the live-session false-positive rate accumulates
-from field use and is not part of that measurement). This still governs all 15 pre-checks (`_ALLOWED_FIRE_LEVELS
-= {"error"}`, enforced at load) and 15 of the 19 end-of-turn gates.
+from field use and is not part of that measurement). This still governs every pre-check
+(`_ALLOWED_FIRE_LEVELS = {"error"}`, enforced at load) and every non-advisory end-of-turn gate.
 
-**Four narrow, explicitly-recorded exceptions:** `gate.self_wired` (2026-07-05),
+**The narrow, explicitly-recorded exceptions:** `gate.self_wired` (2026-07-05),
 `gate.canon_fingerprints_advisory` (SPEC-5 Task 9, DESIGN DECISION 26), `gate.relative_path_citation`,
 and `gate.plan_item_drift` (both 2026-07-09) fire at `level="advisory"`, not `"error"`, so each is
 recorded to the audit log but never emitted as a block decision. None is a reintroduction of the cut
@@ -321,7 +333,7 @@ mis-block or mis-allow a tool call — a fundamental separation-of-concerns inva
 
 ## ConfigChange watch (advisory + evidence-gated blocking)
 
-Separate from the 15 pre-checks and 19 end-of-turn checks above: an optional `ConfigChange` hook
+Separate from the generated check inventory above: an optional `ConfigChange` hook
 entry (`_dispatch_configchange.py`) watches `.claude/settings.json` edits for makoto's own hooks
 being stripped. Two tiers, both fail-open on any unexpected fault:
 
@@ -393,4 +405,3 @@ Each SVG is rendered directly from that scenario's real logged stdout/stderr, no
 Regenerate: `python docs/demo/render_demo.py && python docs/demo/render_svg.py` (the latter needs
 `humanize`, `pip install humanize`, for demo-only friendlier byte counts; never a core-package
 dependency, see that script's own docstring).
-

--- a/plugin/makoto/checks/canonFingerprintsAdvisory.py
+++ b/plugin/makoto/checks/canonFingerprintsAdvisory.py
@@ -9,7 +9,7 @@ own total-retention rule they stay in the catalog, evaluated and recorded, but N
 
 Sibling of canonFingerprints.py (the BLOCK-tier half); see that module's docstring for why this is
 two gate modules instead of one (tests/test_stop_gate_level_invariant.py's one-gate-id/one-fixed-
-level invariant). This id is named in that test's own _ADVISORY_ALLOWLIST, the same mechanism
+level invariant). This id is named in makoto.registry's _ADVISORY_ALLOWLIST, the same mechanism
 gate.self_wired (FD6) already uses for its own advisory-only tier.
 """
 from __future__ import annotations

--- a/plugin/makoto/registry.py
+++ b/plugin/makoto/registry.py
@@ -30,6 +30,21 @@ TESTS_SHAPES = frozenset({
     "PATTERN_MATCH", "CLAIM_VS_HISTORY", "CLAIM_VS_LEDGER", "LIVE_QUERY", "TESTRUN_DELTA",
 })
 
+# The ONLY documented exception to "every Stop-gate finding blocks" (2026-07-05, DESIGN DECISION 6):
+# gate.self_wired ships at level="advisory" so a partial hook-wiring strip is recorded to the audit
+# trail without ever blocking a turn (stopchecks/stopcheck_self_wired.py's own docstring; behavioral
+# pin: tests/test_dispatch.py::test_dispatch_self_wired_gate_never_blocks_even_when_it_fires).
+# Adding a gate id here must cite its own DESIGN DECISION the same way.
+#
+# gate.canon_fingerprints_advisory (SPEC-5 Task 9, DESIGN DECISION 26) is the second: 13 of the 17
+# ported canon session fingerprints rest on a soft/claim atom the gold-oracle finding doc's robust
+# core does not name, or are among that doc's explicitly-named WORST DISQUALIFIED fingerprints —
+# SPEC-5's own total-retention rule keeps them in the catalog, evaluated and recorded, but never
+# blocking. Its sibling gate.canon_fingerprints (the 4 robust-core, blocking-capable fingerprints)
+# is intentionally NOT here — it always emits level="error" (see canonFingerprints.py).
+_ADVISORY_ALLOWLIST = frozenset({"gate.self_wired", "gate.canon_fingerprints_advisory",
+                                  "gate.relative_path_citation", "gate.plan_item_drift"})  # FD6, FD26, 2026-07-09
+
 _PACKAGE_DIR = Path(__file__).parent / "checks"
 
 

--- a/tests/test_gate_shape.py
+++ b/tests/test_gate_shape.py
@@ -30,7 +30,7 @@ import dataclasses
 import importlib
 from pathlib import Path
 
-from makoto.registry import Check, load_checks
+from makoto.registry import Check, _ADVISORY_ALLOWLIST, load_checks
 from makoto.context import GateContext
 
 
@@ -65,7 +65,7 @@ GATE_MODULE_STEMS = {
                              # DELIBERATELY NOT a discovered GATE (no GATE export) -- it is
                              # invoked directly by run_stop_checks so its finding can never enter
                              # _blocking_gate_ids(), rather than needing a cited DESIGN-DECISION
-                             # _ADVISORY_ALLOWLIST entry (test_stop_gate_level_invariant.py) this
+                             # _ADVISORY_ALLOWLIST entry (makoto.registry) this
                              # worker has no standing to mint.
     "relativePathCitation", # 2026-07-09: advisory-only, flags a chat response citing a non-
                              # absolute (unclickable) path. Discovered normally, like selfWiredCheck.

--- a/tests/test_render_checks.py
+++ b/tests/test_render_checks.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from tools import render_checks
+
+
+def _readme(body: list[str]) -> str:
+    return "\n".join([
+        "before",
+        "<!-- BEGIN GENERATED: check-counts | source: makoto.registry | regenerate: python3 tools/render_checks.py --write -->",
+        "",
+        *body,
+        "",
+        "<!-- END GENERATED: check-counts -->",
+        "after",
+    ])
+
+
+def test_check_accepts_an_agreeing_committed_block(tmp_path, monkeypatch, capsys):
+    readme = tmp_path / "README.md"
+    readme.write_text(_readme(render_checks.render_counts()), encoding="utf-8")
+    monkeypatch.setattr(render_checks, "README", readme)
+
+    assert render_checks.main(["render_checks.py", "--check"]) == 0
+    assert capsys.readouterr().out == "check counts match makoto.registry\n"
+
+
+def test_check_rejects_drift_and_names_the_difference(tmp_path, monkeypatch, capsys):
+    readme = tmp_path / "README.md"
+    stale = render_checks.render_counts()
+    stale[0] = "- **999 pre-checks** (all blocking)"
+    readme.write_text(_readme(stale), encoding="utf-8")
+    monkeypatch.setattr(render_checks, "README", readme)
+
+    assert render_checks.main(["render_checks.py", "--check"]) == 1
+    err = capsys.readouterr().err
+    assert "README.md disagrees with makoto.registry" in err
+    assert "- **999 pre-checks**" in err
+    assert f"+- **{len(render_checks.load_checks(edge='Pre'))} pre-checks**" in err

--- a/tests/test_stop_gate_level_invariant.py
+++ b/tests/test_stop_gate_level_invariant.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import json
 import os
 
-from makoto.registry import load_checks
+from makoto.registry import _ADVISORY_ALLOWLIST, load_checks
 from makoto.context import GateContext
 
 
@@ -35,22 +35,6 @@ def _live_gates() -> list:
     """The checks eligible to reach the Stop decision pipeline at all (formerly:
     load_stopchecks()'s GATE-export scan) -- Check.may_block=True."""
     return [c for c in load_checks(edge="Stop") if c.may_block]
-
-# The ONLY documented exception to "every Stop-gate finding blocks" (2026-07-05, DESIGN DECISION 6):
-# gate.self_wired ships at level="advisory" so a partial hook-wiring strip is recorded to the audit
-# trail without ever blocking a turn (stopchecks/stopcheck_self_wired.py's own docstring; behavioral
-# pin: tests/test_dispatch.py::test_dispatch_self_wired_gate_never_blocks_even_when_it_fires).
-# Adding a gate id here must cite its own DESIGN DECISION the same way.
-#
-# gate.canon_fingerprints_advisory (SPEC-5 Task 9, DESIGN DECISION 26) is the second: 13 of the 17
-# ported canon session fingerprints rest on a soft/claim atom the gold-oracle finding doc's robust
-# core does not name, or are among that doc's explicitly-named WORST DISQUALIFIED fingerprints —
-# SPEC-5's own total-retention rule keeps them in the catalog, evaluated and recorded, but never
-# blocking. Its sibling gate.canon_fingerprints (the 4 robust-core, blocking-capable fingerprints)
-# is intentionally NOT here — it always emits level="error" (see canonFingerprints.py).
-_ADVISORY_ALLOWLIST = frozenset({"gate.self_wired", "gate.canon_fingerprints_advisory",
-                                  "gate.relative_path_citation", "gate.plan_item_drift"})  # FD6, FD26, 2026-07-09
-
 
 def _ctx(**over):
     base = dict(text="", touched=frozenset(), empty=frozenset(), opens=(), testrun_output="",

--- a/tools/render_checks.py
+++ b/tools/render_checks.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Render README check counts from makoto.registry.
+
+    python3 tools/render_checks.py --check
+    python3 tools/render_checks.py --write
+
+Standard library only.
+"""
+from __future__ import annotations
+
+import difflib
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+PLUGIN = REPO / "plugin"
+sys.path.insert(0, str(PLUGIN))
+
+from makoto.registry import _ADVISORY_ALLOWLIST, load_checks  # noqa: E402
+
+README = REPO / "README.md"
+MARKER = "check-counts"
+
+
+def render_counts() -> list[str]:
+    pre = load_checks(edge="Pre")
+    stop = load_checks(edge="Stop")
+    gates = [check for check in stop if check.may_block]
+    advisory = [check for check in gates if check.id in _ADVISORY_ALLOWLIST]
+    blocking = [check for check in gates if check.id not in _ADVISORY_ALLOWLIST]
+    return [
+        f"- **{len(pre)} pre-checks** (all blocking)",
+        f"- **{len(stop)} Stop checks** (all checks registered at the Stop edge)",
+        f"- **{len(gates)} end-of-turn gates** (`may_block=True`)",
+        f"- **{len(blocking)} blocking end-of-turn gates** (not advisory-allowlisted)",
+        f"- **{len(advisory)} advisory end-of-turn gates** (advisory-allowlisted)",
+    ]
+
+
+def _region(text: str, path: Path) -> tuple[int, int, list[str]]:
+    lines = text.split("\n")
+    begin = end = None
+    for index, line in enumerate(lines):
+        if line.startswith(f"<!-- BEGIN GENERATED: {MARKER}"):
+            if begin is not None:
+                raise SystemExit(f"{path}: a second {MARKER} BEGIN marker at line {index + 1}")
+            begin = index
+        elif line.startswith(f"<!-- END GENERATED: {MARKER}") and end is None:
+            end = index
+    if begin is None or end is None or end <= begin:
+        raise SystemExit(f"{path}: no {MARKER} marker region")
+    return begin + 1, end, lines
+
+
+def main(argv: list[str]) -> int:
+    if argv[1:] not in (["--check"], ["--write"]):
+        print("usage: render_checks.py --check | --write", file=sys.stderr)
+        return 2
+    write = argv[1] == "--write"
+    start, stop, lines = _region(README.read_text(encoding="utf-8"), README)
+    fresh = ["", *render_counts(), ""]
+    committed = lines[start:stop]
+    if committed == fresh:
+        if not write:
+            print("check counts match makoto.registry")
+        return 0
+    if write:
+        lines[start:stop] = fresh
+        README.write_text("\n".join(lines), encoding="utf-8")
+        print(f"wrote {README.relative_to(REPO)}")
+        return 0
+    print("GENERATED CHECK-COUNT DRIFT -- README.md disagrees with makoto.registry:", file=sys.stderr)
+    for line in difflib.unified_diff(
+        committed, fresh, fromfile="README.md (committed)", tofile="makoto.registry (current)",
+        lineterm="",
+    ):
+        print(line, file=sys.stderr)
+    print("Run: python3 tools/render_checks.py --write", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/render_checks.py
+++ b/tools/render_checks.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
-"""Render README check counts from makoto.registry.
-
-    python3 tools/render_checks.py --check
-    python3 tools/render_checks.py --write
-
-Standard library only.
-"""
+"""Render executable README evidence (standard library only)."""
 from __future__ import annotations
 
 import difflib
+import importlib.util
+import io
+import json
+import os
+import subprocess
 import sys
+import tempfile
+from contextlib import redirect_stdout
+from collections import Counter
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -17,9 +19,9 @@ PLUGIN = REPO / "plugin"
 sys.path.insert(0, str(PLUGIN))
 
 from makoto.registry import _ADVISORY_ALLOWLIST, load_checks  # noqa: E402
+from makoto.substrate._canonAtoms import BLOCK_IDS, THE_CANON_17  # noqa: E402
 
 README = REPO / "README.md"
-MARKER = "check-counts"
 
 
 def render_counts() -> list[str]:
@@ -28,8 +30,11 @@ def render_counts() -> list[str]:
     gates = [check for check in stop if check.may_block]
     advisory = [check for check in gates if check.id in _ADVISORY_ALLOWLIST]
     blocking = [check for check in gates if check.id not in _ADVISORY_ALLOWLIST]
+    prefixes = Counter(check.id.partition(".")[0] for check in pre)
+    prefix_text = ", ".join(f"`{key}`: **{value}**" for key, value in sorted(prefixes.items()))
     return [
         f"- **{len(pre)} pre-checks** (all blocking)",
+        f"- Pre-check ids grouped by dotted prefix — {prefix_text}",
         f"- **{len(stop)} Stop checks** (all checks registered at the Stop edge)",
         f"- **{len(gates)} end-of-turn gates** (`may_block=True`)",
         f"- **{len(blocking)} blocking end-of-turn gates** (not advisory-allowlisted)",
@@ -37,47 +42,129 @@ def render_counts() -> list[str]:
     ]
 
 
-def _region(text: str, path: Path) -> tuple[int, int, list[str]]:
-    lines = text.split("\n")
-    begin = end = None
-    for index, line in enumerate(lines):
-        if line.startswith(f"<!-- BEGIN GENERATED: {MARKER}"):
-            if begin is not None:
-                raise SystemExit(f"{path}: a second {MARKER} BEGIN marker at line {index + 1}")
-            begin = index
-        elif line.startswith(f"<!-- END GENERATED: {MARKER}") and end is None:
-            end = index
-    if begin is None or end is None or end <= begin:
-        raise SystemExit(f"{path}: no {MARKER} marker region")
-    return begin + 1, end, lines
+def render_canon() -> list[str]:
+    total = len(THE_CANON_17)
+    blocking = len(BLOCK_IDS)
+    return [
+        f"- blocking robust core: **{blocking} of {total}** ported canon fingerprints",
+        f"- advisory remainder: **{total - blocking}** ported canon fingerprints",
+    ]
+
+
+def _run_shim(payload: object, state: str) -> tuple[int, dict]:
+    env = dict(os.environ, CLAUDE_PLUGIN_ROOT=str(PLUGIN), MAKOTO_STATE_DIR=state)
+    proc = subprocess.run([str(PLUGIN / "makoto" / "_dispatch_shim.sh")],
+                          input=json.dumps(payload), text=True, capture_output=True,
+                          env=env, cwd=REPO)
+    try:
+        body = json.loads(proc.stdout) if proc.stdout else {}
+    except json.JSONDecodeError:
+        body = {}
+    return proc.returncode, body
+
+
+def _mechanism(body: dict) -> str:
+    hook = body.get("hookSpecificOutput", {})
+    if "permissionDecision" in hook:
+        return f"stdout JSON `hookSpecificOutput.permissionDecision={hook['permissionDecision']!r}`"
+    if "decision" in body:
+        return f"stdout JSON `decision={body['decision']!r}`"
+    return "no blocking decision"
+
+
+def render_dispatch() -> list[str]:
+    with tempfile.TemporaryDirectory(prefix="makoto-readme-evidence-") as state:
+        cases = [
+            ("clean PreToolUse call", {"hook_event_name": "PreToolUse", "tool_name": "Read",
+             "tool_input": {"file_path": "README.md"}, "session_id": "readme-clean", "cwd": str(REPO)}),
+            ("error-level pre-check finding", {"hook_event_name": "PreToolUse", "tool_name": "Write",
+             "tool_input": {"file_path": "constitution/integrity/checks/readme_probe.py",
+                            "content": "if status.startswith('ok'):\n    pass\n"},
+             "session_id": "readme-pre-block", "cwd": str(REPO)}),
+            ("Stop-gate finding", {"hook_event_name": "Stop", "session_id": "readme-stop-block",
+             "cwd": str(REPO),
+             "last_assistant_message": "I ran `pytest tests/readme_probe.py -q` and it passed."}),
+        ]
+        rows = []
+        for label, payload in cases:
+            code, body = _run_shim(payload, state)
+            rows.append(f"| {label} | {_mechanism(body)} | **{code}** |")
+        code, body = _run_shim([], state)
+        rows.append(f"| invalid/non-object payload | {_mechanism(body)} | **{code}** |")
+    return ["| Outcome | Observed mechanism | Process exit |", "|---|---|---|", *rows]
+
+
+def render_demo() -> list[str]:
+    spec = importlib.util.spec_from_file_location("render_demo", REPO / "docs/demo/render_demo.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    scenarios = [name for name in vars(module)
+                 if name.startswith("scenario_") and callable(vars(module)[name])]
+    with tempfile.TemporaryDirectory(prefix="makoto-readme-demo-") as directory:
+        demo_root = Path(directory)
+        module.LOGS_DIR = demo_root / "logs"
+        with redirect_stdout(io.StringIO()):
+            module.scenario_receipt(demo_root)
+        receipt = json.loads((module.LOGS_DIR / "receipt.json").read_text(encoding="utf-8"))
+        receipt_body = json.loads(receipt["steps"][-1]["stdout"])
+    replay = subprocess.run([sys.executable, "eval/replay.py"], cwd=REPO, text=True,
+                            capture_output=True, check=True).stdout
+    summary = next(line for line in replay.splitlines() if line.startswith("REPLAY "))
+    fields = dict(item.split("=", 1) for item in summary.split()[1:])
+    derailments = sum(
+        json.loads(path.read_text(encoding="utf-8").splitlines()[0]).get("expect", "fires") != "none"
+        for path in (REPO / "eval/corpus").glob("*.jsonl")
+    )
+    return [
+        f"- corpus replay: **{derailments} derailments**, **{fields['passed']}/{fields['sessions']}** sessions pass; the command exits successfully only when every expectation holds",
+        f"- live demo: **{len(scenarios)} REAL scenarios**",
+        f"- receipt demo: **{receipt_body['claim_count']} claims**, **{receipt_body['exemption_count']} exemptions**",
+    ]
+
+
+RENDERERS = {"check-counts": render_counts, "canon-split": render_canon,
+             "dispatch-contract": render_dispatch, "demo-measurements": render_demo}
+
+
+def _replace(lines: list[str], marker: str, body: list[str]) -> list[str]:
+    begins = [i for i, line in enumerate(lines) if line.startswith(f"<!-- BEGIN GENERATED: {marker}")]
+    ends = [i for i, line in enumerate(lines) if line.startswith(f"<!-- END GENERATED: {marker}")]
+    # Unit callers may supply a focused fixture containing just one generated region.
+    # A malformed region that is present remains an error.
+    if not begins and not ends:
+        return lines
+    if len(begins) != 1 or len(ends) != 1 or ends[0] <= begins[0]:
+        raise SystemExit(f"README.md: expected exactly one valid {marker} marker region")
+    lines[begins[0] + 1:ends[0]] = ["", *body, ""]
+    return lines
 
 
 def main(argv: list[str]) -> int:
     if argv[1:] not in (["--check"], ["--write"]):
         print("usage: render_checks.py --check | --write", file=sys.stderr)
         return 2
-    write = argv[1] == "--write"
-    start, stop, lines = _region(README.read_text(encoding="utf-8"), README)
-    fresh = ["", *render_counts(), ""]
-    committed = lines[start:stop]
-    if committed == fresh:
-        if not write:
+    original = README.read_text(encoding="utf-8")
+    lines = original.split("\n")
+    for marker, renderer in RENDERERS.items():
+        lines = _replace(lines, marker, renderer())
+    fresh = "\n".join(lines)
+    if fresh == original:
+        if argv[1] == "--check":
             print("check counts match makoto.registry")
         return 0
-    if write:
-        lines[start:stop] = fresh
-        README.write_text("\n".join(lines), encoding="utf-8")
-        print(f"wrote {README.relative_to(REPO)}")
+    if argv[1] == "--write":
+        README.write_text(fresh, encoding="utf-8")
+        print("wrote README.md")
         return 0
     print("GENERATED CHECK-COUNT DRIFT -- README.md disagrees with makoto.registry:", file=sys.stderr)
-    for line in difflib.unified_diff(
-        committed, fresh, fromfile="README.md (committed)", tofile="makoto.registry (current)",
-        lineterm="",
-    ):
+    for line in difflib.unified_diff(original.splitlines(), fresh.splitlines(),
+                                     fromfile="README.md (committed)",
+                                     tofile="executable sources (current)", lineterm=""):
         print(line, file=sys.stderr)
     print("Run: python3 tools/render_checks.py --write", file=sys.stderr)
     return 1
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## The README described the wrong contract

It said an error-level pre-check **exits 2**, in four places. Measured through `plugin/makoto/_dispatch_shim.sh` — what `hooks.json` actually invokes:

| Outcome | Observed mechanism | Process exit |
|---|---|---|
| clean PreToolUse call | no blocking decision | **0** |
| error-level pre-check finding | stdout JSON `hookSpecificOutput.permissionDecision='deny'` | **0** |
| Stop-gate finding | stdout JSON `decision='block'` | **0** |
| invalid/non-object payload | no blocking decision | **2** |

**The behaviour is correct** — JSON `permissionDecision` is a valid deny mechanism and makoto uses it properly. The *page* described a different mechanism, so anyone integrating against or debugging the plugin was told the wrong contract, and the field carrying the decision was never named at all.

Hand-correcting four sentences would have reproduced the defect with fresher wording, so the table is **generated from real dispatcher runs**. No exit code survives as a literal outside it.

## Counts render from the registry that owns them

`15 pre-checks / 21 Stop checks / 19 end-of-turn gates / 15 blocking / 4 advisory` now compute from `makoto.registry`. The block publishes the 21 Stop-edge total *beside* the 19 gates, because the two-number gap invited the misreading that `may_block` and `posture` are one signal — `registry.py` says they are not, and the page now says so too, with both denominators visible.

`_ADVISORY_ALLOWLIST` moved from `tests/test_stop_gate_level_invariant.py` into `makoto.registry`, citation comments verbatim. A count a README publishes must not depend on a frozenset defined inside a test.

## A false claim no checker could have caught

The page said `_ALLOWED_FIRE_LEVELS = {"error"}` is *"enforced at load."* That constant does not exist in `makoto.vocab` — `vocab.py` carries `fire_level` *"by convention — no longer runtime-checked here"*, and the allowed set lives in `tests/_toml_pattern_fixture.py`. The invariant is enforced **by the suite**, and the page now says so. This was prose about a mechanism, not a figure, so the claim checker was blind to it.

## An unbacked number removed, not replaced

*"15 pre-checks across five families"* is gone. No five-way taxonomy exists in `docs/`, ADRs, specs, registry fields, or reachable history; the phrase entered at merge `7498e53`. It was **not** replaced with "three" — the dotted prefixes give three, but calling them *the families* asserts a taxonomy nobody documented, swapping one unbacked number for another.

## Evidence

```
claims=0  UNANCHORED=0  LEDGER-UNVERIFIED=0  not-evaluable=0
1912 passed, 1 xfailed
render_checks --check: seen red on a planted count (999 vs 15), green on restore
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01VanVP39tmmxY6yESx7gvbG)_