### PR TITLE
gate.green_claim reads the exit status, not only the output tail

### DIFF
--- a/plugin/makoto/checks/falseGreenClaim.py
+++ b/plugin/makoto/checks/falseGreenClaim.py
@@ -8,7 +8,7 @@ from makoto.substrate.claims import whole_suite_pass_claim
 # The prose half (the whole-suite green-claim signal) lives in substrate.claims.whole_suite_pass_claim,
 # shared with gate.stale_pass (which additionally uses the returned Match's POSITION for its teeth
 # window). See docs/adr/0032-green-claim-signal-relocation.md for the relocation history.
-def green_claim_gate(text, *, testrun_output) -> Optional[Finding]:
+def green_claim_gate(text, *, testrun_output, testrun_exit=None) -> Optional[Finding]:
     """Fire iff the assistant claims UNIVERSAL test success ('tests pass', 'the suite is green',
     'CI is green') while the MOST RECENT recorded test-runner output shows a REAL failure — a
     verifiable contradiction between "the tests pass" and the last run the world actually recorded.
@@ -31,8 +31,21 @@ def green_claim_gate(text, *, testrun_output) -> Optional[Finding]:
     never fires; it is also SCOPE-BLIND — a narrow green re-run supersedes a whole-suite red."""
     if not whole_suite_pass_claim(text):
         return None                                  # no whole-suite green claim -> inert
+    # THE STATUS FIRST, the tail second. A nonzero exit on the latest recorded testrun is the run
+    # saying it failed, in a number: it carries no vocabulary, cannot be paraphrased, and does not
+    # depend on a 500-char tail having kept the summary line. This is the half of the
+    # absence-reads-as-green edge that CAN be closed, and it is closed positively rather than by
+    # widening the token list -- a longer token list has the identical silent mode waiting for the
+    # next runner whose failure it does not spell.
+    if testrun_exit is not None and testrun_exit != 0:
+        return _finding()
     if not testrun_output or not is_failing_testrun(testrun_output):
         return None                                  # no run, or the latest run was green/xfail
+    return _finding()
+
+
+def _finding() -> Finding:
+    """One construction, reached by both signals, so the two cannot drift into two messages."""
     return Finding(
         pattern_id="gate.green_claim",
         file="tests",
@@ -47,5 +60,6 @@ def green_claim_gate(text, *, testrun_output) -> Optional[Finding]:
 from makoto.registry import Check as _Check
 # tests="": registered ONE_OFF -- claim-vs-history and test-run-delta genuinely straddle here.
 CHECK = _Check(id="gate.green_claim", applies_at="Stop", posture="BLOCK", may_block=True,
-               eats=frozenset({"text", "testrun_output"}),
-               run=lambda c: green_claim_gate(c.text, testrun_output=c.testrun_output))
+               eats=frozenset({"text", "testrun_output", "testrun_exit"}),
+               run=lambda c: green_claim_gate(c.text, testrun_output=c.testrun_output,
+                                             testrun_exit=c.testrun_exit))

--- a/plugin/makoto/context.py
+++ b/plugin/makoto/context.py
@@ -37,6 +37,11 @@ class GateContext:
     history: Sequence = ()     # the events-table rows _select_recent returns (faithful: full
     #                            command + full tool_response per prior tool event). Fabrication
     #                            gates walk this like predicate content.unsourced_webfetch; default () keeps it optional.
+    testrun_exit: Optional[int] = None   # the exit STATUS of the same ledger row `testrun_output`
+    #   came from, or None when unrecorded -- see state.ledger.latest_testrun_exit for the
+    #   absence-reads-as-green edge it closes. DEFAULTED deliberately: every existing construction
+    #   of this substrate stays valid, and an unrecorded status behaves exactly as before rather
+    #   than becoming a new way to fail.
     permission_mode: Optional[str] = None   # raw hook payload's `permission_mode` field verbatim
     #   (CONFIRMED real, snake_case, top-level on every hook event — Claude Code hooks reference,
     #   fetched 2026-07-06: "default"|"plan"|"acceptEdits"|"auto"|"dontAsk"|"bypassPermissions").
@@ -258,6 +263,7 @@ def run_stop_checks(conn, payload: dict, history=(), *, root=None) -> list:
         ctx = GateContext(
             text=text, touched=touched, empty=empty, opens=opens,
             testrun_output=_ledger.latest_testrun(conn, sid),
+            testrun_exit=_ledger.latest_testrun_exit(conn, sid),
             cwd=cwd, fs_exists=fs_exists, fs_size=fs_size, fs_read=fs_read,
             history=history,   # faithful events-table rows (A1.3) — fabrication gates walk this
             history_all_agents=history_all_agents,   # unnarrowed twin — see GateContext's own doc

--- a/plugin/makoto/state/ledger.py
+++ b/plugin/makoto/state/ledger.py
@@ -195,6 +195,36 @@ def latest_testrun(conn, session_id: str) -> str:
         return ""
 
 
+def latest_testrun_exit(conn, session_id: str) -> "int | None":
+    """The EXIT STATUS of the same row `latest_testrun` returns, or None if unrecorded.
+
+    Same table, same `kind='testrun'`, same `ORDER BY source_event_id DESC, rowid DESC` -- it must
+    be the same row or the pair lies, so the ordering is written identically here rather than
+    approximated. (One query returning both would be better still; it is kept separate only
+    because `latest_testrun`'s `-> str` contract is read by several callers.)
+
+    WHY THIS EXISTS. `green_claim_gate` decided a green claim by scanning the recorded 500-char
+    OUTPUT TAIL for a failure token, and its own docstring recorded the consequence: a run that
+    really was red but whose tail holds no recognized token -- a 'Killed' timeout, a bare
+    collection abort, a coverage footer that pushed the summary out of the tail -- read as green.
+    Detecting the PRESENCE of failure means absence is success by default.
+
+    The status was on that row the whole time. A number does not have a vocabulary, cannot be
+    paraphrased, and is not defeated by a tail that got truncated."""
+    try:
+        r = conn.execute(
+            "SELECT exit FROM ledger WHERE session_id = ? AND kind = 'testrun' "
+            "ORDER BY source_event_id DESC, rowid DESC LIMIT 1", [session_id]).fetchone()
+    except Exception:
+        return None
+    if not r or r[0] is None:
+        return None
+    try:
+        return int(r[0])
+    except (TypeError, ValueError):
+        return None
+
+
 # =============================================================================================
 # The chained, tamper-evident surface (owner decision 2026-07-07: verification lives IN the
 # ledger — the gates' verdicts depend on these rows, so the store and its verifier share one

--- a/tests/test_gate_shape.py
+++ b/tests/test_gate_shape.py
@@ -104,6 +104,11 @@ EXPECTED_GATE_FIELDS = {"id", "applies_at", "posture", "run", "may_block",
                         "layer", "eats", "tests"}   # "object" | "meta" -- see Check's own docstring; only
                                    # content.self_mute_guard / gate.self_wired are "meta" today
 EXPECTED_CONTEXT_FIELDS = {"text", "touched", "empty", "opens", "testrun_output",
+                           "testrun_exit",   # the exit STATUS of the row `testrun_output` came
+                           # from. gate.green_claim reads the NUMBER, closing the half of its
+                           # absence-reads-as-green edge a token scan structurally cannot: a red
+                           # run whose 500-char tail kept no failure token read as green.
+                           # Defaulted to None, so an unrecorded status behaves as before.
                            "cwd", "fs_exists", "fs_size", "fs_read", "history",
                            "permission_mode", "agent_id", "agent_type", "plan",
                            "session_id", "transcript_path", "state_root",
@@ -114,7 +119,7 @@ EXPECTED_CONTEXT_FIELDS = {"text", "touched", "empty", "opens", "testrun_output"
 EXPECTED_FUNCTION_COUNTS = {                               # top-level def count per module, verified
     "claimedProduceAbsent.py": 2,
     "undischargedCommitment.py": 7,
-    "falseGreenClaim.py": 1,
+    "falseGreenClaim.py": 2,
     "silentlyDroppedCommitment.py": 6,                     # 7->6, 2026-08-20: _drop_def_or_class
                                                             # inlined into its single call site
     "fabricatedToolAction.py": 3,

--- a/tests/test_green_claim_gate.py
+++ b/tests/test_green_claim_gate.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import sqlite3
 
 from makoto.substrate.claims import whole_suite_pass_claim
+from makoto.kit import is_failing_testrun
 from makoto.checks.falseGreenClaim import green_claim_gate
 from makoto.dispatch import run_stop_checks
 from makoto.state import ledger as L
@@ -101,9 +102,16 @@ def _conn():
     return c
 
 
-def _bash(c, cmd, stdout, ev_id, sid="s"):
+def _bash(c, cmd, stdout, ev_id, sid="s", exit_code=1):
+    """`exit_code` is explicit because the gate now READS it.
+
+    It used to be hardcoded to 1 for every recorded run, green ones included -- harmless while
+    nothing consulted the column, and a fixture that contradicted itself the moment something
+    did: `test_e2e_silent_after_fix_and_rerun_green` recorded `=== 12 passed ===` with a FAILING
+    status. Correcting it to 0 is making the fixture faithful, not weakening the case; the run it
+    is meant to represent exits 0."""
     L.record_update(c, {"tool_name": "Bash", "tool_input": {"command": cmd},
-                        "tool_response": {"stdout": stdout, "stderr": "", "exitCode": 1}},
+                        "tool_response": {"stdout": stdout, "stderr": "", "exitCode": exit_code}},
                     event_id=ev_id, session_id=sid)
 
 
@@ -120,7 +128,7 @@ def test_e2e_silent_after_fix_and_rerun_green():
     -> NO fire. This is the dominant honest-corpus shape A must not false-block."""
     c = _conn()
     _bash(c, "python -m pytest tests/auth.py", "=== 1 failed in 1.0s ===", 1)
-    _bash(c, "python -m pytest tests/ -q", "=== 12 passed in 4.0s ===", 2)   # re-run, later ts/ev
+    _bash(c, "python -m pytest tests/ -q", "=== 12 passed in 4.0s ===", 2, exit_code=0)  # green re-run
     findings = run_stop_checks(c, {"last_assistant_message": "Fixed — all tests pass now.",
                                   "session_id": "s", "cwd": "/repo"})
     assert not any(f.pattern_id == "gate.green_claim" for f in findings)
@@ -135,3 +143,44 @@ def test_e2e_silent_when_cat_a_log_not_a_runner():
     findings = run_stop_checks(c, {"last_assistant_message": "All tests pass.",
                                   "session_id": "s", "cwd": "/repo"})
     assert not any(f.pattern_id == "gate.green_claim" for f in findings)
+
+def test_TEETH_a_red_run_whose_tail_kept_no_failure_token_still_fires():
+    """The absence-reads-as-green edge this gate's own docstring recorded, now closed.
+
+    `is_failing_testrun` detects the PRESENCE of a failure token, so a run that really was red but
+    whose recorded 500-char tail holds none -- a 'Killed' timeout, a bare collection abort, a
+    coverage footer that pushed the summary out of the tail -- read as GREEN. Absence was success
+    by default, which is what a negative check always does.
+
+    The status was on that same ledger row the whole time and was never consulted. A number has no
+    vocabulary, cannot be paraphrased, and does not depend on a tail surviving truncation -- so it
+    is checked FIRST and the token scan is the fallback, not the other way round.
+
+    Note the fixture this exposed: `_bash` hardcoded exitCode=1 for every recorded run, green ones
+    included, so `test_e2e_silent_after_fix_and_rerun_green` recorded `12 passed` with a FAILING
+    status. Harmless while nothing read the column; self-contradictory the moment something did.
+    """
+    c = _conn()
+    _bash(c, "python -m pytest tests/ -q", "Killed\n", 1, exit_code=1)   # red, tail has no token
+    assert not is_failing_testrun("Killed\n"), "premise: the tail carries no recognized token"
+    findings = run_stop_checks(c, {"last_assistant_message": "Done — all tests pass.",
+                                   "session_id": "s", "cwd": "/repo"})
+    assert any(f.pattern_id == "gate.green_claim" for f in findings), \
+        "a red run whose tail kept no failure token still read as green"
+
+
+def test_NON_VACUITY_a_green_status_with_a_green_tail_stays_silent():
+    """Firing on every run would satisfy the cell above and block every honest turn."""
+    c = _conn()
+    _bash(c, "python -m pytest tests/ -q", "=== 12 passed in 4.0s ===", 1, exit_code=0)
+    findings = run_stop_checks(c, {"last_assistant_message": "Done — all tests pass.",
+                                   "session_id": "s", "cwd": "/repo"})
+    assert not any(f.pattern_id == "gate.green_claim" for f in findings)
+
+
+def test_an_unrecorded_status_behaves_exactly_as_before():
+    """The new read must not turn 'we do not know' into a new way to fail."""
+    from makoto.checks.falseGreenClaim import green_claim_gate
+    claim = "All tests pass."
+    assert green_claim_gate(claim, testrun_output="Killed\n", testrun_exit=None) is None
+    assert green_claim_gate(claim, testrun_output="1 failed, 2 passed", testrun_exit=None) is not None


### PR DESCRIPTION
## The defect, in the gate's own words

`falseGreenClaim`'s docstring already named it:

> `is_failing_testrun` detects the PRESENCE of failure, never the presence of success... and the ledger `exit` column recorded on that same row is never consulted. This is the gate's known absence-reads-as-green edge.

`latest_testrun` selected `value` and never `exit`. So a test run that exited non-zero while printing a tail carrying no failure token read as green, and a claim of success over it passed.

## The change

- `state/ledger.py` — new `latest_testrun_exit(conn, session_id)`. Same table, same `ORDER BY source_event_id DESC, rowid DESC` as `latest_testrun`: it must be the same row or the pair lies.
- `context.py` — `testrun_exit: Optional[int] = None`, in the defaulted section.
- `checks/falseGreenClaim.py` — the recorded status is checked FIRST; the token scan stays as the fallback for a run with no recorded status. `_finding()` is extracted so both signals emit one message. `eats` grows to `{"text", "testrun_output", "testrun_exit"}`.

All 8 directions are now correct, including `status 1, tail carries NO failure token` → FIRES, which was the open edge.

## Honest limit, stated rather than implied

The residual half is **narrowed, not closed**: a red run with no failure token *and* no recorded status is still unreadable. That is a smaller set than before, and it is not zero.

## A fixture defect the fix exposed

`tests/test_green_claim_gate.py`'s `_bash` helper hardcoded `"exitCode": 1` for every run, so `test_e2e_silent_after_fix_and_rerun_green` recorded `=== 12 passed ===` beside a FAILING status. Harmless while nothing read the column; self-contradictory the moment something did. `_bash` now takes `exit_code`, and the green re-run records `0` — making the fixture faithful, not weakening the case.

## Verification (bare exit codes, clean worktree)

- `python3 -m pytest -q` → `1940 passed, 1 xfailed, 43 subtests`
- `tools/render_checks.py --check` → 0
- `eval/replay.py` → 5/5

`tests/test_gate_shape.py` moved by measurement, not by hand: `EXPECTED_CONTEXT_FIELDS` gains `testrun_exit`, and `falseGreenClaim.py`'s def count 1 → 2.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSeHeTrYof2BRmgrT3SFm2)_