### PR TITLE
Close the check-posture vocabulary, and give "blocking" one owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ makoto fires on mechanical hook events — every `PreToolUse`, `PostToolUse`, an
 
 <!-- END GENERATED: check-counts -->
 
+Two different things are called a *gate* in that list, and the counts are not comparable. The
+`gate.` in a **pre-check id** is a naming prefix and nothing more; an **end-of-turn gate** is a
+check registered at the Stop edge with `may_block=True`. The one pre-check carrying the prefix,
+`gate.contract_order`, is not an end-of-turn gate — it has a same-named Stop sibling that is, and
+the two are separate checks with separate predicates. Every count above is scoped by edge, so no
+check is counted twice within a line.
+
 Every pre-check and every non-advisory end-of-turn gate blocks; there is no silent "warning" tier
 for those (see [Fire level](#fire-level)) — the documented exceptions are
 `gate.self_wired`, `gate.canon_fingerprints_advisory`, `gate.relative_path_citation`, and
@@ -264,9 +271,14 @@ the distinct process-error path.
 
 ## Fire level
 
-Every non-advisory live pattern blocks through the dispatcher mechanism measured above. makoto deliberately has **no
-non-blocking tier**: a `warning`/`disabled` resting state — witnessing a violation and letting the
-tool through — is itself an illusory word, the exact weakening shape makoto exists to catch. The
+Every non-advisory live pattern blocks through the dispatcher mechanism measured above. makoto
+deliberately has **no non-blocking *tier***: no resting state a check can be assigned to, no
+`warning`/`disabled` level to demote a pattern into — witnessing a violation and letting the tool
+through as a matter of policy is itself an illusory word, the exact weakening shape makoto exists
+to catch. Four checks do fire without blocking, and they are named below; the claim is that no
+*category* admits them, not that the count is zero. There is no predicate that qualifies a check
+as advisory — each of the four carries its own dated argument, and a fifth would need its own.
+That is deliberate: a rule for admitting advisory checks is the tier, rebuilt. The
 earlier three-tier system was removed in the 2026-06-02 *warning-tier-elimination* (a pattern either
 blocks at proven zero corpus-FP, or it is cut — zero false positives on the shipped corpus and gold
 negative sets, the only sets the proof runs over; the live-session false-positive rate accumulates

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ every pre-check even though pre-checks deny. `configchange.py` emits a block of 
 outside the check registry, so no registry predicate is defined over it. And "blocking robust
 core" below counts canon fingerprints in `_canonAtoms.BLOCK_IDS`, a population of patterns.
 
-*Advisory* names seven things. Two are columns of the catalog table: the Certification label, and
+*Advisory* names eight things. Two are columns of the catalog table: the Certification label, and
 the Fire column -- which is a two-valued TIER label reading `blocking` or `advisory`, not a print
 of `Finding.level`, whose values are `error` and `advisory`; that column is therefore also a
 sixth producer of the word *blocking* above. Two are check tiers: `registry.POSTURE_ADVISE`, a
@@ -37,8 +37,10 @@ check's declared tier, and membership of `registry._ADVISORY_ALLOWLIST` -- `bloc
 consults the posture, not the allowlist, and `registry.py` warns in its own words that the two
 agree only because today's four happen to coincide. One is a raw outcome, `verdict.ADVISE`. One
 is `gate.configchange_advisory`, which fires without blocking from outside the registry, so it is
-in neither the allowlist nor the count. The last is the canon "advisory remainder" of
-fingerprints resting on a soft or disqualified atom.
+in neither the allowlist nor the count. One is the canon "advisory remainder" of fingerprints
+resting on a soft or disqualified atom. The last is `Finding.level == "advisory"`, which the Fire
+column reports but is not -- eight checks emit it, and `dispatch.py`'s `_OUTCOME_FOR_LEVEL`
+maps it to `verdict.ADVISE`.
 
 *Silent* has five senses and they sit on different axes, which is why one of them looked like a
 contradiction. A fail-open is never silent: `dispatch.py` emits its notice whenever a check

--- a/README.md
+++ b/README.md
@@ -18,36 +18,43 @@ against the record, it is only harder to follow. `makoto.vocab`'s `_INTEG_VOCAB`
 the lexical half of the same idea — the word-set naming integrity concepts *in a subject's
 code* — and is not a second definition of this one.
 
-**Six words this page reuses. None of them has a single owner, so each is listed with every
-artifact that produces it.** *Blocking* describes an outcome -- the act is stopped -- and four
-different things produce it: `registry.blocking_eligible` (Stop edge, `may_block`, posture BLOCK)
-decides it for end-of-turn gates and owns the count above; a pre-check stops an act by denying
-the tool call, a different mechanism for which `blocking_eligible` is False; `configchange.py`
-emits a `{"decision": "block"}` of its own from outside the check registry, so no registry
-predicate is defined over it; and "blocking robust core" below counts canon fingerprints in
-`_canonAtoms.BLOCK_IDS`, a population of patterns rather than of checks.
+**Six words this page reuses. None has a single owner, so each is listed with every artifact
+that produces it.** *Blocking* is an outcome -- the act is stopped -- with five producers.
+`verdict.BLOCK` is the raw one a check returns; `verdict.apply` folds it by posture and
+`dispatch.py` turns the result into a Pre-edge `permissionDecision: "deny"` or a Stop-edge
+`{"decision": "block"}`. `registry.POSTURE_BLOCK` is a check's own declared tier, an input to
+that folding and not the same vocabulary. `registry.blocking_eligible` (Stop edge, `may_block`,
+posture BLOCK) decides which end-of-turn gates the count above calls blocking, and is False for
+every pre-check even though pre-checks deny. `configchange.py` emits a block of its own from
+outside the check registry, so no registry predicate is defined over it. And "blocking robust
+core" below counts canon fingerprints in `_canonAtoms.BLOCK_IDS`, a population of patterns.
 
-*Advisory* names five things. Three are about checks: the certification label below, membership
-of `registry._ADVISORY_ALLOWLIST` (four Stop gates), and `gate.configchange_advisory`, which
-fires without blocking and is deliberately NOT in that allowlist because it is not a registry
-gate. One is about patterns: the "advisory remainder" of canon fingerprints resting on a soft or
-disqualified atom. The fifth is `verdict.ADVISE`, one of the four raw outcomes a check can
-produce, which `registry.py` already flags as its own vocabulary.
+*Advisory* names seven things. Two are columns of the catalog table: the Certification label, and
+the Fire column, which prints `Finding.level`. Two are check tiers: `registry.POSTURE_ADVISE`, a
+check's declared tier, and membership of `registry._ADVISORY_ALLOWLIST` -- `blocking_eligible`
+consults the posture, not the allowlist, and `registry.py` warns in its own words that the two
+agree only because today's four happen to coincide. One is a raw outcome, `verdict.ADVISE`. One
+is `gate.configchange_advisory`, which fires without blocking from outside the registry, so it is
+in neither the allowlist nor the count. The last is the canon "advisory remainder" of
+fingerprints resting on a soft or disqualified atom.
 
-*Silent* has an operator sense and a machine sense, and they can disagree. A fail-open is never
-silent -- it reaches a seat that can act on it; a check "staying silent" emitted no finding and
-is loud in the audit log anyway. But `verdict.SILENT` is a configured POSTURE under which every
-outcome becomes ALLOW with no enforcement and no advisory, which is the one case where nothing
-surfaces. It is named here so the first sentence is not read as covering it.
+*Silent* has four senses and they sit on different axes, which is why one of them looked like a
+contradiction. A fail-open is never silent: `dispatch.py` emits its notice whenever a check
+faulted, gated on the fault and never on posture. A check "staying silent" emitted no finding.
+`verdict.SILENT` is a configured posture that softens outcomes toward ALLOW -- but not
+unconditionally: a meta-layer BLOCK still floors at ASK, and it is `# record only`, so audit rows
+are written either way. And a verifier "silently neutered" is the SUBJECT's code losing a check,
+which is what several patterns exist to catch.
 
 *A claim* is one of the three ledger row kinds named above (`verdict`, `certified-fact`,
 `testrun`); where this page says the agent "claims" something it means the utterance a row may
-later record; and where the page says "the claim is", it is asserting something itself. *A check*
+later record; and where it says "the claim is", the page is asserting something itself. *A check*
 in a pattern description is one in the subject's code; a check of makoto's own is a
-`registry.Check`. *The record* is the session's recorded call stream; the RECORD step of the
-receipt chain is the appended `kind="audit"` row, one entry in it; and where the page asks what
-"could not be answered from the record" it means the written logs -- `audit.jsonl` and
-`dispatch_errors.jsonl` -- which outlive the session the call stream belongs to.
+`registry.Check`. *The record* has five referents: the session's recorded call stream; the RECORD
+step of the receipt chain, an appended `kind="audit"` row; the written logs `audit.jsonl` and
+`dispatch_errors.jsonl`, which outlive the session; a FOREIGN ledger, as in `gate.stale_pass`
+reading pytest's own `lastfailed`; and "on the record" for a `makoto-allow:` rationale left in
+the subject's source.
 
 It judges the agent against its _own_ utterances and record — never the world's truth. It holds no
 facts ("France doesn't exist to it"); it only checks that a claimed word is kept, whole, and honored

--- a/README.md
+++ b/README.md
@@ -18,20 +18,36 @@ against the record, it is only harder to follow. `makoto.vocab`'s `_INTEG_VOCAB`
 the lexical half of the same idea — the word-set naming integrity concepts *in a subject's
 code* — and is not a second definition of this one.
 
-**Six words this page reuses, each owned in one place.** *Blocking* is
-`registry.blocking_eligible` -- Stop edge, `may_block`, posture BLOCK -- and is False for every
-pre-check; a pre-check stops an act by denying the tool call, which is a different mechanism, not
-a weaker one. *Advisory* names three things and they are not interchangeable: the certification
-label below, membership of `registry._ADVISORY_ALLOWLIST` (the four gates that fire without
-blocking), and the "advisory remainder" of canon fingerprints resting on a soft or disqualified
-atom. *A claim* is one of the three ledger row kinds named above (`verdict`, `certified-fact`,
-`testrun`); where this page says the agent "claims" something it means the utterance that a row
-may later record. *Silent* is the operator's view -- a fail-open is never silent because it
-reaches a seat that can act on it -- while a check "staying silent" means it emitted no finding,
-which is loud in the audit log either way. *A check* in a pattern description is one in the
-subject's code; a check of makoto's own is a `registry.Check`. *The record* is the session's
-recorded call stream; the RECORD step of the receipt chain is the appended `kind="audit"` row,
-which is one entry in it.
+**Six words this page reuses. None of them has a single owner, so each is listed with every
+artifact that produces it.** *Blocking* describes an outcome -- the act is stopped -- and four
+different things produce it: `registry.blocking_eligible` (Stop edge, `may_block`, posture BLOCK)
+decides it for end-of-turn gates and owns the count above; a pre-check stops an act by denying
+the tool call, a different mechanism for which `blocking_eligible` is False; `configchange.py`
+emits a `{"decision": "block"}` of its own from outside the check registry, so no registry
+predicate is defined over it; and "blocking robust core" below counts canon fingerprints in
+`_canonAtoms.BLOCK_IDS`, a population of patterns rather than of checks.
+
+*Advisory* names five things. Three are about checks: the certification label below, membership
+of `registry._ADVISORY_ALLOWLIST` (four Stop gates), and `gate.configchange_advisory`, which
+fires without blocking and is deliberately NOT in that allowlist because it is not a registry
+gate. One is about patterns: the "advisory remainder" of canon fingerprints resting on a soft or
+disqualified atom. The fifth is `verdict.ADVISE`, one of the four raw outcomes a check can
+produce, which `registry.py` already flags as its own vocabulary.
+
+*Silent* has an operator sense and a machine sense, and they can disagree. A fail-open is never
+silent -- it reaches a seat that can act on it; a check "staying silent" emitted no finding and
+is loud in the audit log anyway. But `verdict.SILENT` is a configured POSTURE under which every
+outcome becomes ALLOW with no enforcement and no advisory, which is the one case where nothing
+surfaces. It is named here so the first sentence is not read as covering it.
+
+*A claim* is one of the three ledger row kinds named above (`verdict`, `certified-fact`,
+`testrun`); where this page says the agent "claims" something it means the utterance a row may
+later record; and where the page says "the claim is", it is asserting something itself. *A check*
+in a pattern description is one in the subject's code; a check of makoto's own is a
+`registry.Check`. *The record* is the session's recorded call stream; the RECORD step of the
+receipt chain is the appended `kind="audit"` row, one entry in it; and where the page asks what
+"could not be answered from the record" it means the written logs -- `audit.jsonl` and
+`dispatch_errors.jsonl` -- which outlive the session the call stream belongs to.
 
 It judges the agent against its _own_ utterances and record — never the world's truth. It holds no
 facts ("France doesn't exist to it"); it only checks that a claimed word is kept, whole, and honored

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ the agent a one-line correction to retry against.
 
 That publication claim is deliberately bounded: Shipped plugin — installable and versioned. The dispatcher is replay-tested against authored sessions; its effect on a live session's outcome is unmeasured.
 
+**Integrity**, as this tool uses the word, is exactly that agreement: a claim the agent made this
+turn is matched by the record of the deed it names. Nothing wider — not correctness, not code
+quality, not whether the deed was a good idea. So `gate.relative_path_citation` says a bare
+path is "a communication-quality signal, not an integrity violation": it contradicts no claim
+against the record, it is only harder to follow. `makoto.vocab`'s `_INTEG_VOCAB` (vocab.py) is
+the lexical half of the same idea — the word-set naming integrity concepts *in a subject's
+code* — and is not a second definition of this one.
+
 It judges the agent against its _own_ utterances and record — never the world's truth. It holds no
 facts ("France doesn't exist to it"); it only checks that a claimed word is kept, whole, and honored
 in deed. A word it lets through becomes spendable: trustworthy tender a reviewer or another agent can

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ outside the check registry, so no registry predicate is defined over it. And "bl
 core" below counts canon fingerprints in `_canonAtoms.BLOCK_IDS`, a population of patterns.
 
 *Advisory* names seven things. Two are columns of the catalog table: the Certification label, and
-the Fire column, which prints `Finding.level`. Two are check tiers: `registry.POSTURE_ADVISE`, a
+the Fire column -- which is a two-valued TIER label reading `blocking` or `advisory`, not a print
+of `Finding.level`, whose values are `error` and `advisory`; that column is therefore also a
+sixth producer of the word *blocking* above. Two are check tiers: `registry.POSTURE_ADVISE`, a
 check's declared tier, and membership of `registry._ADVISORY_ALLOWLIST` -- `blocking_eligible`
 consults the posture, not the allowlist, and `registry.py` warns in its own words that the two
 agree only because today's four happen to coincide. One is a raw outcome, `verdict.ADVISE`. One
@@ -38,23 +40,27 @@ is `gate.configchange_advisory`, which fires without blocking from outside the r
 in neither the allowlist nor the count. The last is the canon "advisory remainder" of
 fingerprints resting on a soft or disqualified atom.
 
-*Silent* has four senses and they sit on different axes, which is why one of them looked like a
+*Silent* has five senses and they sit on different axes, which is why one of them looked like a
 contradiction. A fail-open is never silent: `dispatch.py` emits its notice whenever a check
 faulted, gated on the fault and never on posture. A check "staying silent" emitted no finding.
 `verdict.SILENT` is a configured posture that softens outcomes toward ALLOW -- but not
 unconditionally: a meta-layer BLOCK still floors at ASK, and it is `# record only`, so audit rows
-are written either way. And a verifier "silently neutered" is the SUBJECT's code losing a check,
-which is what several patterns exist to catch.
+are written either way. A verifier "silently neutered" is the SUBJECT's code losing a check,
+which is what several patterns exist to catch. And a "silent bypass" is a fifth thing again -- an
+override that leaves no record, which is why an allow carries its rationale and why the oversight
+clamp is "never overridden SILENTLY".
 
 *A claim* is one of the three ledger row kinds named above (`verdict`, `certified-fact`,
 `testrun`); where this page says the agent "claims" something it means the utterance a row may
 later record; and where it says "the claim is", the page is asserting something itself. *A check*
 in a pattern description is one in the subject's code; a check of makoto's own is a
-`registry.Check`. *The record* has five referents: the session's recorded call stream; the RECORD
+`registry.Check`. *The record* has six referents: the session's recorded call stream; the RECORD
 step of the receipt chain, an appended `kind="audit"` row; the written logs `audit.jsonl` and
 `dispatch_errors.jsonl`, which outlive the session; a FOREIGN ledger, as in `gate.stale_pass`
 reading pytest's own `lastfailed`; and "on the record" for a `makoto-allow:` rationale left in
-the subject's source.
+the subject's source. The durable store the word is named after is `makoto.record.db`, the SQLite
+file under the state dir -- a sixth referent, and the one several of the others are checked
+against.
 
 It judges the agent against its _own_ utterances and record — never the world's truth. It holds no
 facts ("France doesn't exist to it"); it only checks that a claimed word is kept, whole, and honored
@@ -219,7 +225,7 @@ auto-wire dispatch on enable. Claude Code registers `PreToolUse`, `PostToolUse`,
 automatically (which `exec`s `python -m makoto._dispatch`). `~/.claude/settings.json` is NOT
 modified — the plugin system manages its own hook registry.
 
-State dir + `makoto.db` are created lazily on the first hook invocation.
+State dir + `makoto.record.db` are created lazily on the first hook invocation.
 
 ### Companion setting (optional): suppress the harness auto-trailer
 
@@ -268,7 +274,7 @@ pip install -e /path/to/makoto
 # Then add makoto hook entries to ~/.claude/settings.json manually — see "Manual wiring" below.
 ```
 
-The state dir and `makoto.db` are created lazily on the first hook invocation; there is no separate
+The state dir and `makoto.record.db` are created lazily on the first hook invocation; there is no separate
 init step.
 
 ## Uninstall
@@ -281,7 +287,7 @@ init step.
 python -m makoto uninstall   # removes makoto-managed settings.json entries
 ```
 
-The state dir (`~/.claude/makoto_state/`) is preserved on uninstall — `audit.jsonl` and `makoto.db`
+The state dir (`~/.claude/makoto_state/`) is preserved on uninstall — `audit.jsonl` and `makoto.record.db`
 remain for forensic value. To fully reset, `rm -rf` the dir.
 
 ## CLI

--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ against the record, it is only harder to follow. `makoto.vocab`'s `_INTEG_VOCAB`
 the lexical half of the same idea — the word-set naming integrity concepts *in a subject's
 code* — and is not a second definition of this one.
 
+**Six words this page reuses, each owned in one place.** *Blocking* is
+`registry.blocking_eligible` -- Stop edge, `may_block`, posture BLOCK -- and is False for every
+pre-check; a pre-check stops an act by denying the tool call, which is a different mechanism, not
+a weaker one. *Advisory* names three things and they are not interchangeable: the certification
+label below, membership of `registry._ADVISORY_ALLOWLIST` (the four gates that fire without
+blocking), and the "advisory remainder" of canon fingerprints resting on a soft or disqualified
+atom. *A claim* is one of the three ledger row kinds named above (`verdict`, `certified-fact`,
+`testrun`); where this page says the agent "claims" something it means the utterance that a row
+may later record. *Silent* is the operator's view -- a fail-open is never silent because it
+reaches a seat that can act on it -- while a check "staying silent" means it emitted no finding,
+which is loud in the audit log either way. *A check* in a pattern description is one in the
+subject's code; a check of makoto's own is a `registry.Check`. *The record* is the session's
+recorded call stream; the RECORD step of the receipt chain is the appended `kind="audit"` row,
+which is one entry in it.
+
 It judges the agent against its _own_ utterances and record — never the world's truth. It holds no
 facts ("France doesn't exist to it"); it only checks that a claimed word is kept, whole, and honored
 in deed. A word it lets through becomes spendable: trustworthy tender a reviewer or another agent can
@@ -41,11 +56,11 @@ makoto fires on mechanical hook events — every `PreToolUse`, `PostToolUse`, an
 
 <!-- BEGIN GENERATED: check-counts | source: makoto.registry | regenerate: python3 tools/render_checks.py --write -->
 
-- **15 pre-checks** (all blocking)
+- **15 pre-checks** (every one denies the tool call; `blocking_eligible` is about the Stop edge and is False for all of them)
 - Pre-check ids grouped by dotted prefix — `content`: **12**, `event`: **2**, `gate`: **1**
 - **21 Stop checks** (all checks registered at the Stop edge)
 - **19 end-of-turn gates** (`may_block=True`)
-- **15 blocking end-of-turn gates** (not advisory-allowlisted)
+- **15 blocking end-of-turn gates** (`registry.blocking_eligible`)
 - **4 advisory end-of-turn gates** (advisory-allowlisted)
 
 <!-- END GENERATED: check-counts -->
@@ -303,7 +318,9 @@ blocks at proven zero corpus-FP, or it is cut — zero false positives on the sh
 negative sets, the only sets the proof runs over; the live-session false-positive rate accumulates
 from field use and is not part of that measurement). This still governs every pre-check and every non-advisory
 end-of-turn gate. The invariant is enforced by the suite, not at load: `makoto.vocab` carries
-`fire_level` "by convention -- no longer runtime-checked here", and the allowed set lives in
+`fire_level` on its test-fixture `PreCheck` shape only -- "by convention -- no longer
+runtime-checked here", and not the home of this invariant; the level a live gate emits is
+`Finding.level`. The allowed set lives in
 `tests/_toml_pattern_fixture.py`, with `tests/test_stop_gate_level_invariant.py` firing every live
 gate and asserting the level it emits.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ the lexical half of the same idea — the word-set naming integrity concepts *in
 code* — and is not a second definition of this one.
 
 **Six words this page reuses. None has a single owner, so each is listed with every artifact
-that produces it.** *Blocking* is an outcome -- the act is stopped -- with five producers.
+that produces it.** *Blocking* is an outcome -- the act is stopped -- and these artifacts produce it. NO COUNT is
+stated for this list or the next: a number in prose that nothing checks drifts from the list
+beside it, which is how the *advisory* list came to say seven while naming eight, and how
+this list said five while the paragraph below names a sixth.
 `verdict.BLOCK` is the raw one a check returns; `verdict.apply` folds it by posture and
 `dispatch.py` turns the result into a Pre-edge `permissionDecision: "deny"` or a Stop-edge
 `{"decision": "block"}`. `registry.POSTURE_BLOCK` is a check's own declared tier, an input to
@@ -29,17 +32,17 @@ every pre-check even though pre-checks deny. `configchange.py` emits a block of 
 outside the check registry, so no registry predicate is defined over it. And "blocking robust
 core" below counts canon fingerprints in `_canonAtoms.BLOCK_IDS`, a population of patterns.
 
-*Advisory* names eight things. Two are columns of the catalog table: the Certification label, and
+*Advisory* names these things. Two are columns of the catalog table: the Certification label, and
 the Fire column -- which is a two-valued TIER label reading `blocking` or `advisory`, not a print
 of `Finding.level`, whose values are `error` and `advisory`; that column is therefore also a
-sixth producer of the word *blocking* above. Two are check tiers: `registry.POSTURE_ADVISE`, a
+producer of the word *blocking* above. Two are check tiers: `registry.POSTURE_ADVISE`, a
 check's declared tier, and membership of `registry._ADVISORY_ALLOWLIST` -- `blocking_eligible`
 consults the posture, not the allowlist, and `registry.py` warns in its own words that the two
 agree only because today's four happen to coincide. One is a raw outcome, `verdict.ADVISE`. One
 is `gate.configchange_advisory`, which fires without blocking from outside the registry, so it is
 in neither the allowlist nor the count. One is the canon "advisory remainder" of fingerprints
 resting on a soft or disqualified atom. The last is `Finding.level == "advisory"`, which the Fire
-column reports but is not -- eight checks emit it, and `dispatch.py`'s `_OUTCOME_FOR_LEVEL`
+column reports but is not -- checks emit it directly, and `dispatch.py`'s `_OUTCOME_FOR_LEVEL`
 maps it to `verdict.ADVISE`.
 
 *Silent* has five senses and they sit on different axes, which is why one of them looked like a

--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ facts ("France doesn't exist to it"); it only checks that a claimed word is kept
 in deed. A word it lets through becomes spendable: trustworthy tender a reviewer or another agent can
 accept without re-deriving it.
 
+Both of those words are literal here, and the thing they name ships. The **tender** is the receipt
+(`makoto.state.ledger.emit_receipt`, and the Receipt section below): a read-time view over the
+chain, never persisted, listing each claim with its own `row_index` and `row_hash`. A claim is
+**spendable** when it is `trace_bound` -- at or before `verified_through`'s cut, so the chain from
+the claim to that point verifies -- and only three row kinds are claims at all: `verdict`,
+`certified-fact` and `testrun`, the kinds that assert something about the world. Records of deeds
+and machinery (`audit`, `touched`, `release.operator`, `fetch`, `exemption`) are not claims and are
+counted separately. "Without re-deriving it" is what the row hash buys: the reviewer re-checks a
+citation instead of re-running the work. A claim after the first broken link is still listed,
+undisguised, and is not counted as trace-bound -- it is exactly the not-spendable case.
+
 ## What it catches
 
 makoto fires on mechanical hook events — every `PreToolUse`, `PostToolUse`, and `Stop` — and

--- a/plugin/makoto/checks/staleEstablisher.py
+++ b/plugin/makoto/checks/staleEstablisher.py
@@ -38,7 +38,7 @@ from typing import Optional
 from makoto.registry import Check
 from makoto.kit import live_query_finding
 from makoto.substrate._planNode import DONE, Plan
-from makoto.verdict import ADVISE
+from makoto.registry import POSTURE_ADVISE
 from makoto.vocab import Finding
 
 
@@ -91,7 +91,7 @@ run = live_query_finding(query=lambda plan: check(plan), posture_label="gate.sta
 CHECK = Check(
     id="gate.stale_establisher",
     applies_at="Stop",
-    posture=ADVISE,
+    posture=POSTURE_ADVISE,
     eats=frozenset({"plan"}),
     run=run,
     tests="LIVE_QUERY",

--- a/plugin/makoto/checks/undeclaredFalsifiable.py
+++ b/plugin/makoto/checks/undeclaredFalsifiable.py
@@ -27,7 +27,7 @@ from typing import Optional
 
 from makoto.substrate._declared import DECLARED_IDS
 from makoto.registry import Check, scan
-from makoto.verdict import ADVISE
+from makoto.registry import POSTURE_ADVISE
 from makoto.vocab import Finding
 
 
@@ -81,6 +81,6 @@ def undeclared_falsifiable_gate(*, package_dir: Optional[Path] = None,
 CHECK = Check(
     id="gate.undeclared_falsifiable",
     applies_at="Stop",
-    posture=ADVISE,
+    posture=POSTURE_ADVISE,
     run=lambda ctx=None: undeclared_falsifiable_gate(),
 )

--- a/plugin/makoto/registry.py
+++ b/plugin/makoto/registry.py
@@ -59,7 +59,10 @@ ALLOWED_POSTURES = frozenset({POSTURE_BLOCK, POSTURE_ADVISE})
 
 
 def blocking_eligible(check) -> bool:
-    """The one owner of "blocking", stated once and called by every consumer.
+    """Which end-of-turn gates the catalog counts as blocking. ONE owner OF THAT COUNT,
+    called by every consumer of it -- not the one owner of the word: a pre-check denies
+    without being Stop-edge, `configchange` emits a block from outside this registry, and
+    `_canonAtoms.BLOCK_IDS` counts patterns rather than checks. README lists all of them.
 
     The Check docstring below has always defined this as BOTH signals: `may_block is True`
     AND `posture == BLOCK`. `tools/render_checks.py` implemented a different rule -- Stop

--- a/plugin/makoto/registry.py
+++ b/plugin/makoto/registry.py
@@ -45,6 +45,35 @@ TESTS_SHAPES = frozenset({
 _ADVISORY_ALLOWLIST = frozenset({"gate.self_wired", "gate.canon_fingerprints_advisory",
                                   "gate.relative_path_citation", "gate.plan_item_drift"})  # FD6, FD26, 2026-07-09
 
+# THE CHECK-POSTURE VOCABULARY, closed. Three different things in this package are called
+# "posture" and they are three different vocabularies: a CHECK's native tier is `BLOCK`/`ADVISE`
+# (here); `makoto.verdict`'s OUTCOME vocabulary is `block`/`advise` lower-case; and
+# `verdict._POSTURES` is the operator's configured mode, `loose`/`strict`/`ask`/`silent`.
+# `_valid_check` used to require only that `posture` be truthy, so any spelling loaded -- and two
+# checks shipped their native tier spelled in the OUTCOME vocabulary's case. Nothing noticed,
+# because the one consumer that publishes a blocking count never read posture at all. With the
+# set closed, a fourth spelling cannot be loaded rather than being caught later by a reader.
+POSTURE_BLOCK = "BLOCK"
+POSTURE_ADVISE = "ADVISE"
+ALLOWED_POSTURES = frozenset({POSTURE_BLOCK, POSTURE_ADVISE})
+
+
+def blocking_eligible(check) -> bool:
+    """The one owner of "blocking", stated once and called by every consumer.
+
+    The Check docstring below has always defined this as BOTH signals: `may_block is True`
+    AND `posture == BLOCK`. `tools/render_checks.py` implemented a different rule -- Stop
+    edge, `may_block`, and absence from `_ADVISORY_ALLOWLIST` -- and never consulted posture
+    at all. The two agree on today's catalog only because the allowlist happens to name
+    exactly the four checks whose posture is ADVISE. Set a gate's posture to ADVISE without
+    editing the allowlist and the README goes on calling it blocking, because the sentence
+    that defines the word and the code that publishes the count were different owners.
+    """
+    return (getattr(check, "applies_at", None) == "Stop"
+            and bool(getattr(check, "may_block", False))
+            and getattr(check, "posture", None) == POSTURE_BLOCK)
+
+
 _PACKAGE_DIR = Path(__file__).parent / "checks"
 
 
@@ -147,7 +176,7 @@ def _valid_check(chk) -> bool:
     return (
         bool(getattr(chk, "id", None))
         and getattr(chk, "applies_at", None) in ALLOWED_EDGES
-        and bool(getattr(chk, "posture", None))
+        and getattr(chk, "posture", None) in ALLOWED_POSTURES
     )
 
 

--- a/plugin/makoto/state/ledger.py
+++ b/plugin/makoto/state/ledger.py
@@ -741,7 +741,9 @@ re-deriving it" and nothing emitted it. This closes that gap.
 DESIGN DECISION 2026-07-07 (curated brief: claim kinds, shape, persistence):
   1. Only `verdict`/`certified-fact`/`testrun` chain rows count as CLAIMS -- kinds that assert
      something about the world (the ancestor canon/mint.py's "spendable if backed by a real
-     deed" test). `audit`/`touched`/`release.operator`/`fetch`/`exemption` are records of deeds and
+     deed" test -- cited for WHY these three kinds and not the others, not as a second test of
+     spendability: in this package `spendable` means `trace_bound`, defined at the foot of this
+     docstring, and nothing here re-checks that a deed was performed). `audit`/`touched`/`release.operator`/`fetch`/`exemption` are records of deeds and
      machinery, not claims, and folding them in would blur exactly the distinction the receipt
      exists to expose.
   2. One dict per call: {ts, session_id, chain_name, verified_through, claims, claim_count,

--- a/tests/bash/smoke_test.sh
+++ b/tests/bash/smoke_test.sh
@@ -10,7 +10,7 @@ echo "Scratch: $SCRATCH"
 echo "Python: $PYTHON_BIN"
 
 # Drive a synthetic PreToolUse event through the dispatcher.
-# Lazy init in dispatch.py should create makoto.db on first call.
+# Lazy init in dispatch.py should create makoto.record.db on first call.
 EVENT='{"hook_event_name":"PreToolUse","session_id":"smoke","cwd":"/tmp","tool_input":{"file_path":"/tmp/x.txt","content":"hello"}}'
 
 cd "$REPO_ROOT"
@@ -18,7 +18,7 @@ export MAKOTO_STATE_DIR="$SCRATCH/makoto_state"
 printf '%s' "$EVENT" | "$PYTHON_BIN" -m makoto.dispatch
 
 # Verify lazy init worked
-test -f "$SCRATCH/makoto_state/makoto.db" || { echo "FAIL: lazy init didn't create makoto.db"; rm -rf "$SCRATCH"; exit 1; }
+test -f "$SCRATCH/makoto_state/makoto.record.db" || { echo "FAIL: lazy init didn't create makoto.record.db"; rm -rf "$SCRATCH"; exit 1; }
 test -f "$SCRATCH/makoto_state/audit.jsonl" || { echo "FAIL: audit.jsonl missing"; rm -rf "$SCRATCH"; exit 1; }
 
 echo "OK: lazy state init + dispatch wrote audit.jsonl"

--- a/tests/bash/test_smoke.sh
+++ b/tests/bash/test_smoke.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 # Phase 5.4 smoke test — drives makoto.dispatch end-to-end.
-# Spec §6 success criterion: lazy state init + dispatch event + audit row written.
+# Success criterion: lazy state init + dispatch event. NOT an audit row: `state/audit.py`
+# documents an ONLY-FIRES policy -- one row per Finding-producing invocation -- and the
+# benign write below produces no finding, so no row is owed. The original criterion
+# predates that policy and asserted one anyway.
 set -e
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -19,8 +22,13 @@ printf '%s' "$EVENT" | "$PYTHON_BIN" -m makoto.dispatch
 
 # Verify lazy init worked
 test -f "$SCRATCH/makoto_state/makoto.record.db" || { echo "FAIL: lazy init didn't create makoto.record.db"; rm -rf "$SCRATCH"; exit 1; }
-test -f "$SCRATCH/makoto_state/audit.jsonl" || { echo "FAIL: audit.jsonl missing"; rm -rf "$SCRATCH"; exit 1; }
+# Only-fires: a benign event owes no audit row, so an ABSENT or EMPTY audit.jsonl is correct
+# here. What must not happen is a row for an event that fired nothing.
+if [ -s "$SCRATCH/makoto_state/audit.jsonl" ]; then
+  echo "FAIL: audit row written for an event that produced no finding (only-fires policy)"
+  rm -rf "$SCRATCH"; exit 1
+fi
 
-echo "OK: lazy state init + dispatch wrote audit.jsonl"
+echo "OK: lazy state init + dispatch; no audit row for a non-firing event (only-fires policy)"
 rm -rf "$SCRATCH"
 echo "Smoke complete."

--- a/tests/test_checks_taxonomy.py
+++ b/tests/test_checks_taxonomy.py
@@ -18,7 +18,7 @@ import pytest
 from makoto.registry import Check, load_checks
 
 
-def _write(tmp_path, name, id_, applies_at, posture="advise"):
+def _write(tmp_path, name, id_, applies_at, posture="ADVISE"):
     (tmp_path / name).write_text(
         "from makoto.registry import Check\n"
         f"CHECK = Check(id={id_!r}, applies_at={applies_at!r}, posture={posture!r})\n"

--- a/tests/test_stale_establisher.py
+++ b/tests/test_stale_establisher.py
@@ -121,5 +121,8 @@ def test_a_stale_establisher_finding_does_not_block_when_dispatch_runs_it(
 def test_check_export_is_advisory_and_stop_scoped():
     assert staleEstablisher.CHECK.id == "gate.stale_establisher"
     assert staleEstablisher.CHECK.applies_at == "Stop"
-    from makoto.verdict import ADVISE
-    assert staleEstablisher.CHECK.posture == ADVISE
+    # The CHECK-posture vocabulary, not `verdict`'s OUTCOME vocabulary that shares these
+    # names in lower case. This assertion used to read `verdict.ADVISE` ('advise'), which is
+    # what the module itself wrongly imported, so the test agreed with the defect.
+    from makoto.registry import POSTURE_ADVISE
+    assert staleEstablisher.CHECK.posture == POSTURE_ADVISE

--- a/tests/test_undeclared_falsifiable.py
+++ b/tests/test_undeclared_falsifiable.py
@@ -23,7 +23,7 @@ from makoto.checks.undeclaredFalsifiable import (
 def _good(tmp_path, name, id_, applies_at="Stop"):
     (tmp_path / name).write_text(
         "from makoto.registry import Check\n"
-        f"CHECK = Check(id={id_!r}, applies_at={applies_at!r}, posture='advise')\n"
+        f"CHECK = Check(id={id_!r}, applies_at={applies_at!r}, posture='ADVISE')\n"
     )
 
 
@@ -47,7 +47,7 @@ def test_module_with_a_malformed_check_is_an_orphan_module(tmp_path):
     # via load_checks() -- unregistered in the loader's eyes despite the file existing.
     (tmp_path / "mismatched.py").write_text(
         "from makoto.registry import Check\n"
-        "CHECK = Check(id='', applies_at='Stop', posture='advise')\n"
+        "CHECK = Check(id='', applies_at='Stop', posture='ADVISE')\n"
     )
     assert orphan_modules(package_dir=tmp_path) == ["mismatched"]
 
@@ -92,8 +92,8 @@ def test_gate_reports_both_orphan_kinds_together(tmp_path):
 def test_gate_is_advisory_never_blocking():
     # Never "error" -- per this repo's advisory-over-blocking standing policy, same tier as
     # gate.self_wired.
-    from makoto.verdict import ADVISE
-    assert CHECK.posture == ADVISE
+    from makoto.registry import POSTURE_ADVISE
+    assert CHECK.posture == POSTURE_ADVISE
 
 
 # ---- the real, live catalog: this check auditing itself ------------------------------------

--- a/tools/render_checks.py
+++ b/tools/render_checks.py
@@ -18,7 +18,7 @@ REPO = Path(__file__).resolve().parent.parent
 PLUGIN = REPO / "plugin"
 sys.path.insert(0, str(PLUGIN))
 
-from makoto.registry import _ADVISORY_ALLOWLIST, load_checks  # noqa: E402
+from makoto.registry import _ADVISORY_ALLOWLIST, blocking_eligible, load_checks  # noqa: E402
 from makoto.substrate._canonAtoms import BLOCK_IDS, THE_CANON_17  # noqa: E402
 
 README = REPO / "README.md"
@@ -28,8 +28,19 @@ def render_counts() -> list[str]:
     pre = load_checks(edge="Pre")
     stop = load_checks(edge="Stop")
     gates = [check for check in stop if check.may_block]
-    advisory = [check for check in gates if check.id in _ADVISORY_ALLOWLIST]
-    blocking = [check for check in gates if check.id not in _ADVISORY_ALLOWLIST]
+    # `blocking` is read from its one owner, `registry.blocking_eligible`, which is where the
+    # word is defined. This used to be allowlist membership alone, so a gate whose posture moved
+    # to ADVISE without an allowlist edit went on being published as blocking. The allowlist is
+    # still the advisory list -- but it is now asserted against the definition rather than
+    # standing in for it, so the two cannot drift apart silently.
+    blocking = [check for check in gates if blocking_eligible(check)]
+    advisory = [check for check in gates if not blocking_eligible(check)]
+    disagreement = sorted({c.id for c in gates if blocking_eligible(c)}
+                          ^ {c.id for c in gates if c.id not in _ADVISORY_ALLOWLIST})
+    if disagreement:
+        raise SystemExit(
+            "_ADVISORY_ALLOWLIST and registry.blocking_eligible disagree about: "
+            f"{disagreement}. One of them is wrong; the definition is blocking_eligible.")
     prefixes = Counter(check.id.partition(".")[0] for check in pre)
     prefix_text = ", ".join(f"`{key}`: **{value}**" for key, value in sorted(prefixes.items()))
     return [

--- a/tools/render_checks.py
+++ b/tools/render_checks.py
@@ -28,8 +28,8 @@ def render_counts() -> list[str]:
     pre = load_checks(edge="Pre")
     stop = load_checks(edge="Stop")
     gates = [check for check in stop if check.may_block]
-    # `blocking` is read from its one owner, `registry.blocking_eligible`, which is where the
-    # word is defined. This used to be allowlist membership alone, so a gate whose posture moved
+    # The blocking-gate COUNT is read from `registry.blocking_eligible`, its one owner. The
+    # word itself has several producers and this is not all of them -- see README. This used to be allowlist membership alone, so a gate whose posture moved
     # to ADVISE without an allowlist edit went on being published as blocking. The allowlist is
     # still the advisory list -- but it is now asserted against the definition rather than
     # standing in for it, so the two cannot drift apart silently.

--- a/tools/render_checks.py
+++ b/tools/render_checks.py
@@ -44,11 +44,12 @@ def render_counts() -> list[str]:
     prefixes = Counter(check.id.partition(".")[0] for check in pre)
     prefix_text = ", ".join(f"`{key}`: **{value}**" for key, value in sorted(prefixes.items()))
     return [
-        f"- **{len(pre)} pre-checks** (all blocking)",
+        f"- **{len(pre)} pre-checks** (every one denies the tool call; `blocking_eligible` is "
+        f"about the Stop edge and is False for all of them)",
         f"- Pre-check ids grouped by dotted prefix — {prefix_text}",
         f"- **{len(stop)} Stop checks** (all checks registered at the Stop edge)",
         f"- **{len(gates)} end-of-turn gates** (`may_block=True`)",
-        f"- **{len(blocking)} blocking end-of-turn gates** (not advisory-allowlisted)",
+        f"- **{len(blocking)} blocking end-of-turn gates** (`registry.blocking_eligible`)",
         f"- **{len(advisory)} advisory end-of-turn gates** (advisory-allowlisted)",
     ]
 


### PR DESCRIPTION
Three different things in this package are called `posture`, and they are three different vocabularies:

| where | values | what it means |
| --- | --- | --- |
| `Check.posture` | `BLOCK` / `ADVISE` | a check's own native tier |
| `makoto.verdict` | `block` / `advise` | the OUTCOME vocabulary |
| `verdict._POSTURES` | `loose` / `strict` / `ask` / `silent` | the operator's configured mode |

`_valid_check` required only that `posture` be truthy, so any spelling loaded. Two checks — `gate.stale_establisher` and `gate.undeclared_falsifiable` — imported `ADVISE` from `makoto.verdict`, the right name from the wrong vocabulary, and shipped their native tier as `'advise'`.

Nothing caught it, and the reason is the second half of this PR: the one consumer that publishes a blocking count read allowlist membership and **never consulted posture at all**.

## The closure, witnessed

Closed the set the same way `ALLOWED_EDGES` already closes the hook edges. With the closure in place and *before* correcting the imports, the loader refuses exactly the two mis-spellings:

```
checks now: 34      # was 36
```

After pointing them at `registry.POSTURE_ADVISE`, back to 36 with `{'ADVISE', 'BLOCK'}` as the entire vocabulary. A fourth spelling can no longer be written down, rather than being caught later by whichever reader happens to compare against the right constant.

The suite then found how far the wrong constant had spread: two more test assertions and two test fixture helpers built checks in the outcome vocabulary, so four further sites **agreed with the defect instead of catching it**. All corrected to the owner's constant.

## One owner for "blocking"

`registry.blocking_eligible` now states the rule the `Check` docstring has always given — Stop edge, `may_block`, and `posture == POSTURE_BLOCK`, *"two independent signals, not one"*. `tools/render_checks.py` calls it instead of standing `_ADVISORY_ALLOWLIST` in for it.

The two agree on today's catalog, 15 each, and they agreed before this change too — but by coincidence, because the allowlist happens to name exactly the four ADVISE-postured gates. Move a gate's posture without editing the allowlist and the README would have gone on publishing it as blocking. The renderer now raises if they ever disagree, naming which ids and which of the two is the definition.

## Scope, measured rather than assumed

`dispatch._blocking_gate_ids()` derives its set from `may_block` alone and does not read posture. A comment in `canonTimeoutRecur.py` describing it as `may_block and c.posture == BLOCK` is stale documentation of that function. So `posture` is catalog metadata, and this PR does not claim the dispatcher enforces it — the advisory gates stay non-blocking by the `level=="advisory"` route in `_emit_decision`, unchanged.

## Recorded, not swept

`gate.undeclared_falsifiable` carries no `eats`. Checked rather than assumed: its derived reads are genuinely empty — it audits the catalog on disk, not `GateContext` — and `tests/test_check_law_eats.py` agrees. The empty declaration is correct and is left alone.

## Verification

Hand-run from a clean worktree, bare exit codes, at `53e935f`:

| command | result |
| --- | --- |
| `PYTHONPATH=plugin python3 -m pytest -q` | **1964 passed, 1 xfailed, 43 subtests, exit 0** |
| `python3 tools/render_checks.py --check` | exit 0 |
| `python3 eval/replay.py` | exit 0 |

The loader closure was observed refusing the two mis-spelled checks before the correction, and the count restored after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSeHeTrYof2BRmgrT3SFm2

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSeHeTrYof2BRmgrT3SFm2)_