### PR TITLE
Carry the tier this page was declared, in the owner's own words

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ fix, verified the certificate — makoto holds that word against its record. If 
 or the verification was quietly disabled, makoto blocks the tool call (or the end-of-turn) and hands
 the agent a one-line correction to retry against.
 
+That publication claim is deliberately bounded: Shipped plugin — installable and versioned. The dispatcher is replay-tested against authored sessions; its effect on a live session's outcome is unmeasured.
+
 It judges the agent against its _own_ utterances and record — never the world's truth. It holds no
 facts ("France doesn't exist to it"); it only checks that a claimed word is kept, whole, and honored
 in deed. A word it lets through becomes spendable: trustworthy tender a reviewer or another agent can


### PR DESCRIPTION
## What

The README said what the plugin does and never what it **is**. `eval/TIERS.tsv` in Clear-Sights/Courthouse is the owner's declaration; the opening section now carries that row's line **verbatim**.

It reads: *"That publication claim is deliberately bounded: Shipped plugin — installable and versioned…"* — the limit sits directly beside the claim it bounds, where a reader meets both together.

The line was read from `TIERS.tsv`, not copied out of a brief. A line quoted into a brief is a second writer.

## The SHIPPED limit is the substance

Every corpus session is an **authored fixture** through the real dispatcher: that proves the guard fires where the fixture says, not that a live session goes better for having it installed. The page may cite replay evidence and may never claim outcome efficacy.

## No aggregate, no preventions

A cross-plugin total (Keel 5 + Ward 6 + Makoto 5) is unrecomputable by any single repo's CI, so it would be true once and unfalsifiable afterwards. And a "preventions" count converts fixture behaviour into outcome efficacy — the one claim this tier forbids.

The page's existing wording already gets this right where it matters, describing `gate.self_wired` as *"partial-strip **detection**, not prevention"*. That distinction is kept.

## Evidence

```
UNANCHORED=0, and zero findings of every type
check counts match makoto.registry
```

Estate-wide, `claims.py --estate` now exits 0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VanVP39tmmxY6yESx7gvbG)_