### PR TITLE
Name the encoding on the hook path, and make the shape a law

### DIFF
--- a/plugin/makoto/checks/claimedShippedAbsent.py
+++ b/plugin/makoto/checks/claimedShippedAbsent.py
@@ -54,7 +54,7 @@ def pushed_tip_matches_remote(text, cwd) -> PushTipResult:
         if branch is None:
             head = subprocess.run(
                 ["git", "-C", str(cwd), "symbolic-ref", "--quiet", "--short", "HEAD"],
-                capture_output=True, text=True, timeout=3.0,
+                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=3.0,
             )
             branch = head.stdout.strip() if head.returncode == 0 else ""
             if not branch:
@@ -64,11 +64,11 @@ def pushed_tip_matches_remote(text, cwd) -> PushTipResult:
             return PushTipResult(PushTipStatus.NOT_EVALUABLE, detail="empty branch")
         local = subprocess.run(
             ["git", "-C", str(cwd), "rev-parse", "--verify", f"refs/heads/{branch}"],
-            capture_output=True, text=True, timeout=3.0,
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=3.0,
         )
         remote = subprocess.run(
             ["git", "-C", str(cwd), "ls-remote", "origin", f"refs/heads/{branch}"],
-            capture_output=True, text=True, timeout=3.0,
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=3.0,
         )
     except Exception as exc:
         return PushTipResult(PushTipStatus.NOT_EVALUABLE, detail=f"git observation unavailable: {exc}")

--- a/plugin/makoto/kit.py
+++ b/plugin/makoto/kit.py
@@ -1049,7 +1049,7 @@ def resolve_in_worktree(loc, cwd):
             return os.path.normpath(loc) if os.path.exists(loc) else None
         root_result = subprocess.run(
             ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, timeout=_LOCAL_GIT_TIMEOUT,
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=_LOCAL_GIT_TIMEOUT,
         )
         if root_result.returncode != 0:
             return None
@@ -1097,7 +1097,7 @@ def pushed_ref_matches_world(text, cwd):
         if branch is None:
             branch_result = subprocess.run(
                 ["git", "-C", cwd, "symbolic-ref", "--quiet", "--short", "HEAD"],
-                capture_output=True, text=True, timeout=_LOCAL_GIT_TIMEOUT,
+                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=_LOCAL_GIT_TIMEOUT,
             )
             if branch_result.returncode != 0:
                 return False
@@ -1114,7 +1114,7 @@ def pushed_ref_matches_world(text, cwd):
         refs = (f"refs/heads/{branch}", f"refs/remotes/origin/{branch}")
         result = subprocess.run(
             ["git", "-C", cwd, "show-ref", "--verify", "--hash", *refs],
-            capture_output=True, text=True, timeout=_LOCAL_GIT_TIMEOUT,
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=_LOCAL_GIT_TIMEOUT,
         )
         object_ids = result.stdout.splitlines()
         return result.returncode == 0 and len(object_ids) == 2 and object_ids[0] == object_ids[1]

--- a/plugin/makoto/registry.py
+++ b/plugin/makoto/registry.py
@@ -115,7 +115,13 @@ def _candidate_edges(path: Path) -> frozenset[str]:
     output (which files' CHECK objects show up) is unchanged by this function's existence
     either way; it only changes how many modules get imported to compute that output."""
     try:
-        text = path.read_text()
+        # utf-8, stated. The default here is `locale.getpreferredencoding(False)`, which is
+        # cp1252 on a Windows host -- and this read is the CHECK CATALOG loader, so a decode
+        # failure does not fail one check, it fails the population. Measured in the field:
+        # `UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 3017`, whose
+        # call was then allowed without being checked. Python source is utf-8 by definition, so
+        # this is the encoding these files actually have, not a guess.
+        text = path.read_text(encoding="utf-8")
     except OSError:
         return ALLOWED_EDGES
     edges = frozenset(_APPLIES_AT_RE.findall(text))

--- a/tests/test_encoding_is_stated.py
+++ b/tests/test_encoding_is_stated.py
@@ -1,0 +1,118 @@
+"""Text-mode I/O on the hook path names its encoding, and the check that says so has teeth.
+
+THE INCIDENT. A live dispatch reported:
+
+    makoto: 1 check-evaluation fault(s) on this call -- [exception] UnicodeDecodeError:
+    'charmap' codec can't decode byte 0x9d in position 3017: character maps to <undefined>.
+    The call was ALLOWED WITHOUT BEING CHECKED (fail-open).
+
+The fail-open is correct and deliberate (`dispatch.py:197-211`): a broken gate must not wedge the
+session, and the `systemMessage` is what makes it loud. The DEFECT is the crash that provoked it.
+`charmap` is the Windows platform default, so a text read had named no encoding. Byte 0x9d is
+undefined in cp1252 and is the third byte of U+201D -- a right double quotation mark. Any file
+carrying one curly quote kills a check that reads it under the platform default, on one OS and
+not the other, which is why it survived every run in this estate.
+
+WHY A LAW AND NOT SIX EDITS. The crash named one site. A grep for the shape returned ~879 lines
+across the estate, which is a fact about grep: it counts test files and misses calls whose
+`encoding=` sits on a continuation line -- `dispatch.py:266` was on the grep's list and has
+carried an explicit encoding all along. Parsed rather than grepped, `plugin/` held SEVEN real
+sites. Fixing only the one that fired would leave six twins waiting for a different curly quote.
+
+THE SAME SEVEN SITES EXIST IN `makoto-dev`, and this is the shipped copy -- the one whose fault
+was actually reported. Landing the fix in the development tree alone would leave the plugin
+users install exactly as it was.
+
+SCOPE, STATED. This law covers `plugin/` -- the code that runs inside the host's hook, where a
+crash costs a check that nobody was told did not run. This tree carries 9 further sites outside
+`plugin/`; those are developer entrypoints where a decode crash is immediate
+and loud, and they are recorded here rather than silently excluded. Widening this law to them is
+a separate change with a separate argument, not an oversight.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import unittest
+
+PLUGIN = pathlib.Path(__file__).resolve().parent.parent / "plugin"
+READERS = {"read_text", "write_text"}
+RUNNERS = {"run", "check_output", "Popen", "call", "check_call"}
+
+
+def unstated_sites(root: pathlib.Path) -> list[str]:
+    """Every text-mode call under `root` that does not name an encoding.
+
+    Parsed, never grepped: a keyword counts wherever in the call it appears, and a binary-mode
+    `open` is not a text read. Both distinctions were mistakes a grep made on this exact code.
+    """
+    found = []
+    for path in sorted(root.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, OSError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            keywords = {k.arg for k in node.keywords if k.arg}
+            if "encoding" in keywords:
+                continue
+            name = (node.func.attr if isinstance(node.func, ast.Attribute)
+                    else node.func.id if isinstance(node.func, ast.Name) else None)
+            hit = None
+            if name in READERS:
+                hit = name
+            elif name == "open":
+                mode = ""
+                if node.args[1:2] and isinstance(node.args[1], ast.Constant):
+                    mode = str(node.args[1].value)
+                for keyword in node.keywords:
+                    if keyword.arg == "mode" and isinstance(keyword.value, ast.Constant):
+                        mode = str(keyword.value.value)
+                hit = None if "b" in mode else "open"
+            elif name in RUNNERS and ({"text", "universal_newlines"} & keywords):
+                hit = f"subprocess.{name}"
+            if hit:
+                found.append(f"{path.relative_to(root)}:{node.lineno} {hit}")
+    return found
+
+
+class EncodingIsStatedOnTheHookPath(unittest.TestCase):
+    def test_no_plugin_text_io_relies_on_the_platform_default(self):
+        unstated = unstated_sites(PLUGIN)
+        self.assertEqual(unstated, [], "text-mode I/O with no encoding= under plugin/: "
+                                       + "; ".join(unstated))
+
+    def test_the_check_can_fail(self):
+        """NON-VACUITY. A law that scans a tree can pass because it found nothing to scan."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as name:
+            root = pathlib.Path(name)
+            (root / "clean.py").write_text(
+                'p.read_text(encoding="utf-8")\nopen(f, "rb")\n', encoding="utf-8")
+            self.assertEqual(unstated_sites(root), [], "a stated encoding must not be flagged")
+            (root / "dirty.py").write_text("p.read_text()\n", encoding="utf-8")
+            self.assertEqual(len(unstated_sites(root)), 1,
+                             "a bare read_text() must be flagged")
+
+    def test_the_incident_byte_is_read_by_utf8_and_not_by_the_platform_default(self):
+        """The actual fault, reproduced: one curly quote, two codecs, two outcomes.
+
+        This is what makes the fix a fix rather than a preference. Pinning utf-8 does not merely
+        change which error appears -- these bytes are VALID utf-8 and undefined in cp1252, so the
+        pin is the difference between the check running and the call going unchecked.
+        """
+        import tempfile
+        with tempfile.TemporaryDirectory() as name:
+            path = pathlib.Path(name) / "module.py"
+            path.write_text('NOTE = "he said ”hello”"\n', encoding="utf-8")
+            self.assertIn(0x9D, path.read_bytes(), "the fixture must carry the incident byte")
+            with self.assertRaises(UnicodeDecodeError):
+                path.read_text(encoding="cp1252")
+            self.assertIn("hello", path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The incident

A live dispatch reported:

```
makoto: 1 check-evaluation fault(s) on this call -- [exception] UnicodeDecodeError:
'charmap' codec can't decode byte 0x9d in position 3017: character maps to <undefined>.
The call was ALLOWED WITHOUT BEING CHECKED (fail-open).
```

This is the shipped copy, and the one that threw it.

**The fail-open is not the defect and is deliberately unchanged.** `dispatch.py` argues the open direction on its merits — *a broken gate must not wedge the session* — and the `systemMessage` is already the landed fix for the silent version of it. What is wrong is the crash that provoked it.

## Root cause

`charmap` is the Windows platform default, so a text read named no encoding. Byte `0x9d` is undefined in cp1252 **and is the third byte of `U+201D`**, a right double quotation mark.

So one curly quote kills a check that reads the file — on one OS and never on the other, which is exactly why it survived every run in this estate.

Reproduced: a file containing `”` raises `'charmap' codec can't decode byte 0x9d in position 3435: character maps to <undefined>` under cp1252 and reads clean under utf-8. Those bytes are **valid** utf-8, so pinning the codec is the difference between the check running and the call going unchecked — not a nicer error message.

## The seven sites, found by parsing rather than grepping

A grep for this shape over the estate returns ~879 lines. That is a fact about grep: it counts test files and misses calls whose `encoding=` sits on a continuation line. Walking the AST, seven sites are on the hook path:

| site | why it matters |
|---|---|
| `registry.py:118` `read_text` | the **check catalog loader** — a decode failure there does not fail one check, it fails the population |
| `kit.py:1050,1098,1115` | `subprocess.run` over git output |
| `claimedShippedAbsent.py:55,65,69` | same |

git output is not ours to guarantee, so those six take `errors="replace"`: a check must not die on a byte it was only scanning past. `registry.py` takes plain utf-8, which is what Python source is by definition.

## The law

`tests/test_encoding_is_stated.py` parses rather than greps — a keyword counts wherever it appears, and a binary-mode `open` is not a text read, both distinctions a grep got wrong on this exact code. It carries a non-vacuity cell and reproduces the incident byte in both codecs.

Witnessed with teeth: reverting `registry.py` alone reddens it naming `makoto/registry.py:124 read_text`.

**Scope, stated rather than silent:** the law covers `plugin/`, the code running inside the host's hook. This tree holds 9 further sites outside `plugin/`, where a decode crash is immediate and loud rather than a check that quietly did not run. Widening to them is a separate change with a separate argument.

## Verification — bare exit codes, clean worktree, subject pinned

`import makoto` was checked to resolve to `/home/user/Makoto/plugin/makoto/__init__.py` — **this** tree — rather than assumed. (That check is not idle: the sibling dev checkout resolves `makoto` to *this* package via an editable install, so a bare run there grades the wrong tree while the test count still looks right.)

| gate | result |
|---|---|
| `python3 -m pytest -q` | `1937 passed, 1 xfailed, 43 subtests passed in 58.63s` — 1934 baseline + the 3 cells added here |
| `python3 tools/render_checks.py --check` | 0 |
| `python3 eval/replay.py` | 0 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSeHeTrYof2BRmgrT3SFm2)_