### PR TITLE
An owner-declined call is no call: only terminal rows become Calls (2.8.3)

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "makoto",
   "description": "Holds Claude Code to its word — every claim checked against the agent's own logged record; faked checks blocked, not warned (four narrow advisory self-checks excepted). Two-tier catalog (15 pre-checks, 21 Stop gates), each shipped at measured zero false positives.",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "author": {"name": "Clear-Sights"},
   "homepage": "https://github.com/Clear-Sights/Makoto",
   "repository": "https://github.com/Clear-Sights/Makoto",

--- a/plugin/makoto/checks/canonTimeoutRecur.py
+++ b/plugin/makoto/checks/canonTimeoutRecur.py
@@ -31,31 +31,6 @@ Two primitives are installed:
     success for the same key silences it even when other, different calls happened in between.
     See docs/adr/0022-recur-stuck-latest-run-wins.md for the decision history.
 
-ADAPTATION NOTE (the substrate divergence from the ancestor, revised for FD14-A): the ancestor's
-`calls_from_history` turned every PreToolUse OR PostToolUse row into a Call. Live makoto's real
-events table (see `makoto/dispatch.py::_ingest_event` / `_select_recent`) stores EVERY hook
-payload verbatim, including a PreToolUse row fired BEFORE the tool runs (so its `tool_response`
-is always absent/empty) as a SEPARATE row from the PostToolUse row fired after (carrying the
-actually-resolved result) for the very same call. Decoding both naively would insert a spurious
-result={} Call ahead of every real result: two consecutive identical failing Bash calls would
-decode as [Pre(no-err), Post(err), Pre(no-err), Post(err)] — never a run of >=2 consecutive
-same-key ALL-err calls — silently defeating `recur_stuck` against the real substrate. So
-`calls_from_history` PAIRS each PostToolUse to the nearest preceding still-unpaired identical
-PreToolUse and keeps only the PostToolUse Call for a completed call — the paired Pre is dropped.
-
-FD14-A (scope narrowed by owner decision, see EXECUTION_PLAN.md / SPEC-4 Task 2 — MID-TURN
-ABANDONMENT ONLY): a leftover unpaired PreToolUse is a dangling Pre. NOT every dangling Pre is a
-failure signal — `test_dispatch_fabricated_action_silent_when_command_ran` (test_dispatch.py) pins
-that a SINGLE dangling Pre that is the LAST tool-related row before Stop must mean "presence of
-work, discharge the claim" and must stay silent, not fail. FD14-A's actual target is narrower:
-mid-turn abandonment, where a tool call was fired, never resolved, and the agent moved on to
-something else anyway (another Pre or Post, for any tool) before Stop. So a dangling Pre
-synthesizes a FAILURE Call (result `{"interrupted": True, "error": ...}`) at its original position
-ONLY IF some OTHER decoded row — Pre or Post, any tool — occurs at a LATER index in the decoded
-history than this dangling Pre. If the dangling Pre is the last decoded row overall, it is left
-out entirely, matching the pre-FD14-A/unmodified behavior for that shape (no Call is synthesized,
-so `timed_out_at_turn_end` reads whatever real call preceded it, exactly as before this ticket).
-
 PATTERN_ID CONVENTION (deliberate divergence from the read-only ancestor `makoto-dev`, found
 while porting): the ancestor's canon_gate emitted pattern_id=f"canon.{cid}" (e.g. "canon.timeout",
 "canon.recur") per fired sub-primitive. Live makoto's `dispatch._blocking_gate_ids()` derives the
@@ -322,10 +297,9 @@ def _decode_row(row):
     Raw decode + wrapper-event-type fallback is `kit.decode_history_event` -- the canonical
     step, shared with `identicalRetryInterdiction._most_recent_completed_bash_call`. This
     function keeps only what's specific to canon's OWN adapter shape: the tuple conversion, and
-    keeping PreToolUse plus both settled terminal events (unlike the pre-FD14-A cut which dropped
-    Pre at decode time) so `calls_from_history` can pair them and detect a dangling Pre.
-    PostToolUseFailure is normalized to PostToolUse with its real top-level error/is_interrupt
-    fields, so the existing pairing path treats it as the failed call's terminal."""
+    PostToolUseFailure normalized to PostToolUse with its real top-level error/is_interrupt
+    fields, so it is the failed call's terminal. PreToolUse rows decode too; `calls_from_history`
+    yields nothing for them."""
     ev = decode_history_event(row)
     if ev is None:
         return None
@@ -344,56 +318,11 @@ def _decode_row(row):
 
 
 def calls_from_history(history) -> list:
-    """Decode GateContext.history rows into agnostic Call dicts carrying the protocol fields the
-    terminals read. A completed call contributes a PreToolUse and either a PostToolUse or
-    PostToolUseFailure row; each terminal is normalized to Post and PAIRED to the nearest
-    preceding still-unpaired identical (tool name + `_pairing_input`) Pre, and only the terminal
-    becomes a Call (the Pre is dropped) — so `recur_stuck`'s consecutive-run judgment is not
-    corrupted by spurious result-less Calls (module docstring ADAPTATION NOTE).
-    Pairing uses `_pairing_input` (dunder-insensitive), NOT the full `canon_input` the verdicts
-    key on: a harness may inject bookkeeping keys between a call's Pre and its Post, and pairing
-    on those synthesized a phantom failure for a call that succeeded. See `_pairing_input`.
-
-    FD14-A, narrowed to MID-TURN ABANDONMENT ONLY (see module docstring): a leftover unpaired
-    PreToolUse (a dangling Pre) synthesizes a FAILURE Call — result `{"interrupted": True, ...}` —
-    at its original position ONLY IF some OTHER decoded row (Pre or Post, any tool) sits at a
-    LATER index in the decoded history than this dangling Pre, i.e. it is NOT the chronologically
-    last tool-related row. A dangling Pre that IS the last decoded row is left out entirely (no
-    Call synthesized), preserving `test_dispatch_fabricated_action_silent_when_command_ran`'s
-    presence-of-work discharge. Fail-open per row (a malformed row is skipped, via `_decode_row`)."""
-    decoded = [d for d in (_decode_row(r) for r in (history or ())) if d is not None]
-
-    # pair each PostToolUse to the nearest PRECEDING still-unpaired identical PreToolUse: one
-    # pass, keeping a per-key STACK of the Pre indices still waiting for a terminal. Popping that
-    # stack yields exactly the nearest preceding unpaired Pre a backward rescan would have found,
-    # while computing `_pairing_input` once per row instead of once per (Post, candidate) pair.
-    unpaired_pre: dict = {}
-    for i, (etype, name, ti, _tr) in enumerate(decoded):
-        key = (name, _pairing_input(ti))
-        if etype == "PreToolUse":
-            unpaired_pre.setdefault(key, []).append(i)
-        elif etype == "PostToolUse":
-            waiting = unpaired_pre.get(key)
-            if waiting:
-                waiting.pop()
-    dangling_pre = {i for waiting in unpaired_pre.values() for i in waiting}
-
-    last_index = len(decoded) - 1
-    out: list = []
-    for i, (etype, name, ti, tr) in enumerate(decoded):
-        if etype == "PostToolUse":
-            out.append({"name": name, "input": ti, "result": tr})
-        elif i in dangling_pre and i != last_index:
-            # dangling PreToolUse, NOT the last tool-related row before Stop -> mid-turn
-            # abandonment: something else happened afterward and this call was still never
-            # resolved. Synthesize the failure Call. (If i == last_index it is left silent —
-            # presence-of-work discharge, see docstring.)
-            out.append({"name": name, "input": ti, "result": {
-                "interrupted": True,
-                "error": "no PostToolUse for this PreToolUse (unresolved/failed tool call, "
-                         "mid-turn abandonment)",
-            }})
-    return out
+    """Every terminal row (PostToolUse, or PostToolUseFailure normalized to it by `_decode_row`)
+    is one Call; a PreToolUse row is not a call and yields nothing. A call the owner declined,
+    one that was abandoned, and one still running all leave the same trace, a Pre with no
+    terminal, and none of them is evidence of a failure."""
+    return [{"name": name, "input": ti, "result": tr} for etype, name, ti, tr in (d for d in (_decode_row(r) for r in (history or ())) if d is not None) if etype == "PostToolUse"]
 
 
 # ---- sequence-primitive catalog: {id -> (seq_predicate(calls)->bool, stop_text, retry_hint)} --
@@ -479,63 +408,12 @@ def canon_gate(history, *, transcript_path=None, session_id=None, state_root=Non
     block (a permission block the agent correctly declines to retry) -- text cannot change
     calls[-1], so without a real discharge it re-fires at every subsequent Stop. Reuses
     makoto.state.ledger's SAME transcript-re-derived, spoof-proof discharge (never trusted from
-    chain content) -- one mechanism serving both gates, per SPEC-C's "one mercy model".
-
-    PRE-DENIED CALLS ARE NOT EVIDENCE: dispatch ingests the PreToolUse row BEFORE the Pre
-    handler denies it, and a Pre-denied call never gets a terminal -- so it decoded as a
-    dangling Pre and FD14-A synthesized `{"interrupted": True, ...}` for a call that was never
-    interrupted, never even ran: a BLOCK resting on a fabricated result. The events table alone
-    cannot distinguish a denied Pre from an abandoned one, but makoto's OWN audit log can
-    (dispatch appends an AuditRow for every blocking Pre fire, its findings stamped with the
-    event's own `source_event_id`). This adapter reads the audit log for this session's blocked
-    PreToolUse event ids and drops those Pre rows from the history BEFORE decoding, so nothing
-    is synthesized for them; best-effort (no state_root / unreadable audit leaves history
-    untouched, exactly as before). Row-id matching only works for the events-table tuple shape
-    (id, ts, event_type, cwd, payload) -- dict-shaped test rows carry no id and are never
-    dropped."""
+    chain content) -- one mechanism serving both gates, per SPEC-C's "one mercy model"."""
     try:
         import makoto.state.ledger as _ackblock
         history = _ackblock.operator_window(history, transcript_path)
     except Exception:
         pass
-    denied_pre_ids: set = set()
-    if state_root is not None and session_id:
-        # Direct stdlib read of <state_root>/audit.jsonl, NOT `makoto.state.audit.read_rows`:
-        # the checks->state import firewall (tests/test_import_direction.py) admits only
-        # ledger/citations from a named check module, so this tiny line-per-JSON read is
-        # duplicated here on purpose (the same trade contractOrder makes with its plans SQL).
-        try:
-            audit_path = os.path.join(str(state_root), "audit.jsonl")
-            with open(audit_path, "r", encoding="utf-8") as fh:
-                audit_lines = fh.read().splitlines()
-            for line in audit_lines:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    arow = json.loads(line)
-                except ValueError:
-                    continue
-                if not isinstance(arow, dict):
-                    continue
-                if arow.get("session_id") != session_id:
-                    continue
-                if arow.get("hook_kind") != "PreToolUse":
-                    continue
-                for f in arow.get("findings") or ():
-                    if not isinstance(f, dict) or f.get("level") != "error":
-                        continue
-                    sid = f.get("source_event_id")
-                    if isinstance(sid, int) and sid:
-                        denied_pre_ids.add(sid)
-        except Exception:
-            denied_pre_ids = set()
-    if denied_pre_ids:
-        history = [
-            r for r in (history or ())
-            if not (isinstance(r, (tuple, list)) and len(r) >= 3
-                    and r[2] == "PreToolUse" and r[0] in denied_pre_ids)
-        ]
     out: List[Finding] = []
     for cid, stop_text, retry_hint in fired_primitives(history):
         ack = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "makoto"
-version = "2.8.2"
+version = "2.8.3"
 description = "Integrity hook for Claude Code — holds the agent's claims against its own logged deeds and blocks faked checks; every check ships at measured zero false positives"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_canon_agent_partition.py
+++ b/tests/test_canon_agent_partition.py
@@ -64,8 +64,8 @@ def _canon_recur(history, stop_payload):
 def _cross_agent_history(stopping_agent):
     repeated = {"command": "orphaned-call"}
     return [
-        _row(1, "PreToolUse", repeated, {}, "dangling-agent"),
-        _row(2, "PreToolUse", repeated, {}, "dangling-agent"),
+        _row(1, "PostToolUse", repeated, {"interrupted": True}, "dangling-agent"),
+        _row(2, "PostToolUse", repeated, {"interrupted": True}, "dangling-agent"),
         _row(3, "PostToolUse", {"command": "thread-finished"}, {"stdout": "ok"}, stopping_agent),
     ]
 

--- a/tests/test_canon_failure_synthesis.py
+++ b/tests/test_canon_failure_synthesis.py
@@ -1,25 +1,10 @@
-"""Tests for FD14-A (narrowed to MID-TURN ABANDONMENT ONLY): `canon.calls_from_history` synthesizes
-a FAILURE Call for a dangling PreToolUse (one with no matching PostToolUse) ONLY when it is NOT the
-chronologically last tool-related row before Stop -- i.e. some OTHER decoded row (Pre or Post, any
-tool) occurred after it and it was still never resolved.
-
-This scope was narrowed by owner decision (via AskUserQuestion, this session -- see
-EXECUTION_PLAN.md / docs/superpowers/plans/2026-07-06-spec4-makoto.md for the FD14-A ticket text)
-to resolve a direct conflict with `test_dispatch.py::test_dispatch_fabricated_action_silent_when_
-command_ran`, which pins that a SINGLE dangling Pre that IS the last tool-related row before Stop
-must mean "presence of work, discharge the claim" -- NOT a failure. FD14-A's actual target is a
-tool call that was fired and abandoned mid-turn while the agent moved on to something else, in an
-environment where PostToolUse does not reliably fire on failure/interruption.
-
-Complements test_canon_primitives.py (pure predicate/decode unit tests, pre-existing) and
-test_gate_canon_live_battery.py (anti-Goodhart RED/TN battery through run_stop_checks). This file
-adds: (1) pure calls_from_history unit tests pinning the narrowed synthesis rule directly, and
-(2) end-to-end dispatch tests (mirroring test_dispatch.py's `_run_dispatch` subprocess pattern)
-proving gate.canon actually fires/blocks live on a mid-turn-abandoned call, and stays silent on the
-last-row-discharge shape."""
+"""A PreToolUse row with no terminal is not a call. An owner-declined call, an abandoned one and
+one still running leave the same trace, and `calls_from_history` yields nothing for any of them.
+This file pins that directly and through dispatch: no Call is synthesized, so gate.canon stays
+silent on a dangling Pre wherever it sits, and a fully paired call still becomes one Call."""
 import json
 
-from makoto.checks.canonTimeoutRecur import calls_from_history, timed_out_at_turn_end
+from makoto.checks.canonTimeoutRecur import calls_from_history, canon_gate, timed_out_at_turn_end
 
 
 # ---- pure calls_from_history unit tests: the narrowed synthesis rule --------------------------
@@ -29,41 +14,14 @@ def _tuple_row(idx, event_type, tool_name, tool_input, tool_response, cwd="/repo
     return (idx, "t", event_type, cwd, payload)
 
 
-def test_dangling_pre_as_last_row_is_not_synthesized():
-    """A single dangling Pre that IS the last tool-related row before Stop -> no Call at all (the
-    presence-of-work discharge case; matches unmodified pre-FD14-A behavior for this shape)."""
-    row = _tuple_row(1, "PreToolUse", "Bash", {"command": "long-running-thing"}, {})
-    assert calls_from_history([row]) == []
-
-
-def test_dangling_pre_followed_by_another_unresolved_row_is_synthesized_as_failure():
-    """Mid-turn abandonment: a dangling Pre (A) followed by ANOTHER dangling Pre (B) later in
-    history -- B is itself never resolved either, but A is no longer the last tool-related row, so
-    A synthesizes a failure Call. B, now the last decoded row, is left out (not synthesized) --
-    exactly one Call results, and it is A's synthesized failure."""
-    pre_a = _tuple_row(1, "PreToolUse", "Bash", {"command": "cmd-a"}, {})
-    pre_b = _tuple_row(2, "PreToolUse", "Bash", {"command": "cmd-b"}, {})
-    calls = calls_from_history([pre_a, pre_b])
-    assert len(calls) == 1
-    assert calls[0]["name"] == "Bash"
-    assert calls[0]["input"] == {"command": "cmd-a"}
-    assert calls[0]["result"].get("interrupted") is True
-    # the synthesized failure is the only (and therefore last) Call -> canon.timeout must see it.
-    assert timed_out_at_turn_end(calls) is True
-
-
-def test_dangling_pre_followed_by_a_resolved_post_of_a_different_tool_is_synthesized():
-    """The "something else happened after it" row need not itself be unresolved -- a completed,
-    successful, unrelated call occurring after the dangling Pre still counts as evidence the agent
-    moved on, per the ticket's "Pre or Post, any tool" wording."""
-    pre_a = _tuple_row(1, "PreToolUse", "Bash", {"command": "cmd-a"}, {})
-    pre_read = _tuple_row(2, "PreToolUse", "Read", {"file_path": "x.py"}, {})
-    post_read = _tuple_row(3, "PostToolUse", "Read", {"file_path": "x.py"}, {"stdout": "ok"})
-    calls = calls_from_history([pre_a, pre_read, post_read])
-    # exactly two Calls: the synthesized failure for cmd-a, and the real completed Read.
-    assert len(calls) == 2
-    assert calls[0]["name"] == "Bash" and calls[0]["result"].get("interrupted") is True
-    assert calls[1] == {"name": "Read", "input": {"file_path": "x.py"}, "result": {"stdout": "ok"}}
+def test_a_pre_with_no_terminal_is_no_call():
+    """An owner-declined call, an abandoned one and a running one leave the same trace: a
+    PreToolUse with no terminal. None is a failure; none is a call."""
+    history = [_tuple_row(1, "PreToolUse", "ExitPlanMode", {}, {}),
+               _tuple_row(2, "PreToolUse", "ExitPlanMode", {}, {}),
+               _tuple_row(3, "PreToolUse", "Bash", {"command": "cmd"}, {})]
+    assert calls_from_history(history) == []
+    assert canon_gate(history) == []
 
 
 def test_normal_fully_paired_call_is_unaffected():
@@ -92,33 +50,17 @@ def test_dispatch_last_row_dangling_pre_stays_silent_no_block(state_dir, run_dis
     assert out == "", "a dangling Pre that is the last tool row before Stop must not block"
 
 
-def test_dispatch_mid_turn_abandoned_pre_synthesizes_failure_and_canon_blocks(state_dir, run_dispatch, tmp_path):
-    """Mid-turn abandonment fires canon.timeout live: a PreToolUse (Bash, cmd-a) never gets a
-    PostToolUse, but the agent moves on to ANOTHER PreToolUse (Bash, cmd-b) -- itself also never
-    resolved -- before Stop. cmd-a is no longer the last tool-related row, so it synthesizes a
-    failure Call; that failure becomes the turn's last Call (cmd-b, being the new last row, is
-    left un-synthesized) -> canon.timeout fires -> gate.canon blocks by default, exactly like
-    test_dispatch.py::test_dispatch_canon_gate_blocks_by_default's PostToolUse-interrupted case."""
+def test_dispatch_mid_turn_abandoned_pre_is_silent(state_dir, run_dispatch, tmp_path):
+    """Two PreToolUse rows with no terminal, then Stop: nothing is synthesized, nothing blocks."""
     sid = "midturn_abandon"
-    pre_a = {"hook_event_name": "PreToolUse", "tool_name": "Bash", "session_id": sid,
-             "cwd": str(tmp_path), "tool_input": {"command": "cmd-a-never-resolved"}}
-    pre_b = {"hook_event_name": "PreToolUse", "tool_name": "Bash", "session_id": sid,
-             "cwd": str(tmp_path), "tool_input": {"command": "cmd-b-also-never-resolved"}}
-    rc, out = run_dispatch(state_dir, pre_a)
-    assert rc == 0 and out == ""
-    rc, out = run_dispatch(state_dir, pre_b)
-    assert rc == 0 and out == ""
-    stop = {"hook_event_name": "Stop", "session_id": sid, "cwd": str(tmp_path),
-            "last_assistant_message": "Done for now."}
-    rc, out = run_dispatch(state_dir, stop)
+    for command in ("cmd-a-never-resolved", "cmd-b-also-never-resolved"):
+        rc, out = run_dispatch(state_dir, {"hook_event_name": "PreToolUse", "tool_name": "Bash", "session_id": sid,
+                                           "cwd": str(tmp_path), "tool_input": {"command": command}})
+        assert rc == 0 and out == ""
+    rc, out = run_dispatch(state_dir, {"hook_event_name": "Stop", "session_id": sid, "cwd": str(tmp_path),
+                                       "last_assistant_message": "Done for now."})
     assert rc == 0
-    assert out, "a mid-turn-abandoned dangling Pre must synthesize a failure and block via canon.timeout"
-    decision = json.loads(out)
-    assert decision["decision"] == "block"
-    assert "canon.timeout" in decision["reason"]
-    rows = [json.loads(l) for l in (state_dir / "audit.jsonl").read_text().splitlines() if l.strip()]
-    assert any("gate.canon" in r.get("pattern_fires", []) for r in rows), \
-        "the gate.canon fire must be audited"
+    assert out == "", "a Pre with no terminal is no call and must not block"
 
 
 def test_dispatch_normal_paired_call_unaffected_no_block(state_dir, run_dispatch, tmp_path):

--- a/tests/test_canon_pairing_injected_keys.py
+++ b/tests/test_canon_pairing_injected_keys.py
@@ -1,26 +1,7 @@
-"""Pre<->Post pairing survives harness-injected `tool_input` keys; the verdicts do not widen.
-
-`canon.recur` fired a STUCK verdict on a retry that had actually SUCCEEDED. The primitive was
-behaving as designed -- the bug was upstream, in `calls_from_history`.
-
-A harness may add bookkeeping keys to `tool_input` BETWEEN a call's PreToolUse and its
-PostToolUse. Observed live on the `Artifact` tool: a 3-key Pre, then a 6-key Post carrying
-`__artifactPlanConsentAsk`, `__artifactPlanConsentDecisionCaps`, `__artifactPublishTarget`.
-Pairing keyed on the FULL canonical input, so those two rows never matched: every such call left
-a dangling Pre and synthesized a phantom mid-turn-abandonment failure for a call that succeeded.
-
-One phantom is harmless. Two back-to-back are a run of length 2, all-error, same key -> STUCK.
-The real success lands under a DIFFERENT key, so it cannot flip the phantom run's verdict, and
-the documented [ERR, ERR, OK] guard cannot help.
-
-The fix relaxes PAIRING ONLY (`_pairing_input`), never a verdict: `recur_stuck` and every other
-primitive keep keying on the full `canon_input`. The true-positive cases below are what hold
-that line -- a pairing relaxed until nothing dangles would discharge the gate while leaving its
-name in place.
-
-Not Artifact-specific: any tool whose PostToolUse carries injected `tool_input` keys degrades
-pairing for that tool everywhere `calls_from_history` is used.
-"""
+"""Only terminal rows are calls, and verdicts key on the full `canon_input`. A harness may add
+bookkeeping keys to `tool_input` between a call's PreToolUse and its PostToolUse; the Post is the
+call, with the keys it carries, and a Pre with no terminal is nothing. The true-positive cases
+below hold the line that this never discharges a genuine run of failures."""
 from __future__ import annotations
 
 import json
@@ -77,7 +58,7 @@ def test_the_reported_false_positive_no_longer_fires():
                _row("PreToolUse", "Read", {"file_path": "/y"}),
                _row("PostToolUse", "Read", {"file_path": "/y"})]
     calls = calls_from_history(history)
-    assert _stream(calls) == "Eoo", _stream(calls)
+    assert _stream(calls) == "oo", _stream(calls)
     assert recur_stuck(calls) is False
 
 
@@ -119,14 +100,13 @@ def test_a_command_failing_three_times_still_fires():
     assert recur_stuck(calls_from_history(history)) is True
 
 
-def test_two_adjacent_genuinely_dangling_pres_still_fire():
-    """The abandonment signal itself is untouched: two unresolved Pres with no Post at all are
-    still a stuck run -- what changed is only that a MATCHING Post now pairs."""
+def test_two_adjacent_dangling_pres_are_silent():
+    """A Pre with no terminal is not a call: declined, abandoned and running look alike."""
     history = [_row("PreToolUse", "Bash", {"command": "z"}),
                _row("PreToolUse", "Bash", {"command": "z"}),
                _row("PreToolUse", "Read", {"file_path": "/y"}),
                _row("PostToolUse", "Read", {"file_path": "/y"})]
-    assert recur_stuck(calls_from_history(history)) is True
+    assert recur_stuck(calls_from_history(history)) is False
 
 
 # ---- every fired primitive names a reachable discharge ----------------------------------------


### PR DESCRIPTION
## What

`canon.timeout` and `canon.recur` fired on calls the owner declined (a rejected `ExitPlanMode`, a refused Bash): dispatch had recorded the PreToolUse row, no terminal ever followed, and `calls_from_history` synthesized an interrupted failure for it.

A PreToolUse row with no terminal is left by three things that look alike from the events table: a call the owner declined, one that was abandoned, and one still running. None is evidence of a failure.

- `calls_from_history` yields one Call per terminal row (PostToolUse, or PostToolUseFailure normalized to it) and nothing for a Pre.
- The audit-log lookup that tried to tell a denied Pre from an abandoned one is removed with the synthesis it existed to correct.
- Tests that asserted a synthesized failure assert silence; the dispatch-level abandonment test asserts no block; the agent-partition fixture uses real failed terminals so it still discriminates.
- Version 2.8.3 in plugin.json and pyproject.toml.

## Check

`python3 -m pytest tests -q -x`: 2014 passed, 1 xfailed, 45 subtests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSeHeTrYof2BRmgrT3SFm2

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSeHeTrYof2BRmgrT3SFm2)_