### PR TITLE
One owner for the input fold and the introduced-AST scan

### DIFF
--- a/plugin/makoto/checks/canonTimeoutRecur.py
+++ b/plugin/makoto/checks/canonTimeoutRecur.py
@@ -89,7 +89,7 @@ import re
 from typing import Iterable, List
 
 from makoto.vocab import Finding
-from makoto.kit import classify_failure, decode_history_event, failure_terminal_result
+from makoto.kit import canon_input, classify_failure, decode_history_event, failure_terminal_result
 
 # A Call is one paired tool event in protocol form: {"name": tool_name, "input": tool_input,
 # "result": tool_response} — tool_input/tool_response are kept as full DICTS (not the flattened
@@ -294,17 +294,8 @@ def timed_out_at_turn_end(calls: list) -> bool:
     return transients >= 2
 
 
-def _canon_input(inp) -> str:
-    """A stable, identity-comparable serialization of a tool_input dict (key order-independent).
-    Used ONLY to compare two calls for byte-identity — it reads no content semantically."""
-    try:
-        return json.dumps(inp, sort_keys=True, default=str)
-    except Exception:
-        return repr(inp)
-
-
 def _pairing_input(inp) -> str:
-    """`_canon_input` with leading-dunder keys dropped — the call-identity fold used to pair a
+    """`canon_input` with leading-dunder keys dropped — the call-identity fold used to pair a
     PostToolUse back to its own PreToolUse AND (since the ADR 0024 follow-up) as the per-key
     verdict identity inside this module's own sequence primitives (`recur_stuck`,
     `timed_out_at_turn_end`'s transient budget).
@@ -313,15 +304,15 @@ def _pairing_input(inp) -> str:
     pairing on the FULL canonical input would leave a dangling Pre for a call that in fact
     succeeded. See docs/adr/0024-dunder-insensitive-call-pairing.md for the decision history.
     The SAME injection class also broke the verdict side while it keyed on the full
-    `_canon_input`: a bookkeeping key that VARIES per call (`__seq`) split a byte-identical
+    `canon_input`: a bookkeeping key that VARIES per call (`__seq`) split a byte-identical
     retry loop into distinct keys, so recur never saw a run of length >= 2.
 
     A leading `__` is a transport/bookkeeping convention, never call semantics, so dropping it
     cannot collapse two genuinely distinct calls — for pairing or for a verdict. Primitives in
     OTHER modules (`identical_retry`) still key on their own folds."""
     if isinstance(inp, dict):
-        return _canon_input({k: v for k, v in inp.items() if not str(k).startswith("__")})
-    return _canon_input(inp)
+        return canon_input({k: v for k, v in inp.items() if not str(k).startswith("__")})
+    return canon_input(inp)
 
 
 # ---- the history -> Call adapter (protocol-field decode; fail-open per row) -------------------
@@ -359,7 +350,7 @@ def calls_from_history(history) -> list:
     preceding still-unpaired identical (tool name + `_pairing_input`) Pre, and only the terminal
     becomes a Call (the Pre is dropped) — so `recur_stuck`'s consecutive-run judgment is not
     corrupted by spurious result-less Calls (module docstring ADAPTATION NOTE).
-    Pairing uses `_pairing_input` (dunder-insensitive), NOT the full `_canon_input` the verdicts
+    Pairing uses `_pairing_input` (dunder-insensitive), NOT the full `canon_input` the verdicts
     key on: a harness may inject bookkeeping keys between a call's Pre and its Post, and pairing
     on those synthesized a phantom failure for a call that succeeded. See `_pairing_input`.
 

--- a/plugin/makoto/checks/identicalRetryInterdiction.py
+++ b/plugin/makoto/checks/identicalRetryInterdiction.py
@@ -21,20 +21,14 @@ match by construction.
 """
 from __future__ import annotations
 
-import json
 from typing import Optional
 
-from makoto.kit import (bash_output_text, classify_failure, decode_history_event,
+from makoto.kit import (bash_output_text, canon_input, classify_failure, decode_history_event,
                         failure_terminal_result)
 from makoto.vocab import Finding
 from makoto.registry import Check
 
 
-def _canon_input(ti: dict) -> str:
-    try:
-        return json.dumps(ti, sort_keys=True, default=str)
-    except Exception:
-        return repr(ti)
 
 
 def _most_recent_completed_bash_call(history) -> Optional[tuple]:
@@ -85,7 +79,7 @@ def predicate(*, current_event: dict, history: list, pattern: Check,
         return None
     prior_input, prior_result_text = prior
     current_input = current_event.get("tool_input") or {}
-    if _canon_input(prior_input) != _canon_input(current_input):
+    if canon_input(prior_input) != canon_input(current_input):
         return None                          # not a retry of the SAME call -- silent
     if classify_failure(prior_result_text) is not True:
         return None                          # transient or uncertain -- never fire (the ship bar)

--- a/plugin/makoto/checks/verifierPredicateWeakened.py
+++ b/plugin/makoto/checks/verifierPredicateWeakened.py
@@ -38,7 +38,7 @@ import re
 import textwrap
 from typing import Optional
 
-from makoto.kit import _exempt_or_finding, _gated_content, callee_chain, parse_introduced
+from makoto.kit import ast_introduced_predicate, callee_chain, parse_introduced
 
 _TARGET_RX = re.compile(r"constitution/integrity/checks/.+\.py$")
 _RE_LOOSE_CHAINS = frozenset({"re.match", "re.search"})
@@ -82,27 +82,7 @@ def _parse_fragment(content: str):
         return None, 0
 
 
-def predicate(*, current_event: dict, history: list, pattern, conn=None) -> Optional["object"]:
-    gated = _gated_content(current_event=current_event, target_rx=_TARGET_RX, exempt_rx=None)
-    if gated is None:
-        return None
-    fp, content = gated
-    tree, off = _parse_fragment(content)
-    if tree is None:
-        return None    # unparseable fragment -> never confirmed as active code -> silent (FN-safe)
-    for node in ast.walk(tree):
-        label = _loose_label(node)
-        if not label:
-            continue
-        line_no = max(1, getattr(node, "lineno", 1) - off)
-        lines = content.splitlines()
-        snippet = lines[line_no - 1].strip()[:120] if 0 < line_no <= len(lines) else str(label)
-        return _exempt_or_finding(
-            current_event=current_event, conn=conn, pattern=pattern, fp=fp, line_no=line_no,
-            snippet=snippet, content=content,
-            message=f"row {pattern.id} ({pattern.description}): active-code match {label!r} "
-                    f"at line {line_no}")
-    return None
+predicate = ast_introduced_predicate(target_rx=_TARGET_RX, node_match=_loose_label, parse=_parse_fragment)
 
 
 from makoto.registry import Check as _Check

--- a/plugin/makoto/kit.py
+++ b/plugin/makoto/kit.py
@@ -550,12 +550,23 @@ def jwt_decode_callee_chain(node) -> Optional[str]:
     return chain
 
 
+def canon_input(inp) -> str:
+    """A stable, identity-comparable serialization of a tool_input (key order-independent).
+    Compares two calls for byte-identity only; reads no content semantically. ONE owner:
+    canon.timeout/recur and identicalRetryInterdiction pair calls by the same fold."""
+    try:
+        return json.dumps(inp, sort_keys=True, default=str)
+    except Exception:
+        return repr(inp)
+
+
 def ast_introduced_predicate(
     *,
     target_rx: re.Pattern,
     node_match: Callable[[ast.AST], Optional[str]],
     exempt_rx: Optional[re.Pattern] = None,
     exempt_label: str = "",
+    parse: Callable[[str], tuple] = None,
 ) -> Callable[..., Optional[Finding]]:
     """Build a PreToolUse content-scan predicate that fires ONLY on a real AST node in the
     INTRODUCED code — the "only active code" companion to :func:`regex_file_predicate`.
@@ -577,7 +588,7 @@ def ast_introduced_predicate(
         if gated is None:
             return None
         fp, content = gated
-        tree, off = parse_introduced(content)
+        tree, off = (parse or parse_introduced)(content)
         if tree is None:
             return None  # unparseable fragment -> not confirmed active -> silent (FN-safe)
         for node in ast.walk(tree):

--- a/tests/test_canon_pairing_injected_keys.py
+++ b/tests/test_canon_pairing_injected_keys.py
@@ -14,7 +14,7 @@ The real success lands under a DIFFERENT key, so it cannot flip the phantom run'
 the documented [ERR, ERR, OK] guard cannot help.
 
 The fix relaxes PAIRING ONLY (`_pairing_input`), never a verdict: `recur_stuck` and every other
-primitive keep keying on the full `_canon_input`. The true-positive cases below are what hold
+primitive keep keying on the full `canon_input`. The true-positive cases below are what hold
 that line -- a pairing relaxed until nothing dangles would discharge the gate while leaving its
 name in place.
 
@@ -26,7 +26,7 @@ from __future__ import annotations
 import json
 
 from makoto.checks.canonTimeoutRecur import (
-    _canon_input,
+    canon_input,
     _pairing_input,
     calls_from_history,
     fired_primitives,
@@ -55,16 +55,16 @@ def test_pairing_input_ignores_leading_dunder_keys():
 
 
 def test_the_verdict_identity_still_sees_them():
-    """PAIRED. Only pairing is dunder-insensitive; `_canon_input` -- what every verdict keys on --
+    """PAIRED. Only pairing is dunder-insensitive; `canon_input` -- what every verdict keys on --
     is unchanged, so the relaxation cannot leak into a judgment."""
-    assert _canon_input(BASE) != _canon_input(INJECTED)
+    assert canon_input(BASE) != canon_input(INJECTED)
 
 
 def test_pairing_input_never_collapses_genuinely_distinct_calls():
     """PAIRED REFUSAL. A leading `__` is a transport convention, never call semantics -- so
     dropping it must not make two different calls look like one."""
     assert _pairing_input({"command": "a"}) != _pairing_input({"command": "b"})
-    assert _pairing_input("scalar") == _canon_input("scalar")
+    assert _pairing_input("scalar") == canon_input("scalar")
 
 
 # ---- the four shapes from the report ----------------------------------------------------------

--- a/tests/test_gate_shape.py
+++ b/tests/test_gate_shape.py
@@ -142,11 +142,14 @@ EXPECTED_FUNCTION_COUNTS = {                               # top-level def count
                                                             # _stdlib_ast_helpers.py. 30->31, 2026-08-20:
                                                             # _imported_helper_names_that_assert (the shared
                                                             # plant-and-restore helper FP class)
-    "canonTimeoutRecur.py": 17,                            # engine + adapter merged (canon_gate lives here);
+    "canonTimeoutRecur.py": 16,                            # engine + adapter merged (canon_gate lives here);
                                                             # 15->17, 2026-08-16 (#17 port): _pairing_input
                                                             # (dunder-insensitive Pre<->Post pairing identity)
                                                             # + _release_clause (per-primitive release.operator
                                                             # affordance, generated from the id)
+                                                            # 17->16, 2026-09-06: _canon_input moved to
+                                                            # kit.canon_input, the one owner shared with
+                                                            # identicalRetryInterdiction
     "canonFingerprints.py": 1,                             # thin adapter; atoms/decode live in _canonAtoms.py
     "canonFingerprintsAdvisory.py": 1,                     # thin adapter; atoms/decode live in _canonAtoms.py
     "contractOrder.py": 5,


### PR DESCRIPTION
Two rule applications, nothing else.

**`canon_input`.** `canonTimeoutRecur` and `identicalRetryInterdiction` each carried the same serialization under a private name. `kit.canon_input` owns it and both call it. The pairing test imports it from kit; `test_gate_shape`'s def count for `canonTimeoutRecur` moves 17 to 16 with the dated note the file uses.

**The introduced-AST scan.** `verifierPredicateWeakened` re-implemented `ast_introduced_predicate`'s scan loop, differing only in its parser and label function. The parser is now an argument of the builder (default unchanged), and the check is one call with `_parse_fragment` and `_loose_label`.

Gates: 1964 passed, 1 xfailed; replay 5/5; `render_checks --check` matches.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSeHeTrYof2BRmgrT3SFm2)_