### PR TITLE
Release 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to makoto. Versions follow the live check inventory
 
 ## [Unreleased]
 
+## [2.6.0] — 2026-09-08
+
+### Fixed
+- **`release.operator` was unreachable exactly when it was needed.** `_ACK_RX` was compiled with
+  `re.I` alone and applied with `.search()` to the whole user turn, so its `^` bound at offset 0
+  of the turn. When a Stop gate blocks, the host prepends its feedback to the operator's next
+  turn, which pushed the operator's line off offset 0 — so the only discharge that gate documents
+  could not be typed. Reported by @AliceLJY (#45), with no code; reproduced here before the change.
+
+  The anchor is now per line, and the "non-quoted" rule the retry hint has always promised is
+  implemented with it: a fenced block, a 4-space indented block, an inline backtick span and a
+  blockquote no longer discharge a gate. Both halves land together because anchoring alone opens
+  the mirror defect — measured, all three quoted shapes discharge under a bare `re.M`.
+
+### Added
+- `CONTRIBUTING.md`, a pull request template, and an Acknowledgements table naming every outside
+  report that has changed this code — nine of them, from @AliceLJY and @tkulczy2.
+
+### Known
+- Canon fingerprints are monotone: every atom is an existential over the whole session, so a
+  fingerprint that has matched can never stop matching, and the typed phrase is the only exit.
+  The deeper half of #45, tracked as #57 and not fixed here.
+- Chain reads are O(chain) per hook call, measured at 2.8 s PreToolUse and 12.4–19.2 s
+  PostToolUse on a 214k-row chain by @tkulczy2. Tracked as #58.
+
 ## [2.5.0] — 2026-09-03
 
 ### Fixed

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "makoto",
   "description": "Holds Claude Code to its word — every claim checked against the agent's own logged record; faked checks blocked, not warned (four narrow advisory self-checks excepted). Two-tier catalog (15 pre-checks, 19 Stop gates), each shipped at measured zero false positives.",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "author": {"name": "Clear-Sights"},
   "homepage": "https://github.com/Clear-Sights/Makoto",
   "repository": "https://github.com/Clear-Sights/Makoto",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "makoto"
-version = "2.5.0"
+version = "2.6.0"
 description = "Integrity hook for Claude Code — holds the agent's claims against its own logged deeds and blocks faked checks; every check ships at measured zero false positives"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump so `release.yml` can cut the tag. It reads the version from `plugin/.claude-plugin/plugin.json`, fails if `pyproject.toml` disagrees, and extracts its notes from the matching `CHANGELOG.md` section — so all three move together or the release refuses.

Contents of 2.6.0, already merged in #56:

- the `release.operator` anchor fix and the non-quoted rule (#45, reported by @AliceLJY)
- `CONTRIBUTING.md`, a PR template, and the retroactive Acknowledgements table

The CHANGELOG section carries a `Known` block naming the two defects this release does not fix — the monotone fingerprints (#57) and the O(chain) hook reads (#58). A release note listing only what was fixed reads as a claim that nothing else is outstanding.

Gates: `render_checks --check` clean, pytest 1968 passed / 1 xfailed, replay 5/5, bash suite passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YSeHeTrYof2BRmgrT3SFm2)_