### PR TITLE
Contribution policy, retroactive credit, and the ack anchor (issue #45)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!--
+Before you write the diff, please read this.
+
+This repository does not merge pull requests from outside it. That is a provenance rule and not
+a judgement about your work: every line here carries a claim about where it came from and what
+graded it, and code arriving from outside cannot carry those claims.
+
+Reports ARE acted on, and they are credited by name. If you have found something, please open an
+issue instead -- the artifact and line, what you observed, and the command that produced it. That
+is enough. See CONTRIBUTING.md.
+
+If you open this PR anyway, it will be closed with thanks and the finding will be captured as an
+issue in your name. Nothing you found is discarded. But you will have written a diff you did not
+need to write, and that is what this note is here to save you.
+-->
+
+## What you found
+
+<!-- The artifact and line, what you observed, what you expected. -->
+
+## How you observed it
+
+<!-- The command, and its output. -->
+
+## Where you stopped
+
+<!-- What you did not check. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,12 +34,23 @@ finding is what mattered, and closing the PR does not discard it.
 
 ## Acknowledgements
 
-People outside this repository whose reports changed the code. Listed in the order received.
+People outside this repository whose reports changed the code, every one of them, oldest first.
+Nine reports from two people, and every closed one of them landed a fix.
 
-<!-- Add a row when the fix lands, never when the report arrives: the credit names a change. -->
+<!-- Add a row when the fix lands, never when the report arrives: the credit names a change.
+     Retroactive: every outside report that changed this code is listed, not only recent ones. -->
 
-| who | what they found | where it landed |
+| report | who | what they found |
 | --- | --- | --- |
+| [#2](https://github.com/Clear-Sights/Makoto/issues/2) | [@AliceLJY](https://github.com/AliceLJY) | `gate.completion` false-positive: a file produced remotely over ssh and landed by `git pull` read as an unproduced claim. |
+| [#10](https://github.com/Clear-Sights/Makoto/issues/10) | [@AliceLJY](https://github.com/AliceLJY) | `_DESTRUCTIVE_RX` false-positive on read-only `dd if=`, and the mirror miss of `of=`-first writes. |
+| [#14](https://github.com/Clear-Sights/Makoto/issues/14) | [@AliceLJY](https://github.com/AliceLJY) | `_DISABLE_RX` false-positive on a lowercase `dd skip=` argument -- the sibling of #10. |
+| [#15](https://github.com/Clear-Sights/Makoto/issues/15) | [@AliceLJY](https://github.com/AliceLJY) | A denylist audit naming a whole family of over- and under-matches, several BLOCK-level, with the shared root: the atoms scan the raw command string instead of parsing argv, quotes and comments. |
+| [#17](https://github.com/Clear-Sights/Makoto/issues/17) | [@AliceLJY](https://github.com/AliceLJY) | `canon.recur` false-positive: Pre/Post pairing breaks when the harness injects dunder keys. |
+| [#19](https://github.com/Clear-Sights/Makoto/issues/19) | [@tkulczy2](https://github.com/tkulczy2) | `_dispatch` rejected a camelCase `hookEventName` as `unknown_event` and exited 2, so Cursor-shaped sessions misrouted. |
+| [#20](https://github.com/Clear-Sights/Makoto/issues/20) | [@tkulczy2](https://github.com/tkulczy2) | `makoto uninstall` reported `"unwired": true` unconditionally, and silently removed nothing. |
+| [#28](https://github.com/Clear-Sights/Makoto/issues/28) | [@AliceLJY](https://github.com/AliceLJY) | `canon.recur` fired on transient failures and re-fired every Stop, because failed calls carry no PostToolUse. |
+| [#45](https://github.com/Clear-Sights/Makoto/issues/45) | [@AliceLJY](https://github.com/AliceLJY) | `_ACK_RX` anchored at offset 0 of the whole user turn, so prepended Stop-hook feedback made `release.operator` -- the only discharge that gate honors -- unreachable exactly when it was needed. And the deeper one they filed as secondary: every canon atom is an existential over the whole session, so a fingerprint that has matched can never stop matching, which is what forces a human. That half is still open. |
 
 ## Checking something yourself
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing
+
+Reports are welcome. Code is not merged from outside this repository.
+
+That is a provenance rule, not a judgement about the contribution. Every line here carries a
+claim about where it came from and what graded it — that is the same standard makoto applies to
+an agent's own work, and it is the whole point of the tool. Code arriving from outside cannot
+carry those claims, and I will not assert them on someone else's behalf. So the policy is stated
+up front rather than discovered after the work is done.
+
+## What is genuinely wanted
+
+**Issues.** A defect report with a reproducer, a measurement, or a reading of the code is the
+most useful thing anyone outside this repository can send, and it is acted on. The two most
+valuable reports this project has received were exactly that: a precise reading of one regex and
+its anchor, and a profile naming the hot path. Neither needed a diff to be worth acting on.
+
+A good report has:
+
+- **the artifact and line** — `plugin/makoto/state/ledger.py:511`, not "the ack regex"
+- **what you observed**, and the command that produced it
+- **what you expected instead**, and why the code says it should
+- **the boundary** — where you stopped, and what you did not check
+
+None of that is a template to fill in. A one-paragraph report naming a file and a line is more
+useful than a long one that names neither.
+
+## What happens to a report
+
+The fix is written here, from the report and from this project's own measurements. If your
+report names a defect, you are credited by name in the commit message and in the release note,
+and listed below. If a pull request is opened, it is closed with thanks and the same credit — the
+finding is what mattered, and closing the PR does not discard it.
+
+## Acknowledgements
+
+People outside this repository whose reports changed the code. Listed in the order received.
+
+<!-- Add a row when the fix lands, never when the report arrives: the credit names a change. -->
+
+| who | what they found | where it landed |
+| --- | --- | --- |
+
+## Checking something yourself
+
+The gates are the same ones CI runs, and none of them need this repository's history:
+
+```
+python -m pip install -e . pytest
+python3 tools/render_checks.py --check   # generated blocks match their sources
+python -m pytest -q                      # the suite
+python3 eval/replay.py                   # the authored sessions replay to their expectations
+```
+
+`eval/replay.py` is the one worth knowing about: it drives frozen sessions through the real
+dispatcher and asserts each expectation, so it will tell you whether a change altered any
+recorded outcome without your having to read the suite.
+
+## Security
+
+Do not open a public issue for a vulnerability. Use GitHub's private vulnerability reporting on
+this repository instead.

--- a/README.md
+++ b/README.md
@@ -259,6 +259,11 @@ python -m makoto uninstall                   # removes old settings.json entries
 /plugin install https://github.com/Clear-Sights/Makoto  # installs the plugin
 ```
 
+## Contributing
+
+Reports are welcome and are credited by name; pull requests from outside this repository are not
+merged. See [CONTRIBUTING.md](CONTRIBUTING.md) for why, and for what to send instead.
+
 ## Siblings
 
 Makoto owns the statement surface alongside the independently installed engines for act and

--- a/plugin/makoto/state/ledger.py
+++ b/plugin/makoto/state/ledger.py
@@ -519,10 +519,66 @@ _ACK_RX = re.compile(
 # The former dual-phrase acceptance existed to keep pre-rename records/habits working; the owner
 # retired that guarantee outright -- state predating the reset is archived (zip) or wiped, so
 # there is no history left whose meaning depends on the old phrase."""
+# ---------------------------------------------------------------------------------------------
+# The ack line must be UNQUOTED, which the gate's own retry hint has always promised ("say
+# exactly `makoto release.operator {name}: <reason>` in a real (non-tool, non-quoted) reply")
+# and which nothing implemented. The two halves are one fix and must land together:
+#
+#   * `_ACK_RX` was compiled with re.I only and applied with `.search()` to the WHOLE user turn,
+#     so its `^` bound at offset 0 of the turn. When a Stop gate blocks, the host prepends its
+#     feedback to the operator's next turn, which pushed the operator's line off offset 0 and
+#     made the only discharge this gate honors unreachable exactly when it was needed. Reported
+#     by AliceLJY (issue #45); reproduced here before the change.
+#
+#   * Anchoring per line without the quoting rule opens the mirror defect: a fenced block, a
+#     4-space indented block, or the phrase quoted in prose then discharges the gate. Measured:
+#     all three match under a bare re.M. (The hint as shipped does NOT, because its backtick sits
+#     immediately before `makoto` -- but that is an accident of wording, not a guard, which is
+#     why `test_the_gates_own_hint_never_discharges` pins it.)
+#
+# Scanning line by line rather than with re.M keeps `^\s*` per line and makes each exclusion a
+# readable rule instead of a lookaround.
+_FENCE_RX = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})")
+_INDENTED_CODE_RX = re.compile(r"^(?: {4}|\t)")
+
 _SYNTHETIC_MARKERS = (
     "<system-reminder", "<user-prompt-submit-hook", "<task-notification",
     "<local-command-caveat", "[request interrupted by user]",
 )
+
+
+def _unquoted_ack_matches(text: str):
+    r"""Yield `(fingerprint_id, reason)` for every UNQUOTED release.operator line in `text`.
+
+    Quoted means any of: inside a ``` / ~~~ fenced block, inside a 4-space or tab indented code
+    block, or inside an inline backtick span (a leading backtick already blocks `_ACK_RX`; the
+    parity guard catches a span opened on an earlier line). A blockquote line is excluded for
+    free -- `>` is not whitespace, so `^\s*makoto` cannot reach past it.
+
+    A turn may carry several candidate lines (prepended hook feedback plus what the operator
+    typed), so every line is examined rather than only the first match in the turn."""
+    fence = None
+    for line in text.split("\n"):
+        opener = _FENCE_RX.match(line)
+        if fence is not None:
+            if opener and opener.group(1)[0] == fence:
+                fence = None
+            continue
+        if opener:
+            fence = opener.group(1)[0]
+            continue
+        if _INDENTED_CODE_RX.match(line):
+            continue
+        m = _ACK_RX.match(line)
+        if not m:
+            continue
+        # group(2) can capture a bare leftover separator (an id-only ack backtracks to ":"), so
+        # strip stray punctuation before the truthiness check rather than trusting the regex.
+        acked_id = m.group(1).strip()
+        reason = m.group(2).strip().lstrip(":- ").strip()
+        if not acked_id or not reason:
+            continue
+        yield acked_id, reason
 
 
 def _entry_text(entry: dict) -> str:
@@ -688,17 +744,10 @@ def find_ack_block(fingerprint_id: str, *, transcript_path: Optional[str],
         ts = entry.get("timestamp", "")
         if not ts or ts <= since_ts:
             continue
-        m = _ACK_RX.search(text)
-        if not m:
-            continue
-        # group(2) can still capture a bare leftover separator (e.g. id-only "notestedit_destruct:"
-        # backtracks to reason=":") when nothing real follows -- strip stray leading punctuation
-        # before the truthiness check, rather than trust the regex to have consumed it.
-        acked_id = m.group(1).strip()
-        reason = m.group(2).strip().lstrip(":- ").strip()
-        if acked_id != fingerprint_id or not reason:
-            continue
-        return {"fingerprint_id": fingerprint_id, "reason": reason, "ts": ts}
+        for acked_id, reason in _unquoted_ack_matches(text):
+            if acked_id != fingerprint_id:
+                continue
+            return {"fingerprint_id": fingerprint_id, "reason": reason, "ts": ts}
     return None
 
 

--- a/tests/test_ackblock.py
+++ b/tests/test_ackblock.py
@@ -168,3 +168,73 @@ def test_record_ack_block_if_new_is_idempotent_per_session(tmp_path):
     assert record_ack_block_if_new(ack, session_id="s1", root=tmp_path) is False
     rows = [r for r in ledger.read(root=tmp_path) if r.get("kind") == "release.operator"]
     assert len(rows) == 1
+
+
+# ---- the anchor and the non-quoted rule (issue #45, AliceLJY) -----------------------------------
+# `_ACK_RX` was applied with `.search()` to the whole turn, so its `^` bound at offset 0 of the
+# turn. A blocked Stop prepends the host's feedback to the operator's next turn, which pushed the
+# operator's line off offset 0 -- the only discharge this gate honors became unreachable exactly
+# when it was needed. Anchoring per line fixes that and opens the mirror defect, so the quoting
+# rule the retry hint has always promised lands with it. Both directions are pinned here.
+def test_ack_after_prepended_hook_feedback_discharges(tmp_path):
+    """Issue #45: the reported defect. This turn read as "no ack" before the fix."""
+    _record_first_fired(tmp_path, "notestedit_destruct", "2026-07-07T01:00:00Z")
+    text = ("Stop hook feedback:\n"
+            "- [gate.canon_fingerprints] canon.notestedit_destruct: fired\n"
+            "\n"
+            "makoto release.operator notestedit_destruct: reviewed, the deletion was intended")
+    p = _write_transcript(tmp_path, [_user_turn(text, "2026-07-07T02:00:00Z")])
+    ack = find_ack_block("notestedit_destruct", transcript_path=str(p), root=tmp_path)
+    assert ack is not None
+    assert ack["reason"] == "reviewed, the deletion was intended"
+
+
+def test_the_gates_own_hint_never_discharges(tmp_path):
+    """The gate's retry hint contains the literal phrase and is prepended to the operator's turn.
+    Fed as the whole turn it must NOT discharge -- otherwise the gate releases itself.
+
+    The hint text is taken from the shipped check rather than retyped, so a rewording that would
+    make it self-discharging reddens HERE instead of shipping."""
+    from makoto.checks import canonFingerprints
+    _record_first_fired(tmp_path, "notestedit_destruct", "2026-07-07T01:00:00Z")
+    name = "notestedit_destruct"
+    hint = (f"say exactly `makoto release.operator {name}: <reason>` in a "
+            f"real (non-tool, non-quoted) reply")
+    src = (canonFingerprints.__file__ or "")
+    assert "say exactly `makoto release.operator {name}: <reason>` in a " in \
+        open(src, encoding="utf-8").read(), \
+        "the hint's wording moved -- re-derive this test's `hint` from the shipped text"
+    p = _write_transcript(tmp_path, [_user_turn("Stop hook feedback:\n" + hint,
+                                                "2026-07-07T02:00:00Z")])
+    assert find_ack_block(name, transcript_path=str(p), root=tmp_path) is None
+
+
+def test_ack_inside_a_quoted_block_never_discharges(tmp_path):
+    """A fenced block, an indented code block, and the phrase quoted in prose each match under a
+    bare per-line anchor. Measured before the fix; each must read as no ack."""
+    _record_first_fired(tmp_path, "notestedit_destruct", "2026-07-07T01:00:00Z")
+    for text in (
+        "here is what it said:\n```\nmakoto release.operator notestedit_destruct: <reason>\n```",
+        "here is what it said:\n~~~\nmakoto release.operator notestedit_destruct: <reason>\n~~~",
+        "the docs say:\n\n    makoto release.operator notestedit_destruct: <reason>\n",
+        "> makoto release.operator notestedit_destruct: quoted from someone else",
+        "`makoto release.operator notestedit_destruct: inline`",
+    ):
+        p = _write_transcript(tmp_path, [_user_turn(text, "2026-07-07T02:00:00Z")])
+        assert find_ack_block("notestedit_destruct", transcript_path=str(p),
+                              root=tmp_path) is None, text
+
+
+def test_a_real_ack_beside_the_quoted_hint_still_discharges(tmp_path):
+    """The live shape: the host prepends feedback QUOTING the phrase, and the operator types it
+    for real below. The quoted one must be skipped and the real one honored -- a quoting rule
+    that swallowed the whole turn would re-create issue #45."""
+    _record_first_fired(tmp_path, "notestedit_destruct", "2026-07-07T01:00:00Z")
+    text = ("Stop hook feedback:\n"
+            "say exactly `makoto release.operator notestedit_destruct: <reason>` in a real reply\n"
+            "\n"
+            "makoto release.operator notestedit_destruct: I checked the diff, it is intended")
+    p = _write_transcript(tmp_path, [_user_turn(text, "2026-07-07T02:00:00Z")])
+    ack = find_ack_block("notestedit_destruct", transcript_path=str(p), root=tmp_path)
+    assert ack is not None
+    assert ack["reason"] == "I checked the diff, it is intended"


### PR DESCRIPTION
Two outside reports arrived and neither had a policy to read. This states one, credits every outside report this repository has ever received, and fixes the one that was reproducible today.

## 1. The ack anchor and the non-quoted rule — issue #45, reported by @AliceLJY

`_ACK_RX` was compiled with `re.I` alone and applied with `.search()` to the whole user turn, so its `^` bound at offset 0 of the *turn*. When a Stop gate blocks, the host prepends its feedback to the operator's next turn, which pushes the operator's line off offset 0 — so `release.operator`, documented as the only discharge that gate can honor, was unreachable exactly when it was needed. Reproduced before changing anything; the report carried no code.

Anchoring per line alone opens the mirror defect, so both halves land together. Measured against a bare `re.M`: a ```` ``` ```` fenced block, a 4-space indented block, and the phrase quoted in prose **each discharge the gate**. The hint as shipped does not, because its backtick sits immediately before `makoto` — an accident of wording, not a guard, which is why the wording is now pinned by a test. The quoting rule is not new policy: the retry hint has always said *"in a real (non-tool, non-quoted) reply"* and nothing implemented the second half.

`_unquoted_ack_matches` scans line by line rather than using `re.M`, so `^\s*` is per line and each exclusion reads as a rule. A blockquote is excluded for free — `>` is not whitespace. Every candidate line in a turn is examined, because the live shape is hook feedback quoting the phrase with the operator's real line below it.

Each test observed red against the code that makes it red:

| test | red against |
|---|---|
| `test_ack_after_prepended_hook_feedback_discharges` | pre-fix |
| `test_a_real_ack_beside_the_quoted_hint_still_discharges` | pre-fix |
| `test_ack_inside_a_quoted_block_never_discharges` | the naive fix (`re.M` only) |
| `test_the_gates_own_hint_never_discharges` | passes in every variant by design — it pins the hint's wording against the shipped source |

The deeper half of that report — canon atoms are session-wide existentials, so a fingerprint that has matched can never stop matching — is **not** fixed here. It is #57.

## 2. The contribution policy

Three files, each doing a different job:

- **`CONTRIBUTING.md`** — the canonical statement. GitHub links to it from both the "New issue" and "Open a pull request" pages. It gives the reason (provenance: every line here carries a claim about where it came from and what graded it, and code arriving from outside cannot carry those claims), says what *is* wanted, and carries the Acknowledgements table.
- **`.github/pull_request_template.md`** — the only place the policy can actually save anyone work, because it is shown *before* the diff is written. This repository had issue templates and no PR template.
- **`README.md`** — two lines pointing at the first.

A closed pull request is nearly invisible: it does not appear in the issue list, which is where findings live. So a finding arriving as a PR is captured as an issue in the reporter's name *before* the PR is closed. The finding survives; only the diff is declined.

## 3. Acknowledgements, retroactive

The table would have read as though credit started when the policy did. It does not. Nine reports from two people have reached this repository and **every closed one landed a fix** — checked against the issue list, all eight closed with `state_reason=completed`:

| | |
|---|---|
| @AliceLJY | #2 #10 #14 #15 #17 #28 #45 |
| @tkulczy2 | #19 #20 |

Each row names what the person found, in the terms of the defect, so the table is a record rather than a list of handles. The report column links the issue rather than a commit: for #14 and #15 no commit message names the issue, so a sha there would be a guess.

## A note on how this landed

`ledger.py` was applied to this tree as a **patch, not a file copy**. This tree is ahead of the dev twin by `latest_testrun_exit` (30 lines), which `green_claim_gate` reads; a whole-file copy would have deleted it. `render_checks --check` caught exactly that — the dispatch-contract block flipped `Stop-gate finding → decision='block'` to `no blocking decision`. The generated block earned its keep.

A second sibling gap was found and fixed in the dev twin in the same pass: it still carried `tests/bash/smoke_test.sh`, which `run_all.sh` never globbed (it matches `test_*.sh`), while this tree carries the corrected `test_smoke.sh`.

## Gates

- `python3 tools/render_checks.py --check` — `check counts match makoto.registry`
- `python -m pytest -q` — **1968 passed, 1 xfailed, 43 subtests passed**
- `python3 eval/replay.py` — `REPLAY sessions=5 passed=5 failed=0`
- `bash tests/bash/run_all.sh` — `All bash tests passed.`

Landed on the dev twin first (`makoto-dev` `9281369`, green on the same gates).
