### PR TITLE
ledger: O(1) tail via sidecar, indexed append, incremental verify on tool events

### DIFF
--- a/makoto/_dispatch.py
+++ b/makoto/_dispatch.py
@@ -120,17 +120,34 @@ def _dispatch_fact(state_dir: Path, stage: str, reason: str, *, blocked: bool) -
         pass
 
 
-def _self_verify_chain(state_dir: Path) -> None:
+def _self_verify_chain(state_dir: Path, *, full: bool = False) -> None:
     """Task 2 slice 3 (owner: "Makoto should read its own ledger for verification -- its things
-    literally depend on it"). Re-derives the chain's own tamper-evidence at every dispatch, the
-    same every-event cadence Assay's kernel ran. OWNER DECISION (2026-07-07): advisory-first,
-    block-after-soak -- this ships ADVISORY ONLY (an on-the-record dispatch fact + a stderr line,
-    never a block) until real-session soak evidence earns the flip to block, itself a later,
-    separately-certified change. A clean or absent/empty chain is vacuously silent (verify_chain's
-    own contract). NEVER RAISES: a verification fault must not crash the hot path it protects."""
+    literally depend on it"). Re-derives the chain's own tamper-evidence at every dispatch.
+    OWNER DECISION (2026-07-07): advisory-first, block-after-soak -- this ships ADVISORY ONLY (an
+    on-the-record dispatch fact + a stderr line, never a block) until real-session soak evidence
+    earns the flip to block, itself a later, separately-certified change. A clean or absent/empty
+    chain is vacuously silent (verify_chain's own contract). NEVER RAISES: a verification fault
+    must not crash the hot path it protects.
+
+    CADENCE (owner decision 2026-09-04, superseding the every-event full walk Assay's kernel
+    ran): every dispatch still verifies, but only `full=True` -- Stop -- re-walks and re-hashes
+    the whole chain. Every other event verifies INCREMENTALLY: only the rows appended since the
+    last clean walk, starting from the recorded checkpoint. The full walk was O(chain) on every
+    single tool call, which on a real long-lived chain is seconds of hook latency per call.
+
+    WHAT THE INCREMENTAL PATH DOES AND DOES NOT DETECT. It detects anything wrong with the rows
+    after the checkpoint, plus any truncation, and any earlier edit that changes the file's byte
+    length (which moves the checkpoint's recorded offset off the head row it re-hashes every
+    time). It does NOT detect a BYTE-LENGTH-PRESERVING edit to a row before the checkpoint --
+    that stays invisible until the next Stop's full walk. Note the chain was never anchored
+    anyway: no path here has an external anchor for the chain head, so an actor able to rewrite
+    the stream could always rewrite every derived file in the same directory along with it. This
+    cadence delays detection of a tamper the full walk still catches; it adds no new blind spot
+    beyond that delay."""
     try:
         from makoto.record import ledger as _ledger
-        broken_at = _ledger.verify_chain()
+        broken_at = (_ledger.verify_chain_checkpointed() if full
+                     else _ledger.verify_chain_incremental())
     except Exception as exc:
         _dispatch_fact(state_dir, "chain_verify_error", f"{type(exc).__name__}: {exc}", blocked=False)
         return
@@ -861,8 +878,15 @@ def main() -> int:
     ingest) and nothing about any event."""
     payload_raw = sys.stdin.read()
     state_dir = _state_dir()
-    _self_verify_chain(state_dir)
+    # Parse first, verify second -- the self-verify needs to know whether this is the Stop event
+    # that earns the full chain walk (see _self_verify_chain's CADENCE note). _parse_payload is
+    # total (it returns a sentinel rather than raising), so nothing below it changes: every
+    # not-evaluable envelope still gets its own fact and exit 2, and still gets a chain verify
+    # first, exactly as before.
     payload = _parse_payload(payload_raw)
+    _self_verify_chain(
+        state_dir,
+        full=isinstance(payload, dict) and payload.get("hook_event_name") == "Stop")
     if payload is _PARSE_FAILED:
         reason = ("stdin was empty -- no payload arrived at all"
                   if not payload_raw.strip() else "stdin was not valid JSON")

--- a/makoto/record/claim_graph.py
+++ b/makoto/record/claim_graph.py
@@ -32,13 +32,6 @@ def ensure_schema(conn) -> None:
     _create_claim_graph_tables(conn)
 
 
-def _row_index(root: Path, name: str, row_hash: str) -> Optional[int]:
-    for index, row in enumerate(ledger.read(name=name, root=root)):
-        if row.get("row_hash") == row_hash:
-            return index
-    return None
-
-
 def _project_row(conn, row: Mapping, *, row_index=None, row_hash="") -> bool:
     value = graph_model.row_to_graph_value(row)
     if value is None:
@@ -88,9 +81,11 @@ def persist_value(conn, value, *, root: Optional[Path] = None, name: str = "chai
     row_index = None
     row_hash = ""
     if root is not None:
-        stored = ledger.append(row, name=name, root=root)
+        # append_indexed hands back the index of the row it just wrote. The old code re-read the
+        # whole stream to find that row by hash, which made every persisted graph value cost one
+        # full parse of the chain -- four of them per PostToolUse.
+        stored, row_index = ledger.append_indexed(row, name=name, root=root)
         row_hash = stored.get("row_hash", "")
-        row_index = _row_index(root, name, row_hash)
         row = stored
     _project_row(conn, row, row_index=row_index, row_hash=row_hash)
     return True

--- a/makoto/record/ledger.py
+++ b/makoto/record/ledger.py
@@ -202,6 +202,8 @@ def latest_testrun(conn, session_id: str) -> str:
 import fcntl
 import hashlib
 import json as _json
+import os
+import tempfile
 from pathlib import Path
 from typing import Optional
 
@@ -209,6 +211,17 @@ from makoto.record.state import _state_dir as _chain_state_dir
 
 _DEFAULT_STREAM = "chain"
 OPEN = "open"
+
+# Sidecar suffixes. Both hold the SAME triple -- {"rows": N, "head_hash": H, "bytes": B}, read
+# as "the stream's first B bytes hold N well-formed rows, the last of which hashes to H" -- but
+# they answer different questions and advance at different moments, so they are separate files:
+#   .tail.json      where the NEXT append chains from (advanced by append, under the lock)
+#   .verified.json  how far the chain has been re-walked and found intact (advanced by verify)
+# Both are DERIVED caches, never the record: every consumer validates the triple against the
+# stream's real byte length and falls back to reading the stream itself when it does not match.
+# Neither is an external anchor -- an attacker who can rewrite the stream can rewrite these too.
+_TAIL = "tail"
+_VERIFIED = "verified"
 
 
 def norm_sha256(content: str) -> str:
@@ -290,24 +303,117 @@ def read(*, name: str = _DEFAULT_STREAM, root: Optional[Path] = None) -> list:
     return rows
 
 
+def _sidecar_path(root: Path, name: str, kind: str) -> Path:
+    return root / f"{name}.{kind}.json"
+
+
+def _read_sidecar(root: Path, name: str, kind: str) -> Optional[dict]:
+    """The sidecar triple, or None when it is absent, unreadable, or not the expected shape.
+    NEVER RAISES: every caller's fallback is to read the stream itself, so an unusable sidecar
+    must be indistinguishable from an absent one."""
+    try:
+        with open(_sidecar_path(root, name, kind), "r", encoding="utf-8") as fh:
+            data = _json.load(fh)
+    except (OSError, ValueError, UnicodeDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    rows, head, nbytes = data.get("rows"), data.get("head_hash"), data.get("bytes")
+    # bool is an int subclass; reject it explicitly rather than reading True as 1.
+    if isinstance(rows, bool) or isinstance(nbytes, bool):
+        return None
+    if not isinstance(rows, int) or not isinstance(nbytes, int) or not isinstance(head, str):
+        return None
+    if rows < 0 or nbytes < 0:
+        return None
+    return {"rows": rows, "head_hash": head, "bytes": nbytes}
+
+
+def _write_sidecar(root: Path, name: str, kind: str, *, rows: int, head_hash: str,
+                   nbytes: int) -> None:
+    """Replace the sidecar atomically (unique temp file in the same directory + `os.replace`),
+    so a reader never sees a half-written triple and two concurrent writers cannot interleave.
+    NEVER RAISES: a sidecar that fails to land only costs the next caller a full read."""
+    fd = None
+    tmp = None
+    try:
+        fd, tmp = tempfile.mkstemp(dir=str(root), prefix=f".{name}.{kind}.", suffix=".tmp")
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fd = None                      # fdopen owns it now
+            _json.dump({"rows": rows, "head_hash": head_hash, "bytes": nbytes}, fh)
+        os.replace(tmp, _sidecar_path(root, name, kind))
+        tmp = None
+    except Exception:
+        pass
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        if tmp is not None:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+
+
 def append(row: dict, *, name: str = _DEFAULT_STREAM, root: Optional[Path] = None) -> dict:
     """Append one row, computing its chain link — never rewrites an existing row. Holds the
     stream's exclusive lock across tail-read + append so the chain can never fork. Returns the
     stored row with `prev_hash`/`row_hash` populated. `root` overrides env-var resolution (see
-    `store_root`)."""
+    `store_root`). `append_indexed` is the same write; it also returns the row's chain index."""
+    stored, _index = append_indexed(row, name=name, root=root)
+    return stored
+
+
+def append_indexed(row: dict, *, name: str = _DEFAULT_STREAM,
+                   root: Optional[Path] = None) -> tuple:
+    """`append`, plus the 0-based CHAIN INDEX the written row occupies — the position a reader
+    walking the stream's well-formed rows in order would find it at. Returned rather than
+    re-derived: a caller that needs the index (claim_graph's projection) would otherwise have to
+    re-read the whole stream to find the row it just wrote, which is O(stream) per append.
+
+    The tail sidecar makes the common case O(1): when it matches the stream's current byte
+    length it names both the hash to chain from and the index to use, so no row is read at all.
+    Any mismatch — absent sidecar, unreadable sidecar, a crash between the row write and the
+    sidecar write, an external append, a rewrite, a truncation — falls back to the full `read()`
+    and chains from the last WELL-FORMED row, exactly as this function did before the sidecar
+    existed. The fallback repairs nothing: `bytes` is recorded as the file's real length, so a
+    corrupt tail keeps its bytes and this row goes after them, as always."""
     with _Locked(name, root=root):
-        existing = read(name=name, root=root)
-        prev_hash = existing[-1].get("row_hash", "") if existing else ""
+        root_path = store_root(root=root)
+        target = root_path / f"{name}.jsonl"
+        try:
+            size = os.path.getsize(target)
+        except OSError:                    # absent or unstattable -> take the fallback path
+            size = None
+        tail = _read_sidecar(root_path, name, _TAIL)
+        if tail is not None and size is not None and tail["bytes"] == size:
+            prev_hash = tail["head_hash"]
+            index = tail["rows"]
+        else:
+            existing = read(name=name, root=root)
+            prev_hash = existing[-1].get("row_hash", "") if existing else ""
+            index = len(existing)
         stored = dict(row)
         stored.setdefault("status", OPEN)
         stored["prev_hash"] = prev_hash
         stored.pop("row_hash", None)
         stored["row_hash"] = _row_hash(prev_hash, stored)
-        target = store_root(root=root) / f"{name}.jsonl"
         with open(target, "a", encoding="utf-8") as fh:
             fh.write(_dumps(stored) + "\n")
             fh.flush()
-    return stored
+            # the file's length as it ACTUALLY is, taken from the fd we just wrote through --
+            # not len() of the line, which counts characters, not the utf-8 bytes on disk.
+            try:
+                written = os.fstat(fh.fileno()).st_size
+            except OSError:
+                written = None
+        if written is not None:
+            _write_sidecar(root_path, name, _TAIL, rows=index + 1,
+                           head_hash=stored["row_hash"], nbytes=written)
+    return stored, index
 
 
 def verify_chain(*, name: str = _DEFAULT_STREAM, root: Optional[Path] = None) -> Optional[int]:
@@ -345,3 +451,173 @@ def verify_chain(*, name: str = _DEFAULT_STREAM, root: Optional[Path] = None) ->
         expected_prev = row.get("row_hash", "")
         idx += 1
     return None
+
+
+def _scan_extent(target: Path) -> Optional[tuple]:
+    """(non-blank line count, the LAST such line's `row_hash`, byte length) for the stream as it
+    is right now — a byte-level pass that hashes nothing and parses only the last line. Only
+    meaningful as a checkpoint when a full `verify_chain` of the same file came back clean, which
+    is what makes "non-blank line count" and "well-formed row count" the same number. None when
+    the stream is unreadable or its last line is not a JSON object (in which case `verify_chain`
+    is about to name a broken row anyway, so nothing gets checkpointed)."""
+    if not target.exists():
+        return None
+    rows = 0
+    last = b""
+    size = 0
+    try:
+        with open(target, "rb") as fh:
+            for raw in fh:
+                size += len(raw)
+                try:
+                    text = raw.decode("utf-8")
+                except UnicodeDecodeError:
+                    return None
+                if not text.strip():
+                    continue
+                rows += 1
+                last = raw
+    except OSError:
+        return None
+    head = ""
+    if last:
+        try:
+            parsed = _json.loads(last.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        head = str(parsed.get("row_hash", "") or "")
+    return rows, head, size
+
+
+def _last_line_before(target: Path, offset: int) -> Optional[bytes]:
+    """The last non-blank line lying entirely within the stream's first `offset` bytes, read
+    backwards in chunks so the cost is the length of that one line, not of the stream. None when
+    there is none, the read fails, or a single line runs past the sanity bound."""
+    chunk = 4096
+    pos = offset
+    tail = b""
+    try:
+        with open(target, "rb") as fh:
+            while pos > 0:
+                step = min(chunk, pos)
+                pos -= step
+                fh.seek(pos)
+                tail = fh.read(step) + tail
+                parts = tail.split(b"\n")
+                # parts[0] is only a whole line once we have read back to the file's start.
+                for candidate in reversed(parts if pos == 0 else parts[1:]):
+                    if candidate.strip():
+                        return candidate
+                if len(tail) > (1 << 20):
+                    return None
+    except OSError:
+        return None
+    return None
+
+
+def _checkpoint_resumable(target: Path, checkpoint: dict) -> bool:
+    """Is it safe to trust `checkpoint` and verify only what follows it? Requires the stream to
+    be at least `bytes` long (anything shorter is a truncation) AND the last row inside those
+    bytes to still hash to `head_hash` (the cheap re-verify of the recorded head row). False
+    sends the caller to a full walk, which is always correct and only ever slower."""
+    try:
+        if os.path.getsize(target) < checkpoint["bytes"]:
+            return False
+    except OSError:
+        return False
+    if checkpoint["rows"] == 0:
+        # nothing verified yet: only a zero-length prefix with no head row is coherent.
+        return checkpoint["bytes"] == 0 and checkpoint["head_hash"] == ""
+    if checkpoint["bytes"] == 0:
+        return False
+    raw = _last_line_before(target, checkpoint["bytes"])
+    if raw is None:
+        return False
+    try:
+        row = _json.loads(raw.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return False
+    return isinstance(row, dict) and row.get("row_hash") == checkpoint["head_hash"]
+
+
+def _verify_suffix(target: Path, *, offset: int, index: int, prev_hash: str) -> tuple:
+    """Walk the stream from byte `offset`, chaining from `prev_hash` and numbering from `index`,
+    applying exactly `verify_chain`'s per-row checks. Returns
+    (broken_at_or_None, rows, head_hash, bytes) where the last three describe the extent walked
+    and are meaningful only when broken_at is None. Raises what `verify_chain` raises on the
+    same input (a non-utf-8 byte), so the caller's fault handling is unchanged."""
+    idx = index
+    expected_prev = prev_hash
+    consumed = offset
+    with open(target, "rb") as fh:
+        fh.seek(offset)
+        for raw in fh:
+            consumed += len(raw)
+            stripped = raw.decode("utf-8").strip()
+            if not stripped:
+                continue
+            try:
+                row = _json.loads(stripped)
+            except ValueError:
+                return idx, 0, "", 0
+            if not isinstance(row, dict):
+                return idx, 0, "", 0
+            if row.get("prev_hash", "") != expected_prev:
+                return idx, 0, "", 0
+            if row.get("row_hash") != _row_hash(expected_prev, row):
+                return idx, 0, "", 0
+            expected_prev = row.get("row_hash", "")
+            idx += 1
+    return None, idx, expected_prev, consumed
+
+
+def verify_chain_checkpointed(*, name: str = _DEFAULT_STREAM,
+                              root: Optional[Path] = None) -> Optional[int]:
+    """`verify_chain` — same full walk, same return contract — that ALSO records how far it got,
+    so a later `verify_chain_incremental` can start there. The extent is measured BEFORE the walk
+    on purpose: under a concurrent append the checkpoint then names a prefix the walk definitely
+    covered, never bytes the walk never saw."""
+    root_path = store_root(root=root)
+    target = root_path / f"{name}.jsonl"
+    extent = _scan_extent(target)
+    broken_at = verify_chain(name=name, root=root)
+    if broken_at is None and extent is not None:
+        rows, head, nbytes = extent
+        _write_sidecar(root_path, name, _VERIFIED, rows=rows, head_hash=head, nbytes=nbytes)
+    return broken_at
+
+
+def verify_chain_incremental(*, name: str = _DEFAULT_STREAM,
+                             root: Optional[Path] = None) -> Optional[int]:
+    """Verify only what has been appended since the last checkpoint. Same return contract as
+    `verify_chain`: None when clean, else the 0-based index of the first bad row, counted from
+    the start of the stream. Falls back to the full `verify_chain_checkpointed` walk whenever the
+    checkpoint cannot be trusted — absent, unreadable, longer than the stream (a truncation), or
+    naming a head row that no longer hashes to what was recorded.
+
+    WHAT THIS DOES NOT DETECT. A BYTE-LENGTH-PRESERVING edit to a row before the checkpoint is
+    invisible here until the next full walk. An edit that changes the byte length is caught, but
+    incidentally rather than by design: it shifts every later byte, so the line ending at the
+    recorded offset is no longer the recorded head row and the checkpoint is refused. And an
+    actor who can rewrite the stream can rewrite `<name>.verified.json` too — neither file is
+    anchored anywhere outside this directory — so the incremental pass narrows a tamper's
+    detection window, it does not close it. The full walk is what closes it."""
+    root_path = store_root(root=root)
+    target = root_path / f"{name}.jsonl"
+    if not target.exists():
+        return None
+    checkpoint = _read_sidecar(root_path, name, _VERIFIED)
+    if checkpoint is not None and _checkpoint_resumable(target, checkpoint):
+        try:
+            broken_at, rows, head, nbytes = _verify_suffix(
+                target, offset=checkpoint["bytes"], index=checkpoint["rows"],
+                prev_hash=checkpoint["head_hash"])
+        except OSError:
+            return None                    # unreadable store reads as clean (verify_chain's contract)
+        if broken_at is not None:
+            return broken_at
+        _write_sidecar(root_path, name, _VERIFIED, rows=rows, head_hash=head, nbytes=nbytes)
+        return None
+    return verify_chain_checkpointed(name=name, root=root)

--- a/tests/test_ledger_hot_path.py
+++ b/tests/test_ledger_hot_path.py
@@ -1,0 +1,425 @@
+"""The hook hot path must not be O(chain size).
+
+Before this, every hook invocation parsed the whole chain repeatedly: `ledger.append` read it
+to find the last row's hash, `claim_graph._row_index` read it again to locate the row append had
+just written, and `_dispatch._self_verify_chain` re-walked and re-hashed all of it. Measured on a
+212k-row chain that was 2.6 s per PreToolUse and 18 s per PostToolUse.
+
+Two sidecars replace the reads, and the tests below are about the two things that can go wrong
+with a cache of a file: it can be WRONG (so every fallback path is exercised here, and the fast
+path is checked against the answer a full read would have given), and it can silently stop being
+used (so `test_hot_dispatch_never_parses_the_whole_chain` asserts STRUCTURALLY -- by spying on
+`ledger.read` / `ledger.verify_chain` -- that the hot path calls neither, which is what a
+wall-clock assertion would only imply, and would flake about on a loaded machine)."""
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from makoto.record import ledger
+
+
+# --------------------------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------------------------
+
+def _chain(root: Path) -> Path:
+    return root / "chain.jsonl"
+
+
+def _rows_on_disk(root: Path) -> list:
+    return ledger.read(root=root)
+
+
+def _index_by_reading(root: Path, row_hash: str):
+    """The index the deleted `claim_graph._row_index` would have returned: the position of the
+    row with this hash among the stream's well-formed rows. This is the ORACLE the O(1) index
+    is checked against."""
+    for index, row in enumerate(ledger.read(root=root)):
+        if row.get("row_hash") == row_hash:
+            return index
+    return None
+
+
+def _tamper_field(root: Path, line_no: int, key: str = "k", value: str = "TAMPERED") -> None:
+    """Hand-edit one row's field, leaving its now-stale row_hash in place."""
+    path = _chain(root)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    row = json.loads(lines[line_no])
+    row[key] = value
+    lines[line_no] = json.dumps(row, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# --------------------------------------------------------------------------------------------
+# A. the tail sidecar: O(1) append, and the index append hands back
+# --------------------------------------------------------------------------------------------
+
+def test_append_indexed_matches_a_full_read_including_across_a_lost_sidecar(tmp_path):
+    """The index append returns must equal the one a full re-read finds -- on the fast path, on
+    the very first (no-sidecar-yet) append, and on an append made right after the sidecar was
+    lost, which is the crash-between-write-and-sidecar-write case."""
+    seen = []
+    for i in range(4):
+        stored, index = ledger.append_indexed({"kind": "test", "k": i}, root=tmp_path)
+        seen.append((stored["row_hash"], index))
+
+    (tmp_path / "chain.tail.json").unlink()          # sidecar lost; next append must fall back
+    stored, index = ledger.append_indexed({"kind": "test", "k": "after-loss"}, root=tmp_path)
+    seen.append((stored["row_hash"], index))
+
+    for i in range(2):                                # and the sidecar rebuilt by that fallback
+        stored, index = ledger.append_indexed({"kind": "test", "k": f"post-{i}"}, root=tmp_path)
+        seen.append((stored["row_hash"], index))
+
+    assert [index for _h, index in seen] == list(range(7))
+    for row_hash, index in seen:
+        assert _index_by_reading(tmp_path, row_hash) == index, (row_hash, index)
+    assert ledger.verify_chain(root=tmp_path) is None
+
+
+def test_append_returns_the_row_unchanged_and_still_chains(tmp_path):
+    """`append`'s own contract (one dict back, linked to its predecessor) is untouched by the
+    index-returning variant it now delegates to."""
+    a = ledger.append({"kind": "verdict", "key": "a"}, root=tmp_path)
+    b = ledger.append({"kind": "verdict", "key": "b"}, root=tmp_path)
+    assert a["prev_hash"] == ""
+    assert b["prev_hash"] == a["row_hash"]
+    assert [r["key"] for r in _rows_on_disk(tmp_path)] == ["a", "b"]
+
+
+def test_tail_sidecar_records_the_real_byte_length_not_the_character_count(tmp_path):
+    """A row carrying non-ASCII text is longer in bytes than in characters (`ensure_ascii=False`).
+    If the sidecar recorded characters, the very next append would see a size mismatch and fall
+    back forever -- silently O(n) again, with every test still green."""
+    ledger.append({"kind": "test", "k": "日本語 — café"}, root=tmp_path)
+    sidecar = json.loads((tmp_path / "chain.tail.json").read_text(encoding="utf-8"))
+    assert sidecar["bytes"] == _chain(tmp_path).stat().st_size
+    assert sidecar["bytes"] > len(_chain(tmp_path).read_text(encoding="utf-8"))
+    assert sidecar["rows"] == 1
+    assert sidecar["head_hash"] == _rows_on_disk(tmp_path)[-1]["row_hash"]
+
+
+def test_append_falls_back_when_the_stream_grew_behind_the_sidecar(tmp_path):
+    """An external append leaves the sidecar naming a stale head. The size check catches it and
+    the fallback chains from the row actually last on disk, so the chain still verifies."""
+    ledger.append({"kind": "test", "k": "a"}, root=tmp_path)
+    outsider = ledger.append({"kind": "test", "k": "b"}, root=tmp_path)
+    (tmp_path / "chain.tail.json").write_text(                     # rewind the sidecar by a row
+        json.dumps({"rows": 1, "head_hash": "0" * 64, "bytes": 10}), encoding="utf-8")
+
+    stored, index = ledger.append_indexed({"kind": "test", "k": "c"}, root=tmp_path)
+    assert stored["prev_hash"] == outsider["row_hash"]
+    assert index == 2
+    assert ledger.verify_chain(root=tmp_path) is None
+
+
+@pytest.mark.parametrize("bad", [
+    "not json at all",
+    json.dumps({"rows": -1, "head_hash": "x", "bytes": 0}),
+    json.dumps({"rows": "two", "head_hash": "x", "bytes": 0}),
+    json.dumps(["rows", 2]),
+    json.dumps({"head_hash": "x"}),
+])
+def test_a_corrupt_tail_sidecar_is_treated_as_an_absent_one(tmp_path, bad):
+    """An unusable sidecar must be indistinguishable from no sidecar: read the stream, chain
+    correctly, rebuild. It must never raise, and never produce a forked chain."""
+    first = ledger.append({"kind": "test", "k": "a"}, root=tmp_path)
+    (tmp_path / "chain.tail.json").write_text(bad, encoding="utf-8")
+    stored, index = ledger.append_indexed({"kind": "test", "k": "b"}, root=tmp_path)
+    assert stored["prev_hash"] == first["row_hash"]
+    assert index == 1
+    assert ledger.verify_chain(root=tmp_path) is None
+
+
+def test_append_after_a_corrupt_tail_still_writes_after_the_corrupt_bytes(tmp_path):
+    """Today's corrupt-tail semantics, preserved on the fallback path: `read()` stops at the bad
+    line, the new row chains from the last WELL-FORMED row, and nothing repairs or rewrites the
+    corrupt bytes -- the new row goes after them."""
+    good = ledger.append({"kind": "test", "k": "a"}, root=tmp_path)
+    with open(_chain(tmp_path), "a", encoding="utf-8") as fh:
+        fh.write("{not json\n")
+    (tmp_path / "chain.tail.json").unlink()          # force the fallback path
+
+    stored, index = ledger.append_indexed({"kind": "test", "k": "b"}, root=tmp_path)
+    assert stored["prev_hash"] == good["row_hash"]
+    assert index == 1
+    raw = _chain(tmp_path).read_text(encoding="utf-8").splitlines()
+    assert raw[1] == "{not json", "the corrupt line must survive untouched, in place"
+    assert len(raw) == 3
+    assert ledger.verify_chain(root=tmp_path) == 1   # still broken at the same row, as before
+
+
+def test_concurrent_appends_do_not_fork_the_chain_through_the_sidecar(tmp_path, monkeypatch):
+    """The sidecar is read and written inside the same exclusive lock as the row, so the
+    fast path cannot hand two racing appends the same prev_hash."""
+    import threading
+    monkeypatch.setenv("MAKOTO_STATE_DIR", str(tmp_path))
+    threads = [threading.Thread(target=lambda t=t: [ledger.append({"k": f"{t}-{i}"})
+                                                    for i in range(10)])
+               for t in range(8)]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+    assert ledger.verify_chain() is None
+    assert len(ledger.read()) == 80
+    sidecar = json.loads((tmp_path / "chain.tail.json").read_text(encoding="utf-8"))
+    assert sidecar["rows"] == 80
+    assert sidecar["bytes"] == _chain(tmp_path).stat().st_size
+
+
+# --------------------------------------------------------------------------------------------
+# B. the verify checkpoint: incremental verification
+# --------------------------------------------------------------------------------------------
+
+def test_incremental_verify_agrees_with_the_full_walk_on_a_clean_chain(tmp_path):
+    for i in range(6):
+        ledger.append({"kind": "test", "k": i}, root=tmp_path)
+    assert ledger.verify_chain_incremental(root=tmp_path) is None      # no checkpoint -> full
+    checkpoint = json.loads((tmp_path / "chain.verified.json").read_text(encoding="utf-8"))
+    assert checkpoint == {"rows": 6, "head_hash": _rows_on_disk(tmp_path)[-1]["row_hash"],
+                          "bytes": _chain(tmp_path).stat().st_size}
+
+    for i in range(3):
+        ledger.append({"kind": "test", "k": f"more-{i}"}, root=tmp_path)
+    assert ledger.verify_chain_incremental(root=tmp_path) is None      # resumed from the checkpoint
+    advanced = json.loads((tmp_path / "chain.verified.json").read_text(encoding="utf-8"))
+    assert advanced["rows"] == 9
+    assert advanced["bytes"] == _chain(tmp_path).stat().st_size
+    assert advanced["head_hash"] == _rows_on_disk(tmp_path)[-1]["row_hash"]
+
+
+def test_incremental_verify_names_the_same_row_as_the_full_walk_for_a_tamper_after_it(tmp_path):
+    """A row appended after the checkpoint and then edited must be named by the incremental pass
+    at the SAME 0-based index the full walk reports -- indices continue from the checkpoint, they
+    do not restart at the resume point."""
+    for i in range(5):
+        ledger.append({"kind": "test", "k": i}, root=tmp_path)
+    assert ledger.verify_chain_incremental(root=tmp_path) is None
+    for i in range(3):
+        ledger.append({"kind": "test", "k": f"more-{i}"}, root=tmp_path)
+    _tamper_field(tmp_path, 6)
+    assert ledger.verify_chain(root=tmp_path) == 6
+    assert ledger.verify_chain_incremental(root=tmp_path) == 6
+
+
+def test_incremental_verify_falls_back_to_the_full_walk_on_truncation(tmp_path):
+    """A stream shorter than the checkpoint cannot be resumed from it: bytes past the end were
+    never verified and are now gone. The full walk runs instead, and reports what it finds."""
+    for i in range(5):
+        ledger.append({"kind": "test", "k": i}, root=tmp_path)
+    assert ledger.verify_chain_incremental(root=tmp_path) is None
+    lines = _chain(tmp_path).read_text(encoding="utf-8").splitlines()
+    _chain(tmp_path).write_text("\n".join(lines[:3]) + "\n", encoding="utf-8")
+
+    assert ledger.verify_chain_incremental(root=tmp_path) is None       # a clean 3-row prefix
+    checkpoint = json.loads((tmp_path / "chain.verified.json").read_text(encoding="utf-8"))
+    assert checkpoint["rows"] == 3                                      # re-anchored, not stale
+
+
+def test_incremental_verify_detects_a_head_row_edited_under_the_checkpoint(tmp_path):
+    """The checkpoint's own head row is re-hashed on every incremental pass, so an edit to THAT
+    row is caught without a full walk -- the one pre-checkpoint edit the fast path does see."""
+    for i in range(5):
+        ledger.append({"kind": "test", "k": i}, root=tmp_path)
+    assert ledger.verify_chain_incremental(root=tmp_path) is None
+    _tamper_field(tmp_path, 4)
+    assert ledger.verify_chain_incremental(root=tmp_path) == 4
+
+
+def test_incremental_verify_misses_a_length_preserving_early_edit_until_the_full_walk(tmp_path):
+    """The stated limit of the fast path, asserted rather than only documented: an edit BEFORE
+    the checkpoint's head row that keeps the file's byte length the same is invisible to the
+    incremental pass, and is caught by the next full walk. This is the cadence's accepted cost."""
+    for i in range(5):
+        ledger.append({"kind": "test", "k": f"row-{i}"}, root=tmp_path)
+    assert ledger.verify_chain_incremental(root=tmp_path) is None
+    size_before = _chain(tmp_path).stat().st_size
+    _tamper_field(tmp_path, 1, key="k", value="ROW-1")             # same byte length as "row-1"
+    assert _chain(tmp_path).stat().st_size == size_before, "the premise of this test"
+
+    assert ledger.verify_chain_incremental(root=tmp_path) is None, "documented blind spot"
+    assert ledger.verify_chain_checkpointed(root=tmp_path) == 1, "the full walk still catches it"
+
+
+def test_an_early_edit_that_changes_the_byte_length_is_caught_incrementally(tmp_path):
+    """Not a designed guarantee, but real and worth pinning: an edit before the checkpoint that
+    changes how many bytes precede it moves every later byte, so the line ending at the recorded
+    offset is no longer the recorded head row. The checkpoint is refused and the full walk runs.
+    Only a length-preserving edit slips through."""
+    for i in range(5):
+        ledger.append({"kind": "test", "k": f"row-{i}"}, root=tmp_path)
+    assert ledger.verify_chain_incremental(root=tmp_path) is None
+    _tamper_field(tmp_path, 1, key="k", value="a much longer tampered value")
+    assert ledger.verify_chain_incremental(root=tmp_path) == 1
+
+
+def test_incremental_verify_is_vacuously_clean_on_an_absent_or_empty_chain(tmp_path):
+    assert ledger.verify_chain_incremental(root=tmp_path) is None       # absent
+    assert not (tmp_path / "chain.verified.json").exists()
+    _chain(tmp_path).write_text("", encoding="utf-8")
+    assert ledger.verify_chain_incremental(root=tmp_path) is None       # empty
+
+
+def test_a_corrupt_checkpoint_is_treated_as_an_absent_one(tmp_path):
+    for i in range(4):
+        ledger.append({"kind": "test", "k": i}, root=tmp_path)
+    (tmp_path / "chain.verified.json").write_text("{{{", encoding="utf-8")
+    assert ledger.verify_chain_incremental(root=tmp_path) is None
+    assert json.loads((tmp_path / "chain.verified.json").read_text(encoding="utf-8"))["rows"] == 4
+
+
+def test_a_checkpoint_naming_a_head_row_that_is_not_there_forces_a_full_walk(tmp_path):
+    """A checkpoint whose head row does not re-hash to the recorded value cannot be resumed from
+    -- and the full walk it forces must still find a tamper the checkpoint would have skipped."""
+    for i in range(5):
+        ledger.append({"kind": "test", "k": i}, root=tmp_path)
+    size = _chain(tmp_path).stat().st_size
+    (tmp_path / "chain.verified.json").write_text(
+        json.dumps({"rows": 5, "head_hash": "f" * 64, "bytes": size}), encoding="utf-8")
+    _tamper_field(tmp_path, 0)
+    assert ledger.verify_chain_incremental(root=tmp_path) == 0
+
+
+def test_checkpoint_never_claims_more_than_the_walk_verified(tmp_path):
+    """The extent is measured before the walk, so a row appended DURING a full walk is left for
+    the next pass rather than being checkpointed as verified."""
+    for i in range(3):
+        ledger.append({"kind": "test", "k": i}, root=tmp_path)
+    size_before = _chain(tmp_path).stat().st_size
+    real_verify = ledger.verify_chain
+
+    def _verify_then_append(**kwargs):
+        result = real_verify(**kwargs)
+        ledger.append({"kind": "test", "k": "raced-in"}, root=tmp_path)
+        return result
+
+    ledger.verify_chain = _verify_then_append
+    try:
+        assert ledger.verify_chain_checkpointed(root=tmp_path) is None
+    finally:
+        ledger.verify_chain = real_verify
+    checkpoint = json.loads((tmp_path / "chain.verified.json").read_text(encoding="utf-8"))
+    assert checkpoint["rows"] == 3 and checkpoint["bytes"] == size_before
+
+
+# --------------------------------------------------------------------------------------------
+# C. the regression guard: the hot path must not go back to parsing the whole chain
+# --------------------------------------------------------------------------------------------
+
+_HOT_STREAM_ROWS = 5000
+
+
+def _setup_state(tmp_path) -> Path:
+    from makoto.record.db import init_db
+    state_dir = tmp_path / "makoto_state"
+    citations = tmp_path / "CITATIONS.md"
+    citations.write_text("Smith 2020\n", encoding="utf-8")
+    init_db(state_dir, citations)
+    return state_dir
+
+
+def _dispatch_in_process(monkeypatch, payload: dict) -> int:
+    """Run one hook envelope through `_dispatch.main()` IN THIS PROCESS. The existing dispatch
+    tests shell out, which is the right call for exit-code and stdout behaviour but useless here:
+    a spy installed in the parent is invisible to a subprocess."""
+    from makoto import _dispatch
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    return _dispatch.main()
+
+
+class _Spy:
+    def __init__(self, fn):
+        self._fn = fn
+        self.calls = 0
+
+    def __call__(self, *a, **kw):
+        self.calls += 1
+        return self._fn(*a, **kw)
+
+
+@pytest.fixture()
+def hot_chain(tmp_path, monkeypatch):
+    """A state dir whose chain is long enough that an O(n) hot path would be obvious, with both
+    sidecars already warmed by one real dispatch."""
+    state_dir = _setup_state(tmp_path)
+    monkeypatch.setenv("MAKOTO_STATE_DIR", str(state_dir))
+    for i in range(_HOT_STREAM_ROWS):
+        ledger.append({"kind": "test", "k": i}, root=state_dir)
+    _dispatch_in_process(monkeypatch, {
+        "hook_event_name": "PostToolUse", "session_id": "warm", "cwd": str(tmp_path),
+        "tool_name": "Bash", "tool_input": {"command": "git status --short"},
+        "tool_response": {"stdout": "", "stderr": "", "interrupted": False},
+    })
+    assert (state_dir / "chain.tail.json").exists()
+    assert (state_dir / "chain.verified.json").exists()
+    return state_dir
+
+
+def test_hot_dispatch_never_parses_the_whole_chain(hot_chain, monkeypatch, capsys):
+    """THE REGRESSION GUARD. With both sidecars warm, a PreToolUse and a PostToolUse must call
+    neither `ledger.read` (a full parse of every row) nor `ledger.verify_chain` (a full re-hash
+    of every row) even once. Asserted structurally: wall time on a shared machine is not
+    evidence, and a timing threshold generous enough not to flake is too generous to catch a
+    regression on a 5000-row chain."""
+    read_spy = _Spy(ledger.read)
+    verify_spy = _Spy(ledger.verify_chain)
+    monkeypatch.setattr(ledger, "read", read_spy)
+    monkeypatch.setattr(ledger, "verify_chain", verify_spy)
+
+    assert _dispatch_in_process(monkeypatch, {
+        "hook_event_name": "PreToolUse", "session_id": "hot", "cwd": str(hot_chain),
+        "tool_input": {"file_path": str(hot_chain / "unrelated.txt"), "content": "hello"},
+    }) == 0
+    assert _dispatch_in_process(monkeypatch, {
+        "hook_event_name": "PostToolUse", "session_id": "hot", "cwd": str(hot_chain),
+        "tool_name": "Bash", "tool_input": {"command": "git status --short"},
+        "tool_response": {"stdout": "", "stderr": "", "interrupted": False},
+    }) == 0
+    capsys.readouterr()
+
+    assert read_spy.calls == 0, (
+        f"the hot path parsed the whole chain {read_spy.calls} time(s) -- the tail sidecar is "
+        "not being used")
+    assert verify_spy.calls == 0, (
+        f"the hot path re-walked the whole chain {verify_spy.calls} time(s) -- the verify "
+        "checkpoint is not being used")
+
+
+def test_stop_still_walks_the_whole_chain_exactly_once(hot_chain, monkeypatch, capsys):
+    """The other half of the cadence: Stop is where the full walk still happens, and it happens
+    once. Without this, 'the hot path is fast' could be satisfied by never verifying at all."""
+    verify_spy = _Spy(ledger.verify_chain)
+    monkeypatch.setattr(ledger, "verify_chain", verify_spy)
+
+    assert _dispatch_in_process(monkeypatch, {
+        "hook_event_name": "Stop", "session_id": "hot", "cwd": str(hot_chain),
+        "last_assistant_message": "Done.",
+    }) == 0
+    capsys.readouterr()
+    assert verify_spy.calls == 1, f"Stop must run exactly one full walk, ran {verify_spy.calls}"
+
+
+def test_a_tamper_appended_after_the_warm_checkpoint_is_still_caught_on_a_tool_event(
+        hot_chain, monkeypatch, capsys):
+    """Speed must not have cost the advisory detection it was protecting: a row appended after
+    the warm checkpoint and then edited still trips `dispatch.chain_tamper` on an ordinary
+    PreToolUse, and still does not block."""
+    ledger.append({"kind": "test", "k": "late"}, root=hot_chain)
+    _tamper_field(hot_chain, _HOT_STREAM_ROWS)
+
+    rc = _dispatch_in_process(monkeypatch, {
+        "hook_event_name": "PreToolUse", "session_id": "hot", "cwd": str(hot_chain),
+        "tool_input": {"file_path": str(hot_chain / "unrelated.txt"), "content": "hello"},
+    })
+    out = capsys.readouterr().out
+    assert rc == 0 and out == "", "chain verification stays advisory -- it must never block"
+    facts = [json.loads(ln) for ln
+             in (hot_chain / "dispatch_errors.jsonl").read_text(encoding="utf-8").splitlines()
+             if ln.strip()]
+    assert any(f.get("pattern_id") == "dispatch.chain_tamper" for f in facts), facts


### PR DESCRIPTION
## Problem

Every hook dispatch parses the whole chain up to ten times. On a real long-lived install (214k rows / 190 MB `chain.jsonl`) that is **2.8 s per PreToolUse and 12–19 s per PostToolUse**, growing linearly with history, with every concurrent session serialised behind `chain.lock`. Profiled with cProfile against a copy of the state:

| site | calls per PostToolUse | cost |
|---|---|---|
| `ledger.append` → `read()` to find the tail hash | 5 | 7.5 s |
| `claim_graph._row_index` → `read()` to find the index of the row just appended | 4 | 6.5 s |
| `_self_verify_chain` → `verify_chain()` full re-walk + re-hash | 1 | 4.3 s (and all of PreToolUse) |

## Change

- **`append_indexed()`** returns the written row and its chain index; `append()` delegates to it, signature and contract unchanged. A `<name>.tail.json` sidecar `{rows, head_hash, bytes}` is written atomically under the lock after each append. It is validated against the stream's real byte length on every use; any mismatch (absent, unreadable, crash between row and sidecar write, external append, truncation) falls back to the full `read()` and chains from the last well-formed row exactly as before. Byte accounting comes from `fstat` on the written fd, never `len(str)` (`ensure_ascii=False` makes those differ).
- **`claim_graph.persist_value`** uses the returned index; `_row_index` is deleted (it had one call site).
- **`verify_chain_incremental()`** walks only the rows appended since a `<name>.verified.json` checkpoint whose recorded head row still re-hashes (checked by a seek-back read of that one line), falling back to **`verify_chain_checkpointed()`**, the unchanged full walk, which records its extent as measured *before* walking so a concurrent append is never checkpointed as verified. **`_self_verify_chain` runs the full walk on `Stop` and the incremental one on every other event.** Both remain advisory, as the 2026-07-07 owner decision specifies.

`read()`, `verify_chain()`, `canonical()`, `_row_hash()`, `norm_sha256()`, the row schema, and the set of recorded events are unchanged.

## Measured (copies of the same real state, before → after)

| event | before | after (warm) |
|---|---|---|
| PreToolUse | 2.8 s | 0.11 s |
| PostToolUse | 12.4–19.2 s | 0.15 s (0.68 s on the largest real session, now dominated by `load_projection`) |
| Stop | 2.79 s | 2.79 s (by design: the full walk lives here) |

Suite: 1548 → 1572 passed, 5 skipped, 1 xfailed. The new structural guard (`test_hot_dispatch_never_parses_the_whole_chain`) was checked to fail — 8 full parses — with either fast path disabled.

## Two semantic points for the maintainer

1. **Verify cadence.** The incremental path detects anything wrong after the checkpoint, any truncation, and any earlier edit that changes byte length. It does **not** detect a byte-length-preserving edit before the checkpoint until the next Stop's full walk. The docstrings say so plainly. Nothing here was ever anchored outside the state directory, so an actor who can rewrite the stream could always rewrite derived files too; this change delays detection of a tamper the full walk still catches, it adds no new blind spot beyond that delay. `SubagentStop` takes the incremental path under this wording; the following main `Stop` always does the full walk. Happy to move SubagentStop to the full walk if you prefer.
2. **Corrupt-tail chaining.** Today every append after a corrupt line re-reads, finds the same last well-formed row, and chains from it, producing a star. Under the sidecar the first such append is identical, but it then writes a valid sidecar, so the *next* append chains from the row just written. Both states are already `chain_tamper`-flagged. If you want today's behaviour preserved exactly, the sidecar can be withheld whenever the `read()` prefix does not account for the whole file, at the cost of staying O(n) on a corrupt chain.

## Follow-ups noticed, not included

- `record/ackblock.py` still does two full `read()`s on Stop/SubagentStop when a canon primitive fires.
- On a corrupt chain the checkpoint is never written, so every dispatch pays the full walk (same total work as today, but now a visible cliff vs the fast path).
- `load_projection` is O(session size) on PostToolUse (~0.5 s on a 6.5k-node session) and is now the dominant term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pebaj4CBNPbZbDSgobEbMg
