### PR TITLE
Release 2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to makoto. Versions follow the live check inventory
 
 ## [Unreleased]
 
+## [2.8.1] — 2026-09-09
+
+### Fixed
+- gate texts now say the human operator releases in a user turn; an assistant reply cannot discharge (#64, closes #45's second half).
+
 ## [2.8.0] — 2026-09-09
 
 ### Added

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "makoto",
   "description": "Holds Claude Code to its word — every claim checked against the agent's own logged record; faked checks blocked, not warned (four narrow advisory self-checks excepted). Two-tier catalog (15 pre-checks, 21 Stop gates), each shipped at measured zero false positives.",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "author": {"name": "Clear-Sights"},
   "homepage": "https://github.com/Clear-Sights/Makoto",
   "repository": "https://github.com/Clear-Sights/Makoto",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "makoto"
-version = "2.8.0"
+version = "2.8.1"
 description = "Integrity hook for Claude Code — holds the agent's claims against its own logged deeds and blocks faked checks; every check ships at measured zero false positives"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps `plugin/.claude-plugin/plugin.json` and `pyproject.toml` to 2.8.1 and adds the `## [2.8.1]` CHANGELOG section, so `release.yml` cuts `v2.8.1` from `main` (#64: gate texts say the human operator releases in a user turn; an assistant reply cannot discharge — closes the second half of #45).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsD5raWyWLW2at1uSDGE5P

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsD5raWyWLW2at1uSDGE5P)_