### PR TITLE
Release 2.5.0: the Windows fail-open, two false blocks, and the exit-masking tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to makoto. Versions follow the live check inventory
 
 ## [Unreleased]
 
+## [2.5.0] — 2026-09-03
+
+### Fixed
+- **Makoto ran no checks at all on Windows.** `state/ledger.py` imported `fcntl` — a Unix-only
+  module — at module scope for the one `flock` guarding the hash chain against concurrent
+  appends. On Windows the import raised, so every ledger update raised, and the dispatcher's
+  deliberate fail-open let **every call through unchecked**, announcing itself only as a
+  per-call fault notice. The lock now selects a backend: `flock` where it exists, `msvcrt`'s
+  exclusive-region lock where it does not, both contending over the same byte of the same
+  sidecar. `tests/test_platform_portability.py` holds the hook path to it.
+- **`gate.claimed_running` blocked truthful agents.** A closed launcher vocabulary returned its
+  *firing* value when nothing matched, so an agent that really started a server with `air`,
+  `bun run dev`, `php artisan serve` or `caddy run` was blocked and told it never started
+  anything. A vocabulary miss is now NOT-EVALUABLE and silent; the gate keeps its teeth where
+  no settled Bash terminal exists at all.
+- **`gate.claimed_shipped` had the same defect**, and blocked agents that really shipped with
+  `gh pr merge`, `npm publish`, `docker push` or a deploy script. Now three-valued: absence is
+  asserted only when a real attempt is on record and none succeeded, so an unrelated command
+  cannot buy silence once an attempt exists.
+- **`gate.green_claim` reads the exit status**, not only the output tail.
+- **Text I/O on the hook path names its encoding.** A single curly quote in a file a check read
+  killed that check under the Windows platform default (`charmap`), one OS and not the other.
+
+### Added
+- **`verifierExitMasking` recognizes this estate's own verifiers** — `python3 -m unittest`,
+  coverage, tox, nox, and interpreter-or-direct invocation of a script whose file name carries a
+  verification word. The wide tier is **advisory**: it surfaces a masked verifier without denying
+  the call, and the narrow blocking vocabulary is unchanged. The stated cost, pinned by a test:
+  a genuinely masked `./gates.sh || true` is surfaced but not stopped, and the tier's own residue
+  is asserted rather than described.
+- Laws that hold the shipped tree to its claims: no unguarded platform-only import on the hook
+  path, and no text-mode I/O relying on the platform default.
+
+### Changed
+- A checked claim replaces several that were satisfied by a substring, a fixture, or a name:
+  `may_block` is observed to reach the pipeline, denials are guaranteed to name their row and
+  replay checks that they did, and check counts are rendered from the registry that owns them.
+
 ## [2.4.0] — 2026-08-20
 
 ### Added

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "makoto",
   "description": "Holds Claude Code to its word — every claim checked against the agent's own logged record; faked checks blocked, not warned (four narrow advisory self-checks excepted). Two-tier catalog (15 pre-checks, 19 Stop gates), each shipped at measured zero false positives.",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "author": {"name": "Clear-Sights"},
   "homepage": "https://github.com/Clear-Sights/Makoto",
   "repository": "https://github.com/Clear-Sights/Makoto",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "makoto"
-version = "2.4.0"
+version = "2.5.0"
 description = "Integrity hook for Claude Code — holds the agent's claims against its own logged deeds and blocks faked checks; every check ships at measured zero false positives"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Why now

The Courthouse marketplace pins makoto at **`v2.4.0` / `a313a34`**, which is **33 commits behind `main`** and contains none of tonight's fixes — including the one a user actually reported hitting:

```
PostToolUse:Bash says: makoto: 1 check-evaluation fault(s) on this call -- [exception]
ledger update failed: ModuleNotFoundError: No module named 'fcntl'. The call was ALLOWED
WITHOUT BEING CHECKED (fail-open).
```

Measured, not assumed:

```
$ git rev-list --count v2.4.0..origin/main
33
$ git show v2.4.0:plugin/makoto/state/ledger.py | grep -c "except ImportError"
0
```

A fix that sits on `main` while every install resolves a tag is a fix nobody has. This cuts the release so the pin can advance.

## What is in it

Full detail in `CHANGELOG.md`; the headline is that **Windows ran no checks at all** until the `fcntl` fix, and two gates were blocking truthful agents when their closed vocabularies missed.

**Minor rather than patch:** the check inventory is unchanged (no checks added or removed), but behaviour is — two gates became three-valued and a new advisory tier ships.

## The version is bumped in both places on purpose

`release.yml` refuses to run when `plugin/.claude-plugin/plugin.json` and `pyproject.toml` disagree. That check exists because of a real incident recorded in the workflow's own comment: `v2.4.0` was cut against a manifest still declaring `2.3.0`, so the tag and the number a user installs came from two places with nothing comparing them.

I verified the workflow's preconditions locally rather than discovering them in CI:

```
plugin.json=2.5.0 pyproject=2.5.0    MATCH
awk extraction of the [2.5.0] section -> 37 lines
```

## Gates

```
1964 passed, 1 xfailed, 43 subtests passed in 108.71s
check counts match makoto.registry          (render_checks --check, rc=0)
REPLAY sessions=5 passed=5 failed=0          (rc=0)
```

## After merge

Dispatch `release.yml` on `main` (the workflow creates the tag from CI, which holds `contents: write` — a direct tag push from a session returns 403), then advance the Courthouse marketplace pin from `v2.4.0` to `v2.5.0`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YSeHeTrYof2BRmgrT3SFm2)_