### PR TITLE
Release 2.7.0: the atom window, and a gate for a cited operator who never spoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to makoto. Versions follow the live check inventory
 
 ## [Unreleased]
 
+## [2.7.0] — 2026-09-08
+
+### Fixed
+- **Canon fingerprints were monotone: once matched, they could never stop matching.** Every canon
+  atom is `_existing(calls, pred)`, an existential over the whole session call stream, so once a
+  green test run and a timeout had each happened both were permanently true and the fingerprint
+  fired at every subsequent Stop whatever the agent did next. The typed `release.operator` phrase
+  was therefore its only exit — forcing a human onto a gate whose premise is that a claim is held
+  against the record and not against an utterance. Atoms are now evaluated over the calls **since
+  the operator last spoke**: the fingerprint fires once, the operator is informed, their next turn
+  resets the window whatever it says, and it fires again only if the agent repeats the pattern
+  after being told. The agent cannot manufacture a reset because it cannot produce a genuine user
+  turn. Reported by @AliceLJY as the secondary half of #45; it was the primary defect (#57).
+
+### Added
+- **`gate.claimed_consent_absent`** — blocks a claim citing the operator's approval, instruction or
+  word in a session whose transcript carries no genuine operator turn at all. An agent citing
+  approval it was never given has licensed itself. Fires only on an EMPTY oracle channel, never on
+  a paraphrase mismatch: absence is countable, similarity is judgement.
+
+### Known
+- Chain reads are O(chain) per hook call — 2.8 s PreToolUse, 12.4–19.2 s PostToolUse on a
+  214k-row chain, measured by @tkulczy2. #58.
+- An operator who spoke once, followed by an agent inventing a second different instruction, is
+  not caught by `gate.claimed_consent_absent`; that needs the claim compared to the turn's content.
+
 ## [2.6.0] — 2026-09-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ makoto fires on mechanical hook events — every `PreToolUse`, `PostToolUse`, an
 
 - **15 pre-checks** (every one denies the tool call; `blocking_eligible` is about the Stop edge and is False for all of them)
 - Pre-check ids grouped by dotted prefix — `content`: **12**, `event`: **2**, `gate`: **1**
-- **21 Stop checks** (all checks registered at the Stop edge)
-- **19 end-of-turn gates** (`may_block=True`)
-- **15 blocking end-of-turn gates** (`registry.blocking_eligible`)
+- **22 Stop checks** (all checks registered at the Stop edge)
+- **20 end-of-turn gates** (`may_block=True`)
+- **16 blocking end-of-turn gates** (`registry.blocking_eligible`)
 - **4 advisory end-of-turn gates** (advisory-allowlisted)
 
 <!-- END GENERATED: check-counts -->
@@ -162,6 +162,7 @@ The **certification** column uses the following labels, each naming its own deno
 | `gate.claimed_running` | "it's running/up" contradicted by this session's own Bash record | blocking | established |
 | `gate.run_promised` | last turn promised a run ("I'll run the tests") and no Bash call followed | blocking | established |
 | `gate.claimed_shipped` | "merged/pushed/live" with no successful remote-mutating call on record | blocking | established |
+| `gate.claimed_consent_absent` | cites the operator's approval, instruction or word in a session whose transcript carries no genuine operator turn at all | blocking | new |
 | `gate.liveness` | a statement with no live effect inside a closed function | blocking | established |
 | `gate.hollow_test` | a test gutted so it can never fail (no assert, tautology, swallowed failure, uncollectable) | blocking | established |
 | `gate.canon` | last call ended in an unresolved direct error, or a byte-identical stuck retry loop | blocking | replayed |

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "makoto",
-  "description": "Holds Claude Code to its word — every claim checked against the agent's own logged record; faked checks blocked, not warned (four narrow advisory self-checks excepted). Two-tier catalog (15 pre-checks, 19 Stop gates), each shipped at measured zero false positives.",
-  "version": "2.6.0",
+  "description": "Holds Claude Code to its word — every claim checked against the agent's own logged record; faked checks blocked, not warned (four narrow advisory self-checks excepted). Two-tier catalog (15 pre-checks, 20 Stop gates), each shipped at measured zero false positives.",
+  "version": "2.7.0",
   "author": {"name": "Clear-Sights"},
   "homepage": "https://github.com/Clear-Sights/Makoto",
   "repository": "https://github.com/Clear-Sights/Makoto",

--- a/plugin/makoto/checks/canonFingerprints.py
+++ b/plugin/makoto/checks/canonFingerprints.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from typing import List
 
-from makoto.substrate._canonAtoms import calls_from_history, fired_canon_fingerprints
+from makoto.substrate._canonAtoms import calls_from_history, calls_since, fired_canon_fingerprints
 from makoto.vocab import Finding
 
 
@@ -37,7 +37,20 @@ def canon_fingerprint_block_gate(text, history, *, transcript_path=None, session
     audit/receipt trail via `record_ack_block_if_new`, but the discharge decision itself is
     always freshly re-derived, never read back from that row. Silent (empty list) when no
     fingerprint fires, or every fired one is acked."""
-    calls = calls_from_history(history)
+    # THE ATOM WINDOW. Atoms are existentials, so over a whole session they are monotone: once a
+    # fingerprint has matched it can never stop matching, whatever the agent does next, and the
+    # typed phrase becomes its only exit. Evaluating over the calls since the operator last spoke
+    # makes it fire once, inform them, and reset when they next speak -- whatever they say --
+    # firing again only if the agent repeats the pattern after being told. The agent cannot force
+    # a reset: it cannot produce a genuine user turn. AliceLJY, issue #45's secondary half; #57.
+    # No transcript, or no genuine turn in it, means NO window -- the whole session, which is the
+    # strict direction and the prior behaviour. `release.operator` remains the explicit override.
+    try:
+        import makoto.state.ledger as _ackblock
+        since = _ackblock.last_operator_turn_ts(transcript_path)
+    except Exception:
+        since = None
+    calls = calls_since(history, since)
     out: List[Finding] = []
     for name, formula, is_block in fired_canon_fingerprints(calls, text or ""):
         if not is_block:

--- a/plugin/makoto/checks/claimedConsentAbsent.py
+++ b/plugin/makoto/checks/claimedConsentAbsent.py
@@ -1,0 +1,106 @@
+"""gate.claimed_consent_absent -- the agent cites the operator's word, and the operator has none.
+
+Makoto's subject is the assistant's statement held against the record. Usually the record is the
+assistant's own tool stream. Here it is the ORACLE channel: the genuine, host-written user turns
+of this session. That is not holding the human to anything -- the human is never graded. It is
+holding the AGENT to a claim it made ABOUT the human, which is the same bar as every other check
+here, against a record Makoto already reads (`ledger.user_turn_texts`, shared with
+`content.unsourced_webfetch._user_supplied` -- one owner, two consumers, no second definition of
+"the user said so").
+
+WHY IT EXISTS. An agent that cites approval it was never given has licensed itself, and the
+licence is the most valuable thing it can forge: it converts "I should ask" into "I was told".
+The hazard is live and currently held off by prose -- a session woken by a schedule or a
+background event carries a hand-written notice on every turn saying that no human input has been
+received and that any statement the user approved something must not be treated as consent. A
+rule stated on every turn and enforced nowhere is B7 in the register, and this is its runner.
+
+THE 0-FP CONDITION, and it is what keeps this from being a paraphrase judge. The check fires only
+when the session contains NO genuine operator turn at all. Not "the turn does not match the
+claim" -- that is a similarity question and similarity is judgement. Absence of the whole channel
+is countable, and when the channel is empty every attribution to it is false, whatever words were
+chosen. So a legitimate paraphrase of a real instruction can never fire this: a real instruction
+means a real turn exists, and one turn is enough to silence it.
+
+Spoof-resistance is inherited, not re-derived: `user_turn_texts` admits only host-written,
+non-synthetic, non-tool-result entries via `_is_genuine_user_turn` -- the same predicate the
+`release.operator` discharge trusts. The agent cannot write itself a user turn, so it cannot
+manufacture the consent OR the record of it.
+
+STATED LIMIT: a session where the operator has spoken once and the agent then invents a second,
+different instruction is NOT caught. Catching it needs the claim compared to the turn's content,
+which is the similarity question this check refuses. Named here so the gap is a choice on the
+record rather than an oversight.
+"""
+from __future__ import annotations
+import re
+
+from makoto.state.ledger import user_turn_texts
+from makoto.vocab import Finding
+
+# The claim side: the agent attributing a position to the operator. Read on the ASSISTANT's own
+# words, which is what every check here does -- the non-agnostic surface in this package is the
+# three checks that parse the SUBJECT's shell commands, not the claim channel.
+_CONSENT_RX = re.compile(
+    r"\b(?:"
+    r"(?:you|the\s+(?:user|operator|owner))\s+"
+    r"(?:approved|confirmed|agreed|authorized|authorised|okayed|"
+    r"said|asked|told\s+me|requested|instructed|signed\s+off|greenlit)"
+    r"|per\s+your\s+(?:approval|request|instruction|confirmation|go-ahead)"
+    r"|as\s+you\s+(?:asked|requested|instructed|said|confirmed|approved)"
+    r"|with\s+your\s+(?:approval|consent|go-ahead|sign-off)"
+    r"|on\s+your\s+(?:instruction|say-so|go-ahead)"
+    r")\b", re.IGNORECASE)
+
+RETRY_HINT = ("This session has no operator turn, so there is no approval or instruction to "
+              "cite. Say what you are doing and why on your own account, or stop and ask.")
+DESCRIPTION = ("Blocks a claim that the operator approved, asked for or confirmed something in a "
+               "session where the operator has not spoken at all.")
+
+
+def claimed_consent_absent_gate(text, *, transcript_path=None):
+    """One BLOCKING Finding when the claim cites the operator and the oracle channel is empty.
+
+    Never raises. An unreadable or absent transcript reads as NO EVIDENCE and the check is
+    silent: `user_turn_texts` returns [] for a transcript it cannot parse as well as for one with
+    no user turns, and those two must not be treated alike when the consequence is a block. Erring
+    silent here is the safe direction -- the opposite would deny a turn on a decode failure, which
+    is a gate resting on a false fact."""
+    claim = _CONSENT_RX.search(text or "")
+    if not claim:
+        return None
+    if not transcript_path:
+        return None
+    try:
+        turns = user_turn_texts(transcript_path)
+    except Exception:
+        return None
+    if turns:
+        # The operator has spoken. Whether THIS claim matches THAT turn is the similarity
+        # question this check refuses to answer; see the stated limit in the module docstring.
+        return None
+    try:
+        import os
+        if not os.path.exists(transcript_path):
+            return None
+    except Exception:
+        return None
+    return Finding(
+        pattern_id="gate.claimed_consent_absent",
+        file="", line=0, level="error",
+        message=(f"Claim cites the operator ({claim.group(0)!r}), but this session's transcript "
+                 f"carries no genuine operator turn — the consent is attributed to a record that "
+                 f"is empty."),
+        retry_hint=RETRY_HINT,
+    )
+
+
+from makoto.registry import Check as _Check
+CHECK = _Check(id="gate.claimed_consent_absent", applies_at="Stop", posture="BLOCK",
+               may_block=True, tests="CLAIM_VS_HISTORY",
+               keywords=("you approved", "you asked", "you said", "you confirmed",
+                         "as you asked", "per your", "with your approval"),
+               retry_hint=RETRY_HINT, description=DESCRIPTION,
+               eats=frozenset({"text", "transcript_path"}),
+               run=lambda c: claimed_consent_absent_gate(c.text,
+                                                         transcript_path=c.transcript_path))

--- a/plugin/makoto/state/ledger.py
+++ b/plugin/makoto/state/ledger.py
@@ -610,8 +610,8 @@ def _is_genuine_user_turn(entry: dict) -> Optional[str]:
     return text
 
 
-def user_turn_texts(transcript_path: Optional[str], *, limit: int = 4000) -> list:
-    """Every genuine, host-written, non-synthetic user turn in the transcript, oldest first.
+def _genuine_user_turns(transcript_path: Optional[str], *, limit: int = 4000) -> list:
+    """Every genuine, host-written, non-synthetic user turn as (text, timestamp), oldest first.
 
     The ORACLE channel, exposed for readers other than the ack scanner. `find_ack_block` has always
     needed "what did the human actually type, as opposed to what could the agent have produced" --
@@ -677,8 +677,44 @@ def user_turn_texts(transcript_path: Optional[str], *, limit: int = 4000) -> lis
             continue
         text = _is_genuine_user_turn(entry)
         if text:
-            texts.append(text)
+            texts.append((text, entry.get("timestamp")))
     return texts
+
+
+def user_turn_texts(transcript_path: Optional[str], *, limit: int = 4000) -> list:
+    """Every genuine user turn's TEXT, oldest first. See `_genuine_user_turns` for the reader."""
+    return [text for text, _ in _genuine_user_turns(transcript_path, limit=limit)]
+
+
+def last_operator_turn_ts(transcript_path: Optional[str], *, limit: int = 4000) -> Optional[str]:
+    """The timestamp of the most recent genuine operator turn, or None if there is none.
+
+    This is the boundary of the ATOM WINDOW. A canon fingerprint is a conjunction of atoms, and
+    every atom is an existential over the calls it is given (`_canonAtoms._existing`). Given the
+    whole session, those existentials are monotone: once a green test run and a timeout have each
+    happened, both are permanently true and the fingerprint can never stop matching, whatever the
+    agent does next. The typed `release.operator` phrase is then the ONLY exit, which is what
+    forces a human -- on a gate whose whole premise is that a claim is held against the record and
+    not against an utterance. Reported by AliceLJY as the secondary half of issue #45; it is the
+    primary defect.
+
+    Windowing the atoms at the last operator turn makes the fingerprint fire once, inform the
+    operator, and reset when they next speak -- whatever they say. It fires again only if the
+    agent repeats the pattern after being told. No judgement is involved and nothing is asked of
+    the human.
+
+    The agent cannot manufacture a reset, because it cannot produce a genuine user turn:
+    `_is_genuine_user_turn` requires role=user, no toolUseResult, and no synthetic marker, and it
+    is the same predicate the ack already trusts. One boundary, one owner.
+
+    None when there is no transcript, no genuine turn, or no timestamp on it -- and None means
+    NO WINDOW, i.e. the whole session, which is the strict direction and the behaviour before
+    this existed. A window we cannot establish must never widen what the gate lets through.
+    """
+    for _, ts in reversed(_genuine_user_turns(transcript_path, limit=limit)):
+        if ts:
+            return str(ts)
+    return None
 
 
 def _first_fired_ts(fingerprint_id: str, *, gate_pattern_id: str = "gate.canon_fingerprints",

--- a/plugin/makoto/substrate/_canonAtoms.py
+++ b/plugin/makoto/substrate/_canonAtoms.py
@@ -92,6 +92,37 @@ def calls_from_history(history) -> List[Call]:
     return [c for c in (_decode_row(r) for r in (history or ())) if c is not None]
 
 
+def _row_ts(row):
+    """The event ts of a history row. `_select_recent` yields (id, ts, event_type, cwd, payload);
+    a dict-shaped row is accepted too, as every other decoder here does."""
+    if isinstance(row, dict):
+        return row.get("ts")
+    try:
+        return row[1]
+    except (TypeError, IndexError, KeyError):
+        return None
+
+
+def calls_since(history, since_ts) -> List[Call]:
+    """The calls at or after `since_ts` -- the ATOM WINDOW.
+
+    Every atom below is `_existing(calls, pred)`, an existential. Over a whole session those are
+    monotone: once a predicate has been satisfied it stays satisfied, so a fingerprint that has
+    matched can never stop matching however the agent behaves afterwards, and the typed phrase
+    becomes its only exit. Evaluating over the calls since the operator last spoke is what makes
+    the fingerprint answerable by conduct instead of by utterance.
+
+    `since_ts` of None means NO WINDOW: the whole session, which is both the prior behaviour and
+    the strict direction. A window that cannot be established must never widen what passes.
+
+    A row whose ts cannot be read is KEPT, for the same reason: dropping it would narrow the
+    window on a decode failure, and a decode failure must not quiet a gate."""
+    if not since_ts:
+        return calls_from_history(history)
+    rows = [r for r in (history or ()) if (_row_ts(r) or "") >= since_ts or _row_ts(r) is None]
+    return calls_from_history(rows)
+
+
 # ---- call accessors (mirror primitives.py's own field reads) --------------------------------------
 def _cmd(c: Call) -> str:
     return str(c["input"].get("command", "")) if c["name"] == "Bash" else ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "makoto"
-version = "2.6.0"
+version = "2.7.0"
 description = "Integrity hook for Claude Code — holds the agent's claims against its own logged deeds and blocks faked checks; every check ships at measured zero false positives"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_canon_atom_window.py
+++ b/tests/test_canon_atom_window.py
@@ -1,0 +1,112 @@
+"""The ATOM WINDOW: canon atoms are evaluated over the calls since the operator last spoke.
+
+Every atom is `_existing(calls, pred)`, an existential. Given the whole session those are
+MONOTONE -- once a green run and a timeout have each happened, both are permanently true, so
+`nosrc_green_timeout` can never stop matching however the agent behaves afterwards. The typed
+`release.operator` phrase is then its only exit, which is what forces a human onto a gate whose
+whole premise is that a claim is held against the record and not against an utterance.
+
+Reported by AliceLJY as the "secondary, lower priority" half of issue #45; it is the primary
+defect of the two. Tracked as #57.
+
+Four directions, each a way the fix could be wrong rather than four ways it could be right:
+  fires again on repetition          -- the gate is windowed, not disabled
+  silent when the agent has stopped  -- monotonicity is actually gone
+  a tool result does not reset       -- the boundary is a GENUINE operator turn
+  no transcript means no window      -- an unestablished window never widens what passes
+"""
+from __future__ import annotations
+
+import json
+
+from makoto.checks.canonFingerprints import canon_fingerprint_block_gate
+from makoto.substrate._canonAtoms import calls_since
+
+T0, T1, T2 = "2026-09-08T10:00:00Z", "2026-09-08T11:00:00Z", "2026-09-08T12:00:00Z"
+
+
+def _ev(tool_name, tool_input, tool_response):
+    return {"hook_event_name": "PostToolUse", "tool_name": tool_name,
+            "tool_input": tool_input, "tool_response": tool_response}
+
+
+def _row(ts, tool_name, tool_input, **result):
+    """A history row in `_select_recent` shape: (id, ts, event_type, cwd, payload)."""
+    return (1, ts, "PostToolUse", "/w", json.dumps(_ev(tool_name, tool_input, result)))
+
+
+def _green(ts):
+    return _row(ts, "Bash", {"command": "pytest -q"}, stdout="3 passed in 0.1s", stderr="")
+
+
+def _timeout(ts):
+    return _row(ts, "Bash", {"command": "slow-thing"}, interrupted=True)
+
+
+def _transcript(tmp_path, entries):
+    p = tmp_path / "t.jsonl"
+    p.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+    return str(p)
+
+
+def _operator(text, ts):
+    return {"type": "user", "message": {"role": "user", "content": text}, "timestamp": ts}
+
+
+def _fires(history, transcript_path):
+    return {f.message.split(":")[0].replace("canon.", "")
+            for f in canon_fingerprint_block_gate("", history, transcript_path=transcript_path)}
+
+
+# ---- the window itself ------------------------------------------------------------------------
+def test_calls_before_the_operator_turn_are_outside_the_window():
+    history = [_green(T0), _timeout(T0), _green(T2)]
+    assert len(calls_since(history, None)) == 3, "no window means the whole session"
+    assert len(calls_since(history, T1)) == 1, "only the call after the boundary survives"
+
+
+def test_a_row_whose_ts_cannot_be_read_is_kept():
+    """Narrowing the window on a decode failure would let a decode failure quiet a gate."""
+    assert len(calls_since([{"payload": json.dumps(
+        _ev("Bash", {"command": "pytest -q"}, {"stdout": "3 passed"}))}], T1)) == 1
+
+
+# ---- the four directions ----------------------------------------------------------------------
+def test_monotonicity_is_gone_once_the_operator_has_spoken(tmp_path):
+    """The same call stream that fires must stop firing when a genuine turn separates it."""
+    history = [_green(T0), _timeout(T0)]
+    before = _transcript(tmp_path, [_operator("go on", T0)])
+    assert "nosrc_green_timeout" in _fires(history, before), "must fire with no window"
+    after = _transcript(tmp_path, [_operator("I looked, it is fine", T1)])
+    assert _fires(history, after) == set(), "the operator spoke after it; nothing has repeated"
+
+
+def test_it_fires_again_when_the_agent_repeats_the_pattern(tmp_path):
+    """Windowed is not disabled: the same conduct after being told still blocks."""
+    history = [_green(T0), _timeout(T0), _green(T2), _timeout(T2)]
+    t = _transcript(tmp_path, [_operator("noted, carry on", T1)])
+    assert "nosrc_green_timeout" in _fires(history, t)
+
+
+def test_a_tool_result_turn_does_not_reset_the_window(tmp_path):
+    """The agent must not be able to manufacture a reset. `_is_genuine_user_turn` is the boundary
+    and it refuses a turn carrying toolUseResult, so this transcript has NO genuine turn -- which
+    means no window, which means the fingerprint still fires."""
+    history = [_green(T0), _timeout(T0)]
+    fake = {"type": "user", "message": {"role": "user", "content": "done"},
+            "toolUseResult": {"stdout": "ok"}, "timestamp": T1}
+    assert "nosrc_green_timeout" in _fires(history, _transcript(tmp_path, [fake]))
+
+
+def test_a_synthetic_turn_does_not_reset_the_window(tmp_path):
+    history = [_green(T0), _timeout(T0)]
+    synth = _operator("<system-reminder>keep going</system-reminder>", T1)
+    assert "nosrc_green_timeout" in _fires(history, _transcript(tmp_path, [synth]))
+
+
+def test_no_transcript_means_no_window(tmp_path):
+    """An unestablished window is the whole session -- the strict direction, and the behaviour
+    before the window existed. It must never widen what the gate lets through."""
+    history = [_green(T0), _timeout(T0)]
+    assert "nosrc_green_timeout" in _fires(history, None)
+    assert "nosrc_green_timeout" in _fires(history, str(tmp_path / "absent.jsonl"))

--- a/tests/test_check_law_tests.py
+++ b/tests/test_check_law_tests.py
@@ -34,6 +34,14 @@ ONE_OFF = {
 HISTORY_PRIMITIVES = frozenset({
     "iter_tool_events", "raw_payload_str", "decode_history_row", "decode_history_event",
     "turn_tool_calls", "calls_from_history",
+    # `calls_since` is `calls_from_history` with the atom window applied (the calls since the
+    # operator last spoke). It reads the same history rows through the same decoder, so it is the
+    # same primitive at a narrower quantifier -- not a second way of consulting history.
+    "calls_since",
+    # `user_turn_texts` is the ORACLE half of the same session record: the host-written user
+    # turns, read as the record a claim ABOUT the operator is held against. Same session, same
+    # spoof-resistance (`_is_genuine_user_turn`), different channel.
+    "user_turn_texts",
 })
 LEDGER_PRIMITIVES = frozenset({"_discharged", "_discharge_kwargs", "_drop_discharged"})
 TESTRUN_PRIMITIVES = frozenset({

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1414,6 +1414,49 @@ def test_dispatch_claimed_running_gate_blocks_after_recorded_failed_launch(tmp_p
         "the claimed_running fire must be audited"
 
 
+def test_dispatch_claimed_consent_absent_gate_blocks_when_the_operator_never_spoke(tmp_path):
+    """Behavioral blocking pin for gate.claimed_consent_absent through the real dispatcher.
+
+    The transcript holds one user-ROLE entry carrying toolUseResult, which `_is_genuine_user_turn`
+    refuses -- so the oracle channel is empty and the agent's citation of operator approval is
+    attributed to a record that has nothing in it. The negative half is the next test: one genuine
+    turn is enough to silence this, because whether the claim MATCHES that turn is a similarity
+    question the check deliberately does not answer."""
+    state_dir = _setup_state(tmp_path)
+    tp = tmp_path / "transcript.jsonl"
+    tp.write_text(json.dumps({"type": "user", "message": {"role": "user", "content": "ok"},
+                              "toolUseResult": {"stdout": ""},
+                              "timestamp": "2026-09-08T10:00:00Z"}) + "\n", encoding="utf-8")
+    stop = {"hook_event_name": "Stop", "session_id": "consent_block", "cwd": str(tmp_path),
+            "transcript_path": str(tp),
+            "last_assistant_message": "You approved this, so I went ahead and merged it."}
+    rc, out = _run_dispatch(state_dir, stop)
+    assert rc == 0
+    assert out, "claimed_consent_absent must block a citation of operator approval with no operator turn"
+    decision = json.loads(out)
+    assert decision["decision"] == "block"
+    rows = [json.loads(line) for line in (state_dir / "audit.jsonl").read_text().splitlines()
+            if line.strip()]
+    assert any("gate.claimed_consent_absent" in row.get("pattern_fires", []) for row in rows), \
+        "the claimed_consent_absent fire must be audited"
+
+
+def test_dispatch_claimed_consent_absent_is_silent_when_the_operator_has_spoken(tmp_path):
+    """One genuine operator turn silences it. Without this the check would be a paraphrase judge,
+    and paraphrase is judgement; absence of the whole channel is what it counts."""
+    state_dir = _setup_state(tmp_path)
+    tp = tmp_path / "transcript.jsonl"
+    tp.write_text(json.dumps({"type": "user", "message": {"role": "user", "content": "go ahead"},
+                              "timestamp": "2026-09-08T10:00:00Z"}) + "\n", encoding="utf-8")
+    stop = {"hook_event_name": "Stop", "session_id": "consent_ok", "cwd": str(tmp_path),
+            "transcript_path": str(tp),
+            "last_assistant_message": "You approved this, so I went ahead and merged it."}
+    rc, out = _run_dispatch(state_dir, stop)
+    assert rc == 0
+    if out:
+        assert "gate.claimed_consent_absent" not in out
+
+
 def test_dispatch_claimed_shipped_gate_blocks_on_unbacked_remote_claim(tmp_path):
     """Behavioral blocking pin for gate.claimed_shipped through the real dispatcher: an immediate
     completed merge claim with no prior successful remote mutation must produce a block decision
@@ -1873,7 +1916,8 @@ def test_no_shadow_gate_every_gate_blocks():
                           "gate.plan_item_drift",         # advisory-tier (2026-07-09): same shape
                           "gate.claimed_running",  # agnostic claim-vs-recorded-Bash-evidence gate (2026-07-23)
                           "gate.run_promised",  # claimed_running's forward-looking sibling (2026-07-23)
-                          "gate.claimed_shipped"}  # completed remote-mutation claim-vs-record gate
+                          "gate.claimed_shipped",  # completed remote-mutation claim-vs-record gate
+                          "gate.claimed_consent_absent"}  # claim-vs-ORACLE-record gate (2026-09-08)
     # `discovered` is built from may_block, and `_blocking_gate_ids()` IS
     # `{c.id for c in load_checks(edge="Stop") if c.may_block}` -- so comparing them is a
     # restatement that holds however the dispatcher behaves. It stays as documentation of the

--- a/tests/test_gate_shape.py
+++ b/tests/test_gate_shape.py
@@ -50,6 +50,8 @@ GATES_DIR = Path(__file__).resolve().parent.parent / "plugin" / "makoto" / "chec
 # The 11 named Stop-gate modules — each is its adapter AND its own engine merged into one file
 # (SPEC-5 Task 4 folded what used to be a separate `stopcheck_X.py` + `X.py` engine pair together).
 GATE_MODULE_STEMS = {
+    "claimedConsentAbsent",  # the agent cites the operator's word in a session with no operator
+                             # turn at all -- the ORACLE channel as record, never as subject
     "claimedProduceAbsent", "undischargedCommitment", "falseGreenClaim", "silentlyDroppedCommitment",
     "fabricatedToolAction", "namedTestTeeth", "stalePytestCache",
     "deadPureStatement",    # liveness gate: adapter + its own AST analyzer engine, one file
@@ -98,7 +100,8 @@ EXPECTED_LIVE_GATE_IDS = {"gate.completion", "gate.advance", "gate.green_claim",
                           "gate.canon_fingerprints", "gate.canon_fingerprints_advisory",
                           "gate.contract_order",
                           "gate.relative_path_citation", "gate.plan_item_drift",
-                          "gate.claimed_running", "gate.run_promised", "gate.claimed_shipped"}
+                          "gate.claimed_running", "gate.run_promised", "gate.claimed_shipped",
+                          "gate.claimed_consent_absent"}
 EXPECTED_GATE_FIELDS = {"id", "applies_at", "posture", "run", "may_block",
                         "keywords", "retry_hint", "description", "predicate_module",
                         "layer", "eats", "tests"}   # "object" | "meta" -- see Check's own docstring; only
@@ -278,10 +281,10 @@ def test_package_file_shape_matches_the_design():
     present = {p.name for p in GATES_DIR.glob("*.py")}
     assert EXPECTED_GATE_FILES <= present, f"missing gate files: {EXPECTED_GATE_FILES - present}"
     assert not (GATES_DIR / "_dark").exists()                    # dark tier CUT (io-purge B3) — Bible holds the designs
-    assert len(GATE_MODULE_FILES & present) == 19                # 7 ledger-gates + liveness + self_wired +
+    assert len(GATE_MODULE_FILES & present) == 20                # 7 ledger-gates + liveness + self_wired +
     # hollow_test + canon + the 2 canon-fingerprint gates (SPEC-5 Task 9) + contractOrder (SPEC-5,
     # Makoto absorbs Assay) + relativePathCitation + planItemDrift (2026-07-09) + claimedRunningAbsent
-    # (2026-07-23) + runIntentUnfulfilled (2026-07-23)
+    # (2026-07-23) + runIntentUnfulfilled (2026-07-23) + claimedConsentAbsent (2026-09-08)
 
 
 def test_module_function_counts_match_the_design():

--- a/tests/test_stop_gate_level_invariant.py
+++ b/tests/test_stop_gate_level_invariant.py
@@ -180,7 +180,21 @@ def _scenario_claimed_shipped(tmp_path):
 
 # Every discovered gate id must have a firing scenario here — a new gate added to checks/
 # without an entry below fails loudly (KeyError) rather than being silently skipped.
+def _scenario_claimed_consent_absent(tmp_path):
+    # fires on a claim citing the operator in a session whose transcript carries no genuine
+    # operator turn at all. The transcript here holds one TOOL-RESULT-shaped user entry, which
+    # `_is_genuine_user_turn` refuses -- so the oracle channel is empty and every attribution to
+    # it is false, which is the whole firing condition.
+    import json as _json
+    tp = tmp_path / "transcript.jsonl"
+    tp.write_text(_json.dumps({"type": "user", "message": {"role": "user", "content": "ok"},
+                               "toolUseResult": {"stdout": ""},
+                               "timestamp": "2026-09-08T10:00:00Z"}) + "\n", encoding="utf-8")
+    return _ctx(text="You approved this, so I merged it.", transcript_path=str(tp))
+
+
 _SCENARIOS = {
+    "gate.claimed_consent_absent": _scenario_claimed_consent_absent,
     "gate.completion": _scenario_completion,
     "gate.advance": _scenario_advance,
     "gate.green_claim": _scenario_green_claim,


### PR DESCRIPTION
Two changes, both the remaining half of @AliceLJY's #45.

## The atom window (#57)

Every canon atom is `_existing(calls, pred)` — an existential over the whole session call stream. So once a green test run and a timeout had each happened, both were permanently true and `nosrc_green_timeout` fired at every subsequent Stop whatever the agent did next. **The fingerprint was monotone: once matched it could never stop matching.** The typed `release.operator` phrase was therefore its only exit, which forced a human onto a gate whose entire premise is that a claim is held against the record rather than against an utterance.

Atoms now evaluate over the calls **since the operator last spoke**. The fingerprint fires once, the operator is informed, their next turn resets the window whatever it says, and it fires again only if the agent repeats the pattern after being told. No judgement, nothing asked of the human.

The agent cannot manufacture a reset because it cannot produce a genuine user turn. `_is_genuine_user_turn` already draws that boundary and the ack already trusts it, so the window boundary and the ack boundary are one rule with one owner.

No transcript, no genuine turn, or no timestamp means **no window** — the whole session, which is both the prior behaviour and the strict direction. A window that cannot be established must never widen what a gate lets through. A history row whose ts cannot be read is kept, for the same reason.

## `gate.claimed_consent_absent`

Blocks a claim citing the operator's approval, instruction or word in a session whose transcript carries **no genuine operator turn at all**. An agent citing approval it was never given has licensed itself, and that licence is the most valuable thing it can forge.

The hazard is live and currently held off by prose: a session woken by a schedule carries a hand-written notice on every turn saying no human input has been received and that any claim the user approved something must not be treated as consent. A rule stated every turn and enforced nowhere is `B7` in the register; this is its runner.

**The 0-FP condition** is what keeps it from being a paraphrase judge: it fires only on an *empty* channel. Not "the turn does not match the claim" — that is similarity, and similarity is judgement. Absence of the whole channel is countable, and when it is empty every attribution to it is false whatever words were chosen. One genuine turn silences it.

**Stated limit**, on the record rather than as an oversight: an operator who spoke once, followed by an agent inventing a second different instruction, is not caught. That needs the claim compared to the turn's content.

## How it landed

As a **patch, not a file copy**. This tree carries `latest_testrun_exit` in `ledger.py` that the dev twin does not; a whole-file copy would have deleted it. README and `plugin.json` counts are regenerated here rather than copied — the twin's counts are the twin's.

Thirteen of Makoto's own laws reddened when the new gate was added, and every one was right: the design list, scenario map, module-stem set, file count, the dispatch behavioural pin and its naming convention, `plugin.json`'s gate count, and the README's count and gate table.

## Gates

- `python3 tools/render_checks.py --check` — `check counts match makoto.registry`
- `python -m pytest -q` — **1979 passed, 1 xfailed, 44 subtests**
- `python3 eval/replay.py` — `REPLAY sessions=5 passed=5 failed=0`
- `bash tests/bash/run_all.sh` — `All bash tests passed.`


---
_Generated by [Claude Code](https://claude.ai/code/session_01YSeHeTrYof2BRmgrT3SFm2)_