### PR TITLE
Gate text: the release phrase is the operator's, in a user turn; an assistant reply cannot discharge

### DIFF
--- a/plugin/makoto/checks/canonFingerprints.py
+++ b/plugin/makoto/checks/canonFingerprints.py
@@ -78,8 +78,10 @@ def canon_fingerprint_block_gate(text, history, *, transcript_path=None, session
                         f"Re-examine the flagged behavior (a suppressed check, a destructive "
                         f"command, or an unresolved gap between claim and evidence) before "
                         f"continuing, OR if the flagged action was legitimate and already fully "
-                        f"re-examined, say exactly `makoto release.operator {name}: <reason>` in a "
-                        f"real (non-tool, non-quoted) reply -- the only discharge this gate can "
+                        f"re-examined, the human operator must say exactly "
+                        f"`makoto release.operator {name}: <reason>` in a user turn "
+                        f"(non-tool, non-quoted); an assistant reply cannot discharge this gate "
+                        f"-- the only release this gate can "
                         f"honor, per Task 2 slice 5."),
         ))
     return out

--- a/plugin/makoto/checks/canonTimeoutRecur.py
+++ b/plugin/makoto/checks/canonTimeoutRecur.py
@@ -442,8 +442,10 @@ def _release_clause(cid: str) -> str:
     CANON_SEQ_PRIMITIVES without carrying the discharge it is already wired to honor —
     the affordance is structural, not prose that the next author must remember to copy."""
     return (" If this finding is a genuinely unresolvable, already-reviewed block — or a "
-            f"misfire you have verified — say exactly `makoto release.operator {cid}: <reason>` "
-            "in a real (non-tool, non-quoted) reply; that is the only discharge other than "
+            "misfire you have verified — the human operator must say exactly "
+            f"`makoto release.operator {cid}: <reason>` in a user turn "
+            "(non-tool, non-quoted); an assistant reply cannot discharge this gate. "
+            "That is the only discharge other than "
             "changing what the detector actually reads.")
 
 

--- a/tests/test_ackblock.py
+++ b/tests/test_ackblock.py
@@ -198,10 +198,11 @@ def test_the_gates_own_hint_never_discharges(tmp_path):
     from makoto.checks import canonFingerprints
     _record_first_fired(tmp_path, "notestedit_destruct", "2026-07-07T01:00:00Z")
     name = "notestedit_destruct"
-    hint = (f"say exactly `makoto release.operator {name}: <reason>` in a "
-            f"real (non-tool, non-quoted) reply")
+    hint = (f"the human operator must say exactly "
+            f"`makoto release.operator {name}: <reason>` in a user turn "
+            f"(non-tool, non-quoted); an assistant reply cannot discharge this gate")
     src = (canonFingerprints.__file__ or "")
-    assert "say exactly `makoto release.operator {name}: <reason>` in a " in \
+    assert "`makoto release.operator {name}: <reason>` in a user turn " in \
         open(src, encoding="utf-8").read(), \
         "the hint's wording moved -- re-derive this test's `hint` from the shipped text"
     p = _write_transcript(tmp_path, [_user_turn("Stop hook feedback:\n" + hint,

--- a/tests/test_canon_fingerprints.py
+++ b/tests/test_canon_fingerprints.py
@@ -263,7 +263,7 @@ def test_first_firing_blocks_even_with_a_ready_ack_in_the_transcript(tmp_path):
     assert any(f.message.startswith("canon.notestedit_destruct:") for f in findings)
 
 
-def test_genuine_ack_after_a_recorded_firing_silences_the_gate(tmp_path):
+def test_release_requires_a_human_turn_after_a_recorded_firing(tmp_path):
     """PLANT the fault (first Stop fires and gets recorded), THEN a real ack turn -> the SECOND
     Stop's evaluation must be silent, and must chain-append a release.operator row."""
     from makoto.state import ledger
@@ -273,10 +273,28 @@ def test_genuine_ack_after_a_recorded_firing_silences_the_gate(tmp_path):
                    "pattern_fires": ["gate.canon_fingerprints"],
                    "findings": [{"message": target_msg}]}, root=tmp_path)
 
-    p = _write_transcript(tmp_path, [
-        _user_turn("makoto release.operator notestedit_destruct: reviewed, the rm -rf was sanctioned",
-                  "2026-07-08T00:00:00Z"),
-    ])
+    release = (
+        "makoto release.operator notestedit_destruct: the destructive command removed an untracked stray draft\n"
+        "under keel/plugin/tests only; the committed test file is intact and the red it covered was fixed in\n"
+        "effects.py:418 and re-verified green (324 passed)."
+    )
+    entries = [
+        {"type": "system", "message": {"role": "system", "content": target_msg},
+         "timestamp": "2026-07-07T00:00:00Z"},
+        {"type": "assistant", "message": {"role": "assistant", "content": release},
+         "timestamp": "2026-07-08T00:00:00Z"},
+    ]
+    p = _write_transcript(tmp_path, entries)
+    blocked = canon_fingerprint_block_gate(
+        "", [_DESTRUCTIVE_ROW], transcript_path=str(p), session_id="s1", state_root=tmp_path)
+    target = next(f for f in blocked if f.message.startswith("canon.notestedit_destruct:"))
+    assert "the human operator must say exactly" in target.retry_hint
+    assert "in a user turn (non-tool, non-quoted)" in target.retry_hint
+    assert "an assistant reply cannot discharge this gate" in target.retry_hint
+    assert not any(r.get("kind") == "release.operator" for r in ledger.read(root=tmp_path))
+
+    entries.append(_user_turn(release, "2026-07-08T01:00:00Z"))
+    p = _write_transcript(tmp_path, entries)
     second = canon_fingerprint_block_gate(
         "", [_DESTRUCTIVE_ROW], transcript_path=str(p), session_id="s1", state_root=tmp_path)
     # _DESTRUCTIVE_ROW alone also fires nosrc_destruct (a bare destructive call with no source

--- a/tests/test_canon_primitives.py
+++ b/tests/test_canon_primitives.py
@@ -368,9 +368,19 @@ def test_canon_timeout_genuine_ack_after_a_recorded_firing_silences_the_gate(tmp
                    "pattern_fires": ["gate.canon"],
                    "findings": [{"message": target_msg}]}, root=tmp_path)
 
-    p = _write_transcript(tmp_path, [_user_turn(
-        "makoto release.operator timeout: reviewed, this permission block is correct and final",
-        "2026-07-08T00:00:00Z")])
+    release = "makoto release.operator timeout: reviewed, this permission block is correct and final"
+    entries = [{"type": "assistant", "message": {"role": "assistant", "content": release},
+                "timestamp": "2026-07-08T00:00:00Z"}]
+    p = _write_transcript(tmp_path, entries)
+    blocked = canon_gate([row], transcript_path=str(p), session_id="s1", state_root=tmp_path)
+    target = next(f for f in blocked if f.message.startswith("canon.timeout:"))
+    assert "the human operator must say exactly" in target.retry_hint
+    assert "in a user turn (non-tool, non-quoted)" in target.retry_hint
+    assert "an assistant reply cannot discharge this gate" in target.retry_hint
+    assert not any(r.get("kind") == "release.operator" for r in ledger.read(root=tmp_path))
+
+    entries.append(_user_turn(release, "2026-07-08T01:00:00Z"))
+    p = _write_transcript(tmp_path, entries)
     second = canon_gate([row], transcript_path=str(p), session_id="s1", state_root=tmp_path)
     assert second == []
     ack_rows = [r for r in ledger.read(root=tmp_path) if r.get("kind") == "release.operator"]


### PR DESCRIPTION
Both gate texts (`canonFingerprints`, `canonTimeoutRecur`) told the **assistant** to say `makoto release.operator <row>: <reason>`, but the reader (`find_ack_block`, `ledger.py:744`) deliberately accepts only `message.role == "user"`. An assistant-authored release is rejected by design, so the text advertised a discharge that could not happen. Measured: the exact phrase, sent as an entire text-only assistant reply, re-fired the gate unchanged — three times across two gates.

The reader is unchanged. The texts now say the human operator says the phrase in a user turn and that an assistant reply cannot discharge. Tests added: assistant-authored release rejected, user-authored accepted, for both gates.

## Verification

`python3 -m pytest tests -q`: 16 failed, 1982 passed — the **same 16 fail on untouched HEAD** in this container (dispatcher subprocess exits 1 in `test_dispatch_attribution`, `test_render_checks`, `test_smoke`, `test_wire_surrogates`); pre-existing and environmental, not introduced by this change. The new tests pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsD5raWyWLW2at1uSDGE5P

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsD5raWyWLW2at1uSDGE5P)_